### PR TITLE
Add iPhone single-window shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,12 @@ vars to drive the real SSH→PTY→tmux→SwiftTerm path headlessly:
 - `MULTIPLEX_AUTO_PAYWALL=1` — opens the real locked Pro paywall with a
   deterministic $19.99 storefront preview for App Review screenshot capture;
   DEBUG only, because simctl launches don't inherit Xcode's StoreKit session.
+- `MULTIPLEX_FORCE_SHELL=1|0` — DEBUG-only override for the single-window
+  shell decision. `1` forces the real shell on and `0` forces classic
+  multi-window mode on any device. Without an override, iPhone always uses
+  the shell, iPad uses it only when the connected `UIWindowScene.isFullScreen`
+  is true, and visionOS never uses it. The once-per-scene-connect decision is
+  logged under subsystem `app.multiplexterm.multiplex`, category `shell`.
 
 Pass them through simctl with the `SIMCTL_CHILD_` prefix:
 ```sh
@@ -94,6 +100,15 @@ SIMCTL_CHILD_MULTIPLEX_SEED_HOST=.../state/seed.json \
 SIMCTL_CHILD_MULTIPLEX_AUTO_ATTACH=main \
 xcrun simctl launch <UDID> app.multiplexterm.multiplex
 ```
+
+**iOS 27 scene/screenshot notes:** a first-ever install can connect an empty
+scene and show only the chassis; uninstall the app from that simulator, then
+install and launch it once more. A freshly booted simulator can take 10–15 s
+to paint its first frame (wait at least 12 s before an iPhone screenshot).
+Keep the `UIApplicationSceneManifest~iphone` single-scene override: without it,
+iOS 27 can connect and composite a second scene on the phone panel. Device
+Hub resize mode can report a resized app canvas while `simctl io screenshot`
+still rasterizes the native panel, so use a native-canvas device for captures.
 
 **iOS-app-on-Mac** ("My Mac (Designed for iPad)"): the same hooks work, with
 two twists. The app is sandboxed, so `MULTIPLEX_SEED_HOST` must point at a
@@ -144,6 +159,8 @@ first slash chip in the agent helper strip (inject → pump → PTY → tmux), a
 pane's cwd → tab append → attach), and
 `… -p app.multiplexterm.multiplex.debug.tmuxshortcuts` opens the focused
 iPad terminal's tmux shortcut popover for layout capture, and
+`… -p app.multiplexterm.multiplex.debug.customcommands` opens the focused
+terminal's Custom Commands editor for layout capture, and
 `… -p app.multiplexterm.multiplex.debug.tmuxcopy` sends Copy Mode through
 SwiftTerm and the terminal's ordered input pump, and
 `… -p app.multiplexterm.multiplex.debug.tmuxcopydone` runs the contextual
@@ -175,8 +192,9 @@ headlessly; `SwiftTermView` logs each decision to the unified log
 ## Architecture
 
 ```
-SwiftUI: Deck window  +  N Terminal windows (WindowGroup(for: TerminalWindowRoute))
-                         a window = ordered tabs; each tab a TerminalRoute (one shell)
+SwiftUI: classic Deck window + N Terminal windows, or one adaptive Shell
+         Shell = real FleetWall + one ordered TerminalWindowRoute tab set
+         a terminal window/shell = ordered tabs; each tab a TerminalRoute
   HostStore          hosts.json local cache; secrets + host records sync via
                      iCloud Keychain as synchronizable items (KeychainStore)
   ThemeStore         terminal color schemes — TerminalTheme built-ins + custom
@@ -269,6 +287,11 @@ views.
   Manager transiently clears a moving window's `isKeyWindow` flag while its
   terminal remains first responder; an already-owned focus claim must stay a
   no-op in that state, never call `makeKey()` to fight the system transition.
+  The compact single-window shell's deck is also a focus-exclusion surface:
+  terminals stay mounted behind it, so scene restoration must pass stage
+  visibility through `TerminalFocusArbiter.restore` and refuse/resign a hidden
+  responder. Otherwise foregrounding sees the deliberately cleared owner as
+  an invitation to restore the keyboard over the deck.
 - **The iPad key rail is app-owned chrome, never an `inputAccessoryView`**:
   `TerminalKeyBar` is a TALLY rail (ESC / latching CTRL / TAB, the shell
   symbols `~ | / -`, DECCKM-aware autorepeat arrows, dismiss) installed as a
@@ -279,8 +302,11 @@ views.
   The rail is full-width and bottommost; the agent helper strip occupies a
   fixed gap immediately above it. Both move above a genuinely docked keyboard.
   PgUp/PgDn ride along (autorepeating, `CSI 5~`/`6~`) — pagers and CLI
-  agents like Claude Code page their transcripts with them; the narrowest
-  rail tier drops them after the symbols.
+  agents like Claude Code page their transcripts with them. Narrow tiers drop
+  page keys, then symbols; a 390 pt phone tier compacts keys to 40 pt while
+  retaining TMUX. The final 372 pt tier drops TMUX, and the shell UMD overflow
+  deliberately has no duplicate tmux entry. ESC/CTRL/TAB, all four arrows,
+  and dismiss never leave the rail.
   Every key sends through `TerminalView.send` → delegate → the controller's
   ordered pump (never a side channel); CTRL rides SwiftTerm's public
   `controlModifier`, consumed by the next typed character — the bar observes
@@ -535,8 +561,9 @@ automation or the App Store Connect UI is required.
 
 ## Conventions
 
-- Bundle id `app.multiplexterm.multiplex`; device families iPad + Vision Pro only
-  (no iPhone). Min visionOS 1.0 / iOS 17.
+- Bundle id `app.multiplexterm.multiplex`; Release device families remain iPad
+  + Vision Pro, while Debug also includes iPhone for shell verification. Min
+  visionOS 1.0 / iOS 17.
 - Design tokens live in `Theme.swift` — the TALLY identity: graphite chassis
   (`#17181A`), screens darker than their frames (`#0A0B0C`), tally red
   (`#E5484D`) spent ONLY on live state and always captioned. Use tokens, don't

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,27 @@ views.
   visibility through `TerminalFocusArbiter.restore` and refuse/resign a hidden
   responder. Otherwise foregrounding sees the deliberately cleared owner as
   an invitation to restore the keyboard over the deck.
+- **The shell spends the safe areas; its panes hand back the clearance**
+  (`SingleWindowShell`). Its `GeometryReader` deliberately stays *inside* the
+  safe area — one that ignores an edge reports that edge's inset as zero, and
+  the insets are the whole point — then the pane stack spans the bands and
+  each pane restores its own: FleetWall as wall padding (`shellSafeArea`),
+  the terminal's chrome and grid as content insets (`contentSafeArea`, down to
+  the key rail's own `KeyBarRow` padding, which sits *inside* the ViewThatFits
+  proposal so tier choice measures usable width, and outside the bezel, which
+  runs on). So chassis, rules, bezels, and the terminal's screen reach the
+  physical edge while tiles, chips, keys, and text stay legible. Two traps:
+  **a landscape Dynamic Island sits mid-edge — over text rows, not just the
+  corners — and iOS reports both landscape edges as unsafe without saying
+  which one holds it** (a 180° flip is layout-invisible, insets are
+  symmetric), so no band is ever safe to read in, whichever looks empty; and
+  the deck's viewport alone takes `height + safeArea.bottom` so tiles scroll
+  under the home indicator and a docked keyboard, while the terminal stage
+  keeps the plain safe-area height — its rail is pinned to the container's
+  bottom. Also note the panes are placed with `.offset`, which claims no
+  width: the stack is narrower than the shell, so its frame must align
+  `.topLeading` or SwiftUI centers the lot (that shifted the deck inward and
+  ran the terminal off-screen in landscape).
 - **The iPad key rail is app-owned chrome, never an `inputAccessoryView`**:
   `TerminalKeyBar` is a TALLY rail (ESC / latching CTRL / TAB, the shell
   symbols `~ | / -`, DECCKM-aware autorepeat arrows, dismiss) installed as a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,10 +306,22 @@ views.
   corners — and iOS reports both landscape edges as unsafe without saying
   which one holds it** (a 180° flip is layout-invisible, insets are
   symmetric), so no band is ever safe to read in, whichever looks empty; and
-  the deck's viewport alone takes `height + safeArea.bottom` so tiles scroll
-  under the home indicator and a docked keyboard, while the terminal stage
-  keeps the plain safe-area height — its rail is pinned to the container's
-  bottom. Also note the panes are placed with `.offset`, which claims no
+  the bottom is the one strip content *does* take. Both heights are
+  `height + safeArea.bottom` — this reader is inset by whichever bottom region
+  applies, so adding it back always lands on the window's edge, keyboard or
+  not. The deck always takes it and restores it as scroll padding; the key
+  rail takes it **only at a compact vertical size class** — a phone in
+  landscape, the one layout short enough to spend the home indicator's strip
+  on chrome (portrait and iPad keep the standard clearance and just paint the
+  bezel through it). Where the rail does take it, its resting edge moves, so
+  `SwiftTermView.railOwnsBottomSafeArea` moves `restingBottom` with it —
+  otherwise `keyboardObstruction` (measured from that edge) stops matching the
+  container's own overlap and the helper strip lands *on* the rail. It stays a
+  static fact per pane, never read from the container's live frame: the
+  strip's padding would feed back. Spanning the bottom also hands the docked
+  keyboard back to `SwiftTermView`'s container, the documented sole owner —
+  the shell's own SwiftUI avoidance no longer reaches that pane.
+  Also note the panes are placed with `.offset`, which claims no
   width: the stack is narrower than the shell, so its frame must align
   `.topLeading` or SwiftUI centers the lot (that shifted the deck inward and
   ran the terminal off-screen in landscape).

--- a/Multiplex/App/MultiplexApp.swift
+++ b/Multiplex/App/MultiplexApp.swift
@@ -81,9 +81,49 @@ struct MultiplexApp: App {
         #endif
     }
 
+    @ViewBuilder
     private var deckWindow: some View {
-        DeckWindow()
-            .modifier(DeckWindowSizingBoundary())
+        configuredRoot(
+            SceneShellGate {
+                MultiWindowDeckRoot()
+                    .modifier(DeckWindowSizingBoundary())
+            } shell: {
+                SingleWindowShell()
+            }
+        )
+    }
+
+    private var terminalScene: some Scene {
+        WindowGroup(id: "terminal", for: TerminalWindowRoute.self) { $route in
+            terminalRoot($route)
+        }
+    }
+
+    @ViewBuilder
+    private func terminalRoot(_ route: Binding<TerminalWindowRoute?>) -> some View {
+        configuredRoot(
+            SceneShellGate {
+                if let binding = Binding(route) {
+                    TerminalWindowRoot(route: binding)
+                } else {
+                    // Classic multi-window mode historically leaves a
+                    // value-less terminal scene empty.
+                    EmptyView()
+                }
+            } shell: {
+                if let binding = Binding(route) {
+                    SingleWindowShell(initialRoute: binding.wrappedValue)
+                } else {
+                    // iOS 27 can connect this value-less group first on a
+                    // phone, so it must still be a complete shell root.
+                    SingleWindowShell()
+                }
+            }
+        )
+    }
+
+    private func configuredRoot<Content: View>(_ content: Content) -> some View {
+        content
             .environment(store)
             .environment(hub)
             .environment(themes)
@@ -94,21 +134,20 @@ struct MultiplexApp: App {
             .environment(localNetworkAccess)
             .modifier(PlatformChrome())
     }
+}
 
-    private var terminalScene: some Scene {
-        WindowGroup(id: "terminal", for: TerminalWindowRoute.self) { $route in
-            if let binding = Binding($route) {
-                TerminalWindowRoot(route: binding)
-                    .environment(store)
-                    .environment(hub)
-                    .environment(themes)
-                    .environment(customAgentCommands)
-                    .environment(workspace)
-                    .environment(entitlements)
-                    .environment(attention)
-                    .modifier(PlatformChrome())
-            }
-        }
+/// Classic deck presentation: the injected opener is exactly the existing
+/// `openWindow(id:value:)` route. Shell mode supplies a different opener from
+/// inside `SingleWindowShell`, leaving this path unchanged for windowed iPad
+/// and visionOS.
+private struct MultiWindowDeckRoot: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        DeckWindow(terminalOpener: TerminalRouteOpener(
+            destination: .window,
+            action: { openWindow(id: "terminal", value: $0) }
+        ))
     }
 }
 

--- a/Multiplex/Design/Chassis.swift
+++ b/Multiplex/Design/Chassis.swift
@@ -80,6 +80,8 @@ struct ChassisBadge: View {
                 Text(label)
                     .font(.mono(9, weight: .semibold))
                     .kerning(1.1)
+                    .lineLimit(1)
+                    .fixedSize()
             }
         }
         .foregroundStyle(color ?? (prominent ? Theme.signal : Theme.signal2))

--- a/Multiplex/Info.plist
+++ b/Multiplex/Info.plist
@@ -31,11 +31,24 @@
 		<key>UISceneConfigurations</key>
 		<dict/>
 	</dict>
+	<key>UIApplicationSceneManifest~iphone</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>
 		<string>AppBackground</string>
 	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Multiplex/Models/SingleWindowShellPolicy.swift
+++ b/Multiplex/Models/SingleWindowShellPolicy.swift
@@ -1,0 +1,47 @@
+import CoreGraphics
+
+/// Pure, UIKit-free policy for choosing Multiplex's single-window shell.
+/// UIKit supplies the scene idiom and the connected scene's full-screen bit;
+/// tests can cover the complete matrix without constructing a UIWindowScene.
+enum ShellModeDecision {
+    enum Platform: Equatable {
+        case iOS
+        case visionOS
+    }
+
+    enum Idiom: Equatable {
+        case phone
+        case pad
+        case other
+    }
+
+    static func usesSingleWindowShell(
+        platform: Platform,
+        idiom: Idiom,
+        isFullScreen: Bool,
+        environmentOverride: String?
+    ) -> Bool {
+        if environmentOverride == "1" { return true }
+        if environmentOverride == "0" { return false }
+
+        guard platform == .iOS else { return false }
+        switch idiom {
+        case .phone:
+            return true
+        case .pad:
+            return isFullScreen
+        case .other:
+            return false
+        }
+    }
+}
+
+/// Pure layout constants shared by the real shell and its unit tests.
+enum SingleWindowShellLayout {
+    static let expandedThreshold: CGFloat = 620
+    static let deckRailWidth: CGFloat = 316
+
+    static func isExpanded(width: CGFloat) -> Bool {
+        width >= expandedThreshold
+    }
+}

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -110,6 +110,14 @@ final class TerminalSessionController {
         TerminalFocusArbiter.claim(terminalView)
     }
 
+    /// The single-window shell navigated back to its deck. Focus ownership
+    /// still goes through the app-wide arbiter even though both surfaces live
+    /// in one scene.
+    func releaseFocus() {
+        guard let terminalView else { return }
+        TerminalFocusArbiter.release(terminalView)
+    }
+
     /// Bring this tab's hosting window scene forward and take keyboard
     /// focus — the deck tile's press-to-focus path. The scene raise is
     /// explicit: the arbiter only activates a scene when focus *switches*
@@ -143,11 +151,9 @@ final class TerminalSessionController {
     /// Scene became active again: re-assert focus only if this terminal is
     /// (or nothing is) the app-wide owner — every window's scene activates
     /// at once on foreground, and they must not steal from each other.
-    func restoreFocusIfOwner() {
-        guard let terminalView,
-              TerminalFocusArbiter.current === terminalView || TerminalFocusArbiter.current == nil
-        else { return }
-        TerminalFocusArbiter.claim(terminalView)
+    func restoreFocusIfOwner(allowed: Bool = true) {
+        guard let terminalView else { return }
+        TerminalFocusArbiter.restore(terminalView, allowed: allowed)
     }
 
     func start() {

--- a/Multiplex/Views/Deck/DeckWindow.swift
+++ b/Multiplex/Views/Deck/DeckWindow.swift
@@ -142,9 +142,13 @@ struct DeckWindow: View {
     @Environment(ConnectionHub.self) private var hub
     @Environment(TerminalWorkspace.self) private var workspace
     @Environment(LocalNetworkAccessMonitor.self) private var localNetworkAccess
-    @Environment(\.openWindow) private var openWindow
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
+
+    let terminalOpener: TerminalRouteOpener
+    var wallPresentation: FleetWall.Presentation = .standard
+    var selectedTerminal: TerminalRoute? = nil
+    var shellBottomSafeAreaInset: CGFloat = 0
 
     @State private var addingHost = false
     @State private var editingHost: Host?
@@ -159,6 +163,10 @@ struct DeckWindow: View {
 
     var body: some View {
         FleetWall(
+            terminalOpener: terminalOpener,
+            presentation: wallPresentation,
+            selectedTerminal: selectedTerminal,
+            shellBottomSafeAreaInset: shellBottomSafeAreaInset,
             addHost: requestAddHost,
             editHost: { editingHost = $0 },
             openSettings: { showingSettings = true }
@@ -213,7 +221,7 @@ struct DeckWindow: View {
             await DeckScene.autoAttachIfRequested(
                 store: store,
                 workspace: workspace,
-                openTerminalWindow: { openWindow(id: "terminal", value: $0) }
+                openTerminalWindow: { terminalOpener($0) }
             )
         }
         #endif

--- a/Multiplex/Views/Deck/DeckWindow.swift
+++ b/Multiplex/Views/Deck/DeckWindow.swift
@@ -148,7 +148,7 @@ struct DeckWindow: View {
     let terminalOpener: TerminalRouteOpener
     var wallPresentation: FleetWall.Presentation = .standard
     var selectedTerminal: TerminalRoute? = nil
-    var shellBottomSafeAreaInset: CGFloat = 0
+    var shellSafeArea = EdgeInsets()
 
     @State private var addingHost = false
     @State private var editingHost: Host?
@@ -166,7 +166,7 @@ struct DeckWindow: View {
             terminalOpener: terminalOpener,
             presentation: wallPresentation,
             selectedTerminal: selectedTerminal,
-            shellBottomSafeAreaInset: shellBottomSafeAreaInset,
+            shellSafeArea: shellSafeArea,
             addHost: requestAddHost,
             editHost: { editingHost = $0 },
             openSettings: { showingSettings = true }

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -226,7 +226,7 @@ struct FleetWall: View {
             header
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, wallPadding)
-                .padding(.top, wallPadding)
+                .padding(.top, min(wallPadding, 16))
                 .background(Theme.chassis)
                 .overlay(alignment: .bottom) {
                     Rectangle().fill(Theme.bezelHi).frame(height: 1)
@@ -519,6 +519,7 @@ struct FleetWall: View {
                         Text(host.address)
                             .font(.mono(11))
                             .foregroundStyle(Theme.signal2)
+                            .lineLimit(2)
                         Spacer()
                         railStatus(model)
                         // The SHELL chip is the row's tallest element —

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -95,10 +95,13 @@ struct FleetWall: View {
     var terminalOpener: TerminalRouteOpener
     var presentation: Presentation = .standard
     var selectedTerminal: TerminalRoute?
-    /// The shell deliberately lets its scroll viewport extend beneath the
-    /// home indicator, then restores this inset as scroll-content padding.
-    /// Classic deck scenes leave it at zero and retain their existing layout.
-    var shellBottomSafeAreaInset: CGFloat = 0
+    /// Safe-area insets the shell spends on the wall instead of reserving
+    /// them: chassis, rules, and the scroll viewport reach the window's
+    /// physical edges, and the wall restores these as content padding — so
+    /// tiles pass beneath the home indicator while staying clear of the
+    /// Dynamic Island. Classic deck scenes leave this zero and retain their
+    /// existing layout.
+    var shellSafeArea = EdgeInsets()
     var addHost: () -> Void
     var editHost: (Host) -> Void
     var openSettings: () -> Void
@@ -225,7 +228,8 @@ struct FleetWall: View {
         VStack(spacing: 0) {
             header
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, wallPadding)
+                .padding(.leading, wallPadding + shellSafeArea.leading)
+                .padding(.trailing, wallPadding + shellSafeArea.trailing)
                 .padding(.top, min(wallPadding, 16))
                 .background(Theme.chassis)
                 .overlay(alignment: .bottom) {
@@ -257,12 +261,10 @@ struct FleetWall: View {
                 maxWidth: .infinity,
                 alignment: presentation == .shellCompact ? .center : .leading
             )
-            .padding(.horizontal, wallPadding)
+            .padding(.leading, wallPadding + shellSafeArea.leading)
+            .padding(.trailing, wallPadding + shellSafeArea.trailing)
             .padding(.top, presentation == .standard ? wallPadding : 0)
-            .padding(
-                .bottom,
-                wallPadding + (presentation == .standard ? 0 : shellBottomSafeAreaInset)
-            )
+            .padding(.bottom, wallPadding + shellSafeArea.bottom)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay {
@@ -277,6 +279,7 @@ struct FleetWall: View {
                         availableWidth: max(
                             0,
                             geometry.size.width - wallPadding * 2
+                                - shellSafeArea.leading - shellSafeArea.trailing
                         )
                     )
                 } action: { count in

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -80,13 +80,25 @@ enum FleetTileGridSizing {
 /// hosts render in the composition as NO SIGNAL tiles instead of hiding
 /// behind a selection — there is no sidebar on purpose.
 struct FleetWall: View {
+    enum Presentation: Equatable {
+        case standard
+        case shellCompact
+        case shellRail
+    }
+
     @Environment(HostStore.self) private var store
     @Environment(ConnectionHub.self) private var hub
     @Environment(TerminalWorkspace.self) private var workspace
-    @Environment(\.openWindow) private var openWindow
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
 
+    var terminalOpener: TerminalRouteOpener
+    var presentation: Presentation = .standard
+    var selectedTerminal: TerminalRoute?
+    /// The shell deliberately lets its scroll viewport extend beneath the
+    /// home indicator, then restores this inset as scroll-content padding.
+    /// Classic deck scenes leave it at zero and retain their existing layout.
+    var shellBottomSafeAreaInset: CGFloat = 0
     var addHost: () -> Void
     var editHost: (Host) -> Void
     var openSettings: () -> Void
@@ -114,7 +126,9 @@ struct FleetWall: View {
         var id: UUID { host.id }
     }
 
-    private static let wallPadding: CGFloat = 26
+    private var wallPadding: CGFloat {
+        presentation == .shellRail ? 12 : 26
+    }
     /// Wall cadence: one concurrent probe round-trip per host per tick.
     private static let feedInterval: Duration = .seconds(5)
 
@@ -178,28 +192,55 @@ struct FleetWall: View {
 
     @ViewBuilder
     private var platformWall: some View {
-        #if os(visionOS)
-        wall(showHeader: true)
-        #else
-        if #available(iOS 26.0, *) {
-            // iPadOS window controls occupy the leading edge of the title
-            // bar, but don't contribute a safe-area inset to arbitrary
-            // content. Put the deck rail in the system toolbar so MULTIPLEX
-            // is laid out around those controls instead of underneath them.
-            NavigationStack {
-                wall(showHeader: false)
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbarBackground(Theme.chassis, for: .navigationBar)
-                    .toolbar { deckToolbar }
-            }
+        if presentation != .standard {
+            shellWall
         } else {
+            #if os(visionOS)
             wall(showHeader: true)
+            #else
+            if #available(iOS 26.0, *) {
+                // iPadOS window controls occupy the leading edge of the title
+                // bar, but don't contribute a safe-area inset to arbitrary
+                // content. Put the classic deck rail in the system toolbar
+                // so MULTIPLEX is laid out around those controls instead of
+                // underneath them. The in-scene shell has no window controls
+                // and keeps its TALLY header full-bleed in the wall itself.
+                NavigationStack {
+                    wall(showHeader: false)
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbarBackground(Theme.chassis, for: .navigationBar)
+                        .toolbar { deckToolbar }
+                }
+            } else {
+                wall(showHeader: true)
+            }
+            #endif
         }
-        #endif
+    }
+
+    /// Shell decks use a fixed TALLY header. Only the host sections scroll,
+    /// and their viewport extends beneath the bottom safe area while content
+    /// receives the equivalent inset as trailing breathing room.
+    private var shellWall: some View {
+        VStack(spacing: 0) {
+            header
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, wallPadding)
+                .padding(.top, wallPadding)
+                .background(Theme.chassis)
+                .overlay(alignment: .bottom) {
+                    Rectangle().fill(Theme.bezelHi).frame(height: 1)
+                }
+
+            wall(showHeader: false)
+                .ignoresSafeArea(.container, edges: .bottom)
+        }
     }
 
     private func wall(showHeader: Bool) -> some View {
-        let columns = gridColumns(count: tileGridColumnCount ?? 2)
+        let columns = gridColumns(
+            count: tileGridColumnCount ?? (presentation == .standard ? 2 : 1)
+        )
 
         return ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -212,8 +253,16 @@ struct FleetWall: View {
                     }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(Self.wallPadding)
+            .frame(
+                maxWidth: .infinity,
+                alignment: presentation == .shellCompact ? .center : .leading
+            )
+            .padding(.horizontal, wallPadding)
+            .padding(.top, presentation == .standard ? wallPadding : 0)
+            .padding(
+                .bottom,
+                wallPadding + (presentation == .standard ? 0 : shellBottomSafeAreaInset)
+            )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay {
@@ -227,7 +276,7 @@ struct FleetWall: View {
                         current: tileGridColumnCount,
                         availableWidth: max(
                             0,
-                            geometry.size.width - Self.wallPadding * 2
+                            geometry.size.width - wallPadding * 2
                         )
                     )
                 } action: { count in
@@ -256,6 +305,10 @@ struct FleetWall: View {
             ),
             count: count
         )
+    }
+
+    private var gridAlignment: HorizontalAlignment {
+        presentation == .shellCompact ? .center : .leading
     }
 
     /// While this view exists, keep the wall alive: re-probe each host and
@@ -321,17 +374,70 @@ struct FleetWall: View {
     }
     #endif
 
+    @ViewBuilder
     private var header: some View {
+        if presentation == .shellRail {
+            HStack(alignment: .center, spacing: 8) {
+                ChassisLabel("Multiplex", size: 13)
+                Spacer(minLength: 4)
+                Text(fleetSummary)
+                    .font(.mono(8.5))
+                    .foregroundStyle(Theme.signal2)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                ChassisChip("", systemImage: "plus", action: addHost)
+                    .accessibilityLabel("Add host")
+                ChassisChip("", systemImage: "gearshape", action: openSettings)
+                    .accessibilityLabel("Settings")
+            }
+            .padding(.bottom, 12)
+        } else if presentation == .shellCompact {
+            ViewThatFits(in: .horizontal) {
+                shellCompactHeader(showsSummary: true, iconOnly: false)
+                shellCompactHeader(showsSummary: false, iconOnly: false)
+                shellCompactHeader(showsSummary: false, iconOnly: true)
+            }
+            .padding(.bottom, 16)
+        } else {
+            HStack(alignment: .center, spacing: 10) {
+                ChassisLabel("Multiplex", size: 15)
+                Spacer()
+                Text(fleetSummary)
+                    .font(.mono(11))
+                    .foregroundStyle(Theme.signal2)
+                ChassisChip("HOST", systemImage: "plus", action: addHost)
+                ChassisChip("SETTINGS", systemImage: "gearshape", action: openSettings)
+            }
+            .padding(.bottom, 16)
+        }
+    }
+
+    private func shellCompactHeader(
+        showsSummary: Bool,
+        iconOnly: Bool
+    ) -> some View {
         HStack(alignment: .center, spacing: 10) {
             ChassisLabel("Multiplex", size: 15)
-            Spacer()
-            Text(fleetSummary)
-                .font(.mono(11))
-                .foregroundStyle(Theme.signal2)
-            ChassisChip("HOST", systemImage: "plus", action: addHost)
-            ChassisChip("SETTINGS", systemImage: "gearshape", action: openSettings)
+                .fixedSize()
+            Spacer(minLength: 4)
+            if showsSummary {
+                Text(fleetSummary)
+                    .font(.mono(11))
+                    .foregroundStyle(Theme.signal2)
+                    .lineLimit(1)
+                    .fixedSize()
+            }
+            ChassisChip(iconOnly ? "" : "HOST", systemImage: "plus", action: addHost)
+                .fixedSize()
+                .accessibilityLabel("Add host")
+            ChassisChip(
+                iconOnly ? "" : "SETTINGS",
+                systemImage: "gearshape",
+                action: openSettings
+            )
+            .fixedSize()
+            .accessibilityLabel("Settings")
         }
-        .padding(.bottom, 16)
     }
 
     private var fleetSummary: String {
@@ -386,32 +492,58 @@ struct FleetWall: View {
 
     private func rail(_ host: Host, model: HostConnectionModel) -> some View {
         let connected = model.phase == .connected
-        return VStack(alignment: .leading, spacing: 10) {
-            Rectangle().fill(Theme.bezel).frame(height: 1)
-            HStack(alignment: .firstTextBaseline, spacing: 14) {
-                ChassisLabel(host.name, size: 12)
-                Text(host.address)
-                    .font(.mono(11))
-                    .foregroundStyle(Theme.signal2)
-                Spacer()
-                railStatus(model)
-                // The SHELL chip is the row's tallest element — inserting/
-                // removing it with the phase resizes the whole rail. Keep
-                // its slot in every phase and fade it instead.
-                ChassisChip("SHELL") {
-                    open(TerminalRoute(hostID: host.id, mode: .shell))
+        return Group {
+            if presentation == .shellRail {
+                VStack(alignment: .leading, spacing: 8) {
+                    Rectangle().fill(Theme.bezel).frame(height: 1)
+                    HStack(spacing: 8) {
+                        ChassisLabel(host.name, size: 11)
+                        Spacer(minLength: 4)
+                        railStatus(model)
+                        hostMenu(host)
+                    }
+                    HStack(spacing: 8) {
+                        Text(host.address)
+                            .font(.mono(9.5))
+                            .foregroundStyle(Theme.signal2)
+                            .lineLimit(1)
+                        Spacer(minLength: 4)
+                        shellChip(host, connected: connected)
+                    }
                 }
-                .opacity(connected ? 1 : 0)
-                .allowsHitTesting(connected)
-                .disabled(!connected)
-                .accessibilityHidden(!connected)
-                hostMenu(host)
-            }
-            .contentShape(Rectangle())
-            .contextMenu {
-                hostMenuActions(host)
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    Rectangle().fill(Theme.bezel).frame(height: 1)
+                    HStack(alignment: .firstTextBaseline, spacing: 14) {
+                        ChassisLabel(host.name, size: 12)
+                        Text(host.address)
+                            .font(.mono(11))
+                            .foregroundStyle(Theme.signal2)
+                        Spacer()
+                        railStatus(model)
+                        // The SHELL chip is the row's tallest element —
+                        // inserting/removing it with the phase resizes the
+                        // whole rail. Keep its slot and fade it instead.
+                        shellChip(host, connected: connected)
+                        hostMenu(host)
+                    }
+                }
             }
         }
+        .contentShape(Rectangle())
+        .contextMenu {
+            hostMenuActions(host)
+        }
+    }
+
+    private func shellChip(_ host: Host, connected: Bool) -> some View {
+        ChassisChip("SHELL") {
+            open(TerminalRoute(hostID: host.id, mode: .shell))
+        }
+        .opacity(connected ? 1 : 0)
+        .allowsHitTesting(connected)
+        .disabled(!connected)
+        .accessibilityHidden(!connected)
     }
 
     /// Visible host controls. Edit is most needed when a host is
@@ -523,7 +655,7 @@ struct FleetWall: View {
             animatedGrid(
                 LazyVGrid(
                     columns: columns,
-                    alignment: .leading,
+                    alignment: gridAlignment,
                     spacing: FleetTileGridSizing.gutter
                 ) {
                     newSessionTile(host)
@@ -534,7 +666,7 @@ struct FleetWall: View {
             animatedGrid(
                 LazyVGrid(
                     columns: columns,
-                    alignment: .leading,
+                    alignment: gridAlignment,
                     spacing: FleetTileGridSizing.gutter
                 ) {
                     noteTile("No tmux on host", detail: "You can still open a plain shell.")
@@ -545,7 +677,7 @@ struct FleetWall: View {
             animatedGrid(
                 LazyVGrid(
                     columns: columns,
-                    alignment: .leading,
+                    alignment: gridAlignment,
                     spacing: FleetTileGridSizing.gutter
                 ) {
                     noSignalTile(host, model: model)
@@ -556,7 +688,7 @@ struct FleetWall: View {
             animatedGrid(
                 LazyVGrid(
                     columns: columns,
-                    alignment: .leading,
+                    alignment: gridAlignment,
                     spacing: FleetTileGridSizing.gutter
                 ) {
                     acquiringTile
@@ -578,7 +710,7 @@ struct FleetWall: View {
     ) -> some View {
         LazyVGrid(
             columns: columns,
-            alignment: .leading,
+            alignment: gridAlignment,
             spacing: FleetTileGridSizing.gutter
         ) {
             newSessionTile(host)
@@ -613,7 +745,7 @@ struct FleetWall: View {
     ) -> some View {
         LazyVGrid(
             columns: columns,
-            alignment: .leading,
+            alignment: gridAlignment,
             spacing: FleetTileGridSizing.gutter
         ) {
             newSessionTile(host)
@@ -668,6 +800,11 @@ struct FleetWall: View {
             attention: model.attention[session.name],
             hasLiveAgentState: model.lastRefreshed != nil,
             hasOpenTab: workspace.hasTab(hostID: host.id, sessionName: session.name),
+            compact: presentation == .shellRail,
+            selected: selectedTerminal?.hostID == host.id
+                && selectedTerminal?.sessionName == session.name,
+            duplicateAttachTitle: terminalOpener.duplicateAttachTitle,
+            openTabAccessibilityText: terminalOpener.openTabAccessibilityText,
             attach: {
                 focusOrAttach(host, session: session)
             },
@@ -702,7 +839,10 @@ struct FleetWall: View {
             VStack {
                 ChassisLabel("+ New Session", size: 11, color: Theme.signal2)
             }
-            .frame(maxWidth: .infinity, minHeight: 138)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: presentation == .shellRail ? 92 : 138
+            )
             .overlay(
                 Rectangle().strokeBorder(
                     Theme.bezelHi,
@@ -723,7 +863,10 @@ struct FleetWall: View {
                     HatchedScreen()
                     ChassisLabel("No Signal", size: 13, color: Theme.signal3)
                 }
-                .frame(maxWidth: .infinity, minHeight: 96)
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: presentation == .shellRail ? 64 : 96
+                )
                 HStack {
                     ChassisLabel(host.name, size: 12, color: Theme.signal3)
                     Spacer()
@@ -747,7 +890,10 @@ struct FleetWall: View {
             ProgressView().controlSize(.small)
             ChassisLabel("Acquiring signal", size: 10, color: Theme.signal3)
         }
-        .frame(maxWidth: .infinity, minHeight: 138)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: presentation == .shellRail ? 92 : 138
+        )
         .background(Theme.screen)
         .padding(5)
         .background(Theme.bezel)
@@ -759,7 +905,10 @@ struct FleetWall: View {
             ChassisLabel(title, size: 11, color: Theme.signal3)
             Text(detail).font(.footnote).foregroundStyle(Theme.signal2)
         }
-        .frame(maxWidth: .infinity, minHeight: 138)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: presentation == .shellRail ? 92 : 138
+        )
         .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
     }
 
@@ -809,7 +958,7 @@ struct FleetWall: View {
     }
 
     private func open(_ route: TerminalRoute) {
-        openWindow(id: "terminal", value: TerminalWindowRoute(tab: route))
+        terminalOpener(TerminalWindowRoute(tab: route))
     }
 }
 
@@ -1104,6 +1253,12 @@ private struct SessionTile: View {
     /// Whether some open terminal window already has this session as a tab
     /// — pressing then focuses that window instead of attaching again.
     let hasOpenTab: Bool
+    /// Expanded shell rails use the approved mini-tile anatomy while keeping
+    /// the same live capture, state, actions, and reorder behavior.
+    let compact: Bool
+    let selected: Bool
+    let duplicateAttachTitle: String
+    let openTabAccessibilityText: String
     let attach: () -> Void
     let attachNewWindow: () -> Void
     let delete: () -> Void
@@ -1113,11 +1268,14 @@ private struct SessionTile: View {
             VStack(spacing: 0) {
                 screen
                 umd
-                segmentStrip
+                if !compact { segmentStrip }
             }
-            .padding(5)
+            .padding(compact ? 4 : 5)
             .background(Theme.bezel)
-            .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+            .overlay(Rectangle().strokeBorder(
+                selected ? Theme.signal2 : Theme.bezelHi,
+                lineWidth: selected ? 1.5 : 1
+            ))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -1127,7 +1285,7 @@ private struct SessionTile: View {
         // make the card read as if it shrank under the finger.
         .contentShape(.dragPreview, Rectangle())
         .contextMenu {
-            Button("Attach in New Window", action: attachNewWindow)
+            Button(duplicateAttachTitle, action: attachNewWindow)
             Button("Delete Session…", role: .destructive, action: delete)
         }
         .accessibilityLabel(accessibilitySummary)
@@ -1141,7 +1299,10 @@ private struct SessionTile: View {
                     .font(.mono(11))
                     .foregroundStyle(Theme.signal3)
             } else {
-                ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                ForEach(
+                    Array(lines.prefix(compact ? 3 : lines.count).enumerated()),
+                    id: \.offset
+                ) { _, line in
                     Text(line.isEmpty ? " " : line)
                         .font(.mono(11))
                         .foregroundStyle(Theme.miniText.opacity(0.78))
@@ -1149,14 +1310,18 @@ private struct SessionTile: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 76, alignment: .topLeading)
-        .padding(10)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: compact ? 56 : 76,
+            alignment: .topLeading
+        )
+        .padding(compact ? 8 : 10)
         .background(Theme.screen)
     }
 
     private var umd: some View {
         HStack(spacing: 9) {
-            ChassisLabel(session.name, size: 12)
+            ChassisLabel(session.name, size: compact ? 10 : 12)
             // The badge is taller than the lamp, so swapping them resizes
             // the tile on every attach/detach. The badge keeps its slot in
             // both states (hidden under the lamp) to pin the row's height.
@@ -1174,14 +1339,16 @@ private struct SessionTile: View {
                 TallyLamp(caption: "NEEDS YOU", color: Theme.caution)
             }
             Spacer(minLength: 6)
-            Text(telemetry)
-                .font(.mono(9.5))
-                .foregroundStyle(Theme.signal2)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
+            if !compact {
+                Text(telemetry)
+                    .font(.mono(9.5))
+                    .foregroundStyle(Theme.signal2)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
         }
-        .padding(.horizontal, 7)
-        .padding(.top, 8)
+        .padding(.horizontal, compact ? 6 : 7)
+        .padding(.top, compact ? 6 : 8)
         .padding(.bottom, 5)
     }
 
@@ -1292,6 +1459,6 @@ private struct SessionTile: View {
         if agentRunning { parts.append("agent running") }
         parts.append("\(session.windowCount) windows and \(session.paneCount) panes")
         return parts.joined(separator: ", ")
-            + (hasOpenTab ? ". Shows its open window" : ". Attach")
+            + (hasOpenTab ? ". \(openTabAccessibilityText)" : ". Attach")
     }
 }

--- a/Multiplex/Views/Shell/SceneShellGate.swift
+++ b/Multiplex/Views/Shell/SceneShellGate.swift
@@ -1,0 +1,132 @@
+import OSLog
+import SwiftUI
+import UIKit
+
+/// Resolves shell mode once, when this SwiftUI scene first acquires its
+/// UIWindowScene. The result intentionally does not follow live multitasking
+/// setting changes; reconnecting the scene on the next launch re-evaluates it.
+struct SceneShellGate<Classic: View, Shell: View>: View {
+    @State private var usesShell: Bool?
+
+    private let classic: Classic
+    private let shell: Shell
+
+    init(
+        @ViewBuilder classic: () -> Classic,
+        @ViewBuilder shell: () -> Shell
+    ) {
+        self.classic = classic()
+        self.shell = shell()
+    }
+
+    var body: some View {
+        Group {
+            switch usesShell {
+            case true:
+                shell
+            case false:
+                classic
+            case nil:
+                Theme.chassis
+                    .ignoresSafeArea()
+                    .background(SceneConnectionReader(resolve: resolve))
+            }
+        }
+    }
+
+    private func resolve(_ scene: UIWindowScene) {
+        guard usesShell == nil else { return }
+
+        #if os(visionOS)
+        let platform = ShellModeDecision.Platform.visionOS
+        // A spatial window has no iPad-style full-screen/windowed mode.
+        let isFullScreen = false
+        #else
+        let platform = ShellModeDecision.Platform.iOS
+        let isFullScreen = scene.isFullScreen
+        #endif
+
+        let idiom = ShellModeDecision.Idiom(scene.traitCollection.userInterfaceIdiom)
+        #if DEBUG
+        let override = ProcessInfo.processInfo.environment["MULTIPLEX_FORCE_SHELL"]
+        #else
+        let override: String? = nil
+        #endif
+        let decision = ShellModeDecision.usesSingleWindowShell(
+            platform: platform,
+            idiom: idiom,
+            isFullScreen: isFullScreen,
+            environmentOverride: override
+        )
+        let overrideLabel = override ?? "none"
+
+        Self.logger.info(
+            "decision shell=\(decision, privacy: .public) idiom=\(idiom.logLabel, privacy: .public) isFullScreen=\(isFullScreen, privacy: .public) override=\(overrideLabel, privacy: .public)"
+        )
+        usesShell = decision
+    }
+
+    private static var logger: Logger {
+        Logger(
+            subsystem: "app.multiplexterm.multiplex",
+            category: "shell"
+        )
+    }
+}
+
+private extension ShellModeDecision.Idiom {
+    init(_ idiom: UIUserInterfaceIdiom) {
+        switch idiom {
+        case .phone: self = .phone
+        case .pad: self = .pad
+        default: self = .other
+        }
+    }
+
+    var logLabel: String {
+        switch self {
+        case .phone: "phone"
+        case .pad: "pad"
+        case .other: "other"
+        }
+    }
+}
+
+/// A zero-size UIKit probe that reports the hosting scene at connect time.
+private struct SceneConnectionReader: UIViewRepresentable {
+    var resolve: @MainActor (UIWindowScene) -> Void
+
+    func makeUIView(context: Context) -> ReporterView {
+        ReporterView(resolve: resolve)
+    }
+
+    func updateUIView(_ view: ReporterView, context: Context) {
+        view.resolve = resolve
+        view.reportIfConnected()
+    }
+
+    @MainActor
+    final class ReporterView: UIView {
+        var resolve: @MainActor (UIWindowScene) -> Void
+
+        init(resolve: @escaping @MainActor (UIWindowScene) -> Void) {
+            self.resolve = resolve
+            super.init(frame: .zero)
+            isUserInteractionEnabled = false
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            reportIfConnected()
+        }
+
+        func reportIfConnected() {
+            guard let scene = window?.windowScene else { return }
+            resolve(scene)
+        }
+    }
+}

--- a/Multiplex/Views/Shell/SingleWindowShell.swift
+++ b/Multiplex/Views/Shell/SingleWindowShell.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+/// Multiplex's real one-scene shell for iPhone and full-screen iPad. The deck
+/// and terminal stage remain mounted together: compact navigation slides the
+/// live terminal over the deck, while expanded layout exposes the same deck
+/// as a one-session-wide rail. TerminalSessionController continues to own the
+/// TerminalView, so back navigation, rail collapse, and width transitions do
+/// not interrupt the shell or lose scrollback.
+struct SingleWindowShell: View {
+    @Environment(TerminalWorkspace.self) private var workspace
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var terminalRoute: TerminalWindowRoute
+    @State private var compactShowsTerminal: Bool
+    @State private var deckRailVisible = true
+
+    init(initialRoute: TerminalWindowRoute? = nil) {
+        let route = initialRoute ?? TerminalWindowRoute(tabs: [])
+        _terminalRoute = State(initialValue: route)
+        _compactShowsTerminal = State(initialValue: !route.tabs.isEmpty)
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let expanded = SingleWindowShellLayout.isExpanded(width: geometry.size.width)
+            let deckWidth = expanded
+                ? (deckRailVisible ? min(SingleWindowShellLayout.deckRailWidth, geometry.size.width) : 0)
+                : geometry.size.width
+            let terminalWidth = expanded
+                ? max(0, geometry.size.width - deckWidth)
+                : geometry.size.width
+
+            ZStack(alignment: .leading) {
+                deck(
+                    expanded: expanded,
+                    bottomSafeAreaInset: geometry.safeAreaInsets.bottom
+                )
+                    .frame(width: deckWidth, height: geometry.size.height)
+                    .clipped()
+                    .opacity(expanded || !compactShowsTerminal ? 1 : 0)
+                    .allowsHitTesting(expanded ? deckRailVisible : !compactShowsTerminal)
+                    .zIndex(0)
+
+                terminalStage(expanded: expanded, availableWidth: terminalWidth)
+                    .frame(width: terminalWidth, height: geometry.size.height)
+                    .offset(x: expanded
+                        ? deckWidth
+                        : (compactShowsTerminal ? 0 : geometry.size.width))
+                    .opacity(expanded || compactShowsTerminal ? 1 : 0)
+                    .allowsHitTesting(expanded || compactShowsTerminal)
+                    .zIndex(1)
+
+                if expanded, deckRailVisible {
+                    Rectangle()
+                        .fill(Theme.bezelHi)
+                        .frame(width: 1, height: geometry.size.height)
+                        .offset(x: deckWidth - 1)
+                        .allowsHitTesting(false)
+                        .zIndex(2)
+                }
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+            .background(Theme.chassis.ignoresSafeArea())
+            .animation(shellAnimation, value: compactShowsTerminal)
+            .animation(shellAnimation, value: deckRailVisible)
+            .animation(shellAnimation, value: expanded)
+            .onChange(of: expanded) { _, isExpanded in
+                if !isExpanded, !compactShowsTerminal {
+                    releaseTerminalFocus()
+                }
+            }
+            .onChange(of: scenePhase) { _, phase in
+                guard phase == .active,
+                      !expanded,
+                      !compactShowsTerminal
+                else { return }
+                // UIKit may try to restore the still-mounted terminal's input
+                // session as this scene foregrounds. The deck is frontmost,
+                // so reassert the shell's no-terminal-focus invariant through
+                // the controller/arbiter path.
+                releaseTerminalFocus()
+            }
+        }
+    }
+
+    private func deck(
+        expanded: Bool,
+        bottomSafeAreaInset: CGFloat
+    ) -> some View {
+        DeckWindow(
+            terminalOpener: TerminalRouteOpener(
+                destination: .shell,
+                action: openTerminalRoute
+            ),
+            wallPresentation: expanded ? .shellRail : .shellCompact,
+            selectedTerminal: terminalRoute.activeTab,
+            shellBottomSafeAreaInset: bottomSafeAreaInset
+        )
+    }
+
+    @ViewBuilder
+    private func terminalStage(expanded: Bool, availableWidth: CGFloat) -> some View {
+        if terminalRoute.tabs.isEmpty {
+            emptyTerminal
+        } else {
+            TerminalWindowRoot(
+                route: $terminalRoute,
+                shell: .init(
+                    deckControlLabel: expanded
+                        ? (deckRailVisible ? "◧ HIDE" : "◧ DECK")
+                        : "‹ DECK",
+                    availableWidth: availableWidth,
+                    showDeck: { showDeck(expanded: expanded) },
+                    openTerminalRoute: openTerminalRoute,
+                    revealTab: revealTab,
+                    tabsEmptied: terminalTabsEmptied,
+                    terminalFocusAllowed: expanded || compactShowsTerminal
+                )
+            )
+        }
+    }
+
+    private var emptyTerminal: some View {
+        ZStack {
+            Theme.screen
+            VStack(spacing: 10) {
+                ChassisLabel("No terminal selected", size: 13, color: Theme.signal3)
+                Text("Choose a session from the deck to attach it here.")
+                    .font(.footnote)
+                    .foregroundStyle(Theme.signal2)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(24)
+        }
+    }
+
+    private var shellAnimation: Animation? {
+        reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 1)
+    }
+
+    /// Every incoming window route becomes tabs in this shell. AUTO_ATTACH
+    /// `+` groups arrive as one route and comma-separated entries simply add
+    /// to the same ordered tab list.
+    private func openTerminalRoute(_ incoming: TerminalWindowRoute) {
+        guard !incoming.tabs.isEmpty else { return }
+        terminalRoute.merge(incoming.tabs)
+        if let selected = incoming.activeTab?.id ?? incoming.tabs.first?.id {
+            terminalRoute.activate(selected)
+        }
+        compactShowsTerminal = true
+        focusAfterNavigation(tabID: terminalRoute.activeTabID)
+    }
+
+    /// TerminalWorkspace's existing press-to-focus lookup calls this reveal
+    /// closure for an already-open session instead of creating a duplicate.
+    private func revealTab(_ tabID: UUID) {
+        compactShowsTerminal = true
+        focusAfterNavigation(tabID: tabID)
+    }
+
+    private func showDeck(expanded: Bool) {
+        if expanded {
+            deckRailVisible.toggle()
+        } else {
+            releaseTerminalFocus()
+            compactShowsTerminal = false
+        }
+    }
+
+    private func terminalTabsEmptied() {
+        releaseTerminalFocus()
+        compactShowsTerminal = false
+        deckRailVisible = true
+    }
+
+    private func focusAfterNavigation(tabID: UUID?) {
+        guard let tabID else { return }
+        DispatchQueue.main.async {
+            workspace.controller(for: tabID)?.focusTerminal()
+        }
+    }
+
+    private func releaseTerminalFocus() {
+        guard let tabID = terminalRoute.activeTab?.id else { return }
+        workspace.controller(for: tabID)?.releaseFocus()
+    }
+}

--- a/Multiplex/Views/Shell/SingleWindowShell.swift
+++ b/Multiplex/Views/Shell/SingleWindowShell.swift
@@ -23,30 +23,76 @@ struct SingleWindowShell: View {
 
     var body: some View {
         GeometryReader { geometry in
+            let safeArea = geometry.safeAreaInsets
+            // A landscape phone insets both long edges by the Dynamic
+            // Island's band. This reader stays inside them — an ignoring one
+            // reports the edges it spans as zero — so the stack below spans
+            // them explicitly and every pane is handed its own clearance.
+            // The breakpoint keeps measuring the width panes can really use.
             let expanded = SingleWindowShellLayout.isExpanded(width: geometry.size.width)
+            let fullWidth = geometry.size.width + safeArea.leading + safeArea.trailing
+            // The rail carries its own leading clearance: the frame spans the
+            // Island's band so the wall's chassis and rules reach the physical
+            // edge, while FleetWall pads its content back out of it.
             let deckWidth = expanded
-                ? (deckRailVisible ? min(SingleWindowShellLayout.deckRailWidth, geometry.size.width) : 0)
-                : geometry.size.width
+                ? (deckRailVisible
+                    ? min(
+                        SingleWindowShellLayout.deckRailWidth + safeArea.leading,
+                        fullWidth
+                    )
+                    : 0)
+                : fullWidth
             let terminalWidth = expanded
-                ? max(0, geometry.size.width - deckWidth)
-                : geometry.size.width
+                ? max(0, fullWidth - deckWidth)
+                : fullWidth
+            // The shell is laid out inside the vertical safe area, but the
+            // deck's scroll viewport is meant to reach the window's bottom
+            // edge: FleetWall restores the same inset as scroll-content
+            // padding, so tiles pass beneath the home indicator (and a docked
+            // keyboard) instead of stopping short of it. The terminal stage
+            // keeps the plain safe-area height — its key rail is pinned to
+            // the container's bottom, which must stay above the indicator.
+            let deckHeight = geometry.size.height + safeArea.bottom
+            // Each pane keeps its content clear of the bands its own frame
+            // spans — a hidden rail hands the Island's band to the terminal,
+            // and a compact deck spans both. iOS reports both landscape edges
+            // as unsafe without saying which one carries the Island, and the
+            // Island sits mid-edge, over text rows: neither band is safe to
+            // read in, so surfaces fill them and content stays out.
+            let terminalOriginX = expanded ? deckWidth : 0
 
-            ZStack(alignment: .leading) {
+            ZStack(alignment: .topLeading) {
                 deck(
                     expanded: expanded,
-                    bottomSafeAreaInset: geometry.safeAreaInsets.bottom
+                    safeArea: EdgeInsets(
+                        top: 0,
+                        leading: safeArea.leading,
+                        bottom: safeArea.bottom,
+                        trailing: max(0, deckWidth - (fullWidth - safeArea.trailing))
+                    )
                 )
-                    .frame(width: deckWidth, height: geometry.size.height)
+                    .frame(width: deckWidth, height: deckHeight)
                     .clipped()
                     .opacity(expanded || !compactShowsTerminal ? 1 : 0)
                     .allowsHitTesting(expanded ? deckRailVisible : !compactShowsTerminal)
                     .zIndex(0)
 
-                terminalStage(expanded: expanded, availableWidth: terminalWidth)
+                terminalStage(
+                    expanded: expanded,
+                    availableWidth: terminalWidth
+                        - max(0, safeArea.leading - terminalOriginX)
+                        - safeArea.trailing,
+                    contentSafeArea: EdgeInsets(
+                        top: 0,
+                        leading: max(0, safeArea.leading - terminalOriginX),
+                        bottom: 0,
+                        trailing: safeArea.trailing
+                    )
+                )
                     .frame(width: terminalWidth, height: geometry.size.height)
                     .offset(x: expanded
                         ? deckWidth
-                        : (compactShowsTerminal ? 0 : geometry.size.width))
+                        : (compactShowsTerminal ? 0 : fullWidth))
                     .opacity(expanded || compactShowsTerminal ? 1 : 0)
                     .allowsHitTesting(expanded || compactShowsTerminal)
                     .zIndex(1)
@@ -54,13 +100,27 @@ struct SingleWindowShell: View {
                 if expanded, deckRailVisible {
                     Rectangle()
                         .fill(Theme.bezelHi)
-                        .frame(width: 1, height: geometry.size.height)
+                        .frame(width: 1, height: deckHeight)
                         .offset(x: deckWidth - 1)
                         .allowsHitTesting(false)
                         .zIndex(2)
                 }
             }
-            .frame(width: geometry.size.width, height: geometry.size.height)
+            // Both panes are placed from the leading edge and the terminal
+            // rides an `.offset`, which never claims width. The stack is
+            // therefore narrower than the shell, and an unaligned frame
+            // would center it — in landscape that pushed the deck inward and
+            // ran the terminal off the screen's trailing edge.
+            .frame(
+                width: fullWidth,
+                height: geometry.size.height,
+                alignment: .topLeading
+            )
+            // Spend the side safe areas rather than letting SwiftUI reserve
+            // them: each pane fills its band with chassis and screen, and is
+            // handed the inset back so only content that must stay legible —
+            // tiles, chips, keys — keeps clear of the Island and the corners.
+            .ignoresSafeArea(.container, edges: .horizontal)
             .background(Theme.chassis.ignoresSafeArea())
             .animation(shellAnimation, value: compactShowsTerminal)
             .animation(shellAnimation, value: deckRailVisible)
@@ -86,7 +146,7 @@ struct SingleWindowShell: View {
 
     private func deck(
         expanded: Bool,
-        bottomSafeAreaInset: CGFloat
+        safeArea: EdgeInsets
     ) -> some View {
         DeckWindow(
             terminalOpener: TerminalRouteOpener(
@@ -95,12 +155,16 @@ struct SingleWindowShell: View {
             ),
             wallPresentation: expanded ? .shellRail : .shellCompact,
             selectedTerminal: terminalRoute.activeTab,
-            shellBottomSafeAreaInset: bottomSafeAreaInset
+            shellSafeArea: safeArea
         )
     }
 
     @ViewBuilder
-    private func terminalStage(expanded: Bool, availableWidth: CGFloat) -> some View {
+    private func terminalStage(
+        expanded: Bool,
+        availableWidth: CGFloat,
+        contentSafeArea: EdgeInsets
+    ) -> some View {
         if terminalRoute.tabs.isEmpty {
             emptyTerminal
         } else {
@@ -111,6 +175,7 @@ struct SingleWindowShell: View {
                         ? (deckRailVisible ? "◧ HIDE" : "◧ DECK")
                         : "‹ DECK",
                     availableWidth: availableWidth,
+                    contentSafeArea: contentSafeArea,
                     showDeck: { showDeck(expanded: expanded) },
                     openTerminalRoute: openTerminalRoute,
                     revealTab: revealTab,

--- a/Multiplex/Views/Shell/SingleWindowShell.swift
+++ b/Multiplex/Views/Shell/SingleWindowShell.swift
@@ -10,6 +10,7 @@ struct SingleWindowShell: View {
     @Environment(TerminalWorkspace.self) private var workspace
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     @State private var terminalRoute: TerminalWindowRoute
     @State private var compactShowsTerminal: Bool
@@ -45,14 +46,23 @@ struct SingleWindowShell: View {
             let terminalWidth = expanded
                 ? max(0, fullWidth - deckWidth)
                 : fullWidth
-            // The shell is laid out inside the vertical safe area, but the
-            // deck's scroll viewport is meant to reach the window's bottom
-            // edge: FleetWall restores the same inset as scroll-content
-            // padding, so tiles pass beneath the home indicator (and a docked
-            // keyboard) instead of stopping short of it. The terminal stage
-            // keeps the plain safe-area height — its key rail is pinned to
-            // the container's bottom, which must stay above the indicator.
+            // This reader is inset by whichever bottom region applies, so
+            // adding it back always lands on the window's bottom edge —
+            // keyboard or not. The deck's scroll viewport always wants that:
+            // FleetWall restores the strip as content padding, so tiles pass
+            // beneath the home indicator (and a docked keyboard) instead of
+            // stopping short of it.
             let deckHeight = geometry.size.height + safeArea.bottom
+            // Only a phone held in landscape — the one layout with a compact
+            // vertical size class — is short enough to spend the home
+            // indicator's strip on the key rail. Everywhere with room to
+            // spare the rail keeps the standard clearance and the pane's
+            // bezel simply paints through it. When the rail does take the
+            // strip, SwiftTermView's container becomes the sole owner of
+            // docked-keyboard clearance, exactly as in a classic window.
+            let railTakesBottomStrip = verticalSizeClass == .compact
+            let terminalHeight = geometry.size.height
+                + (railTakesBottomStrip ? safeArea.bottom : 0)
             // Each pane keeps its content clear of the bands its own frame
             // spans — a hidden rail hands the Island's band to the terminal,
             // and a compact deck spans both. iOS reports both landscape edges
@@ -87,9 +97,10 @@ struct SingleWindowShell: View {
                         leading: max(0, safeArea.leading - terminalOriginX),
                         bottom: 0,
                         trailing: safeArea.trailing
-                    )
+                    ),
+                    railOwnsBottomSafeArea: railTakesBottomStrip
                 )
-                    .frame(width: terminalWidth, height: geometry.size.height)
+                    .frame(width: terminalWidth, height: terminalHeight)
                     .offset(x: expanded
                         ? deckWidth
                         : (compactShowsTerminal ? 0 : fullWidth))
@@ -113,14 +124,15 @@ struct SingleWindowShell: View {
             // ran the terminal off the screen's trailing edge.
             .frame(
                 width: fullWidth,
-                height: geometry.size.height,
+                height: deckHeight,
                 alignment: .topLeading
             )
-            // Spend the side safe areas rather than letting SwiftUI reserve
-            // them: each pane fills its band with chassis and screen, and is
-            // handed the inset back so only content that must stay legible —
-            // tiles, chips, keys — keeps clear of the Island and the corners.
-            .ignoresSafeArea(.container, edges: .horizontal)
+            // Spend the safe areas rather than letting SwiftUI reserve them:
+            // each pane fills its band with chassis and screen, and is handed
+            // the inset back to spend on its own content — so what must stay
+            // legible (tiles, chips, text) keeps clear of the Island and the
+            // corners, while the deck's tiles scroll on through the bottom.
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
             .background(Theme.chassis.ignoresSafeArea())
             .animation(shellAnimation, value: compactShowsTerminal)
             .animation(shellAnimation, value: deckRailVisible)
@@ -163,7 +175,8 @@ struct SingleWindowShell: View {
     private func terminalStage(
         expanded: Bool,
         availableWidth: CGFloat,
-        contentSafeArea: EdgeInsets
+        contentSafeArea: EdgeInsets,
+        railOwnsBottomSafeArea: Bool
     ) -> some View {
         if terminalRoute.tabs.isEmpty {
             emptyTerminal
@@ -176,6 +189,7 @@ struct SingleWindowShell: View {
                         : "‹ DECK",
                     availableWidth: availableWidth,
                     contentSafeArea: contentSafeArea,
+                    railOwnsBottomSafeArea: railOwnsBottomSafeArea,
                     showDeck: { showDeck(expanded: expanded) },
                     openTerminalRoute: openTerminalRoute,
                     revealTab: revealTab,

--- a/Multiplex/Views/Shell/TerminalRouteOpener.swift
+++ b/Multiplex/Views/Shell/TerminalRouteOpener.swift
@@ -1,0 +1,39 @@
+/// The deck's only terminal-presentation seam. Classic Multiplex opens a new
+/// scene; the single-window shell adopts the same route as one or more tabs.
+/// Keeping the destination alongside the closure also lets the tile's
+/// duplicate-client context action use truthful copy.
+struct TerminalRouteOpener {
+    enum Destination {
+        case window
+        case shell
+    }
+
+    let destination: Destination
+    private let action: (TerminalWindowRoute) -> Void
+
+    init(
+        destination: Destination,
+        action: @escaping (TerminalWindowRoute) -> Void
+    ) {
+        self.destination = destination
+        self.action = action
+    }
+
+    func callAsFunction(_ route: TerminalWindowRoute) {
+        action(route)
+    }
+
+    var duplicateAttachTitle: String {
+        switch destination {
+        case .window: "Attach in New Window"
+        case .shell: "Attach as New Tab"
+        }
+    }
+
+    var openTabAccessibilityText: String {
+        switch destination {
+        case .window: "Shows its open window"
+        case .shell: "Shows its open tab"
+        }
+    }
+}

--- a/Multiplex/Views/Terminal/AgentHelperStrip.swift
+++ b/Multiplex/Views/Terminal/AgentHelperStrip.swift
@@ -37,6 +37,9 @@ struct AgentHelperStrip: View {
     /// Ornaments otherwise size from their contents and can outgrow a window
     /// after the user narrows it.
     var floatingMaximumWidth: CGFloat? = nil
+    /// Side safe areas the docked strip's pane spans. Its chassis fills them;
+    /// its chips keep clear, like the key rail directly below.
+    var contentSafeArea = EdgeInsets()
     let send: (AgentCommand) -> Void
     let saveCustomCommands: ([CustomAgentCommand]) -> Void
     let openPaywall: () -> Void
@@ -60,7 +63,8 @@ struct AgentHelperStrip: View {
                             .strokeBorder(Theme.bezelHi, lineWidth: 1))
             } else {
                 row
-                    .padding(.horizontal, 12)
+                    .padding(.leading, 12 + contentSafeArea.leading)
+                    .padding(.trailing, 12 + contentSafeArea.trailing)
                     .padding(.vertical, 7)
                     .frame(height: Self.dockedHeight)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Multiplex/Views/Terminal/AgentHelperStrip.swift
+++ b/Multiplex/Views/Terminal/AgentHelperStrip.swift
@@ -40,6 +40,9 @@ struct AgentHelperStrip: View {
     let send: (AgentCommand) -> Void
     let saveCustomCommands: ([CustomAgentCommand]) -> Void
     let openPaywall: () -> Void
+    /// Lets DEBUG layout hooks select the one helper strip whose terminal
+    /// owns app-wide focus without introducing another focus authority.
+    let isFocusOwner: () -> Bool
 
     @State private var showingCustomCommands = false
     @State private var customCommandEditorID = UUID()
@@ -78,6 +81,15 @@ struct AgentHelperStrip: View {
         // identity. Never let one agent's open drafts relabel or save into the
         // other agent's profile.
         .onChange(of: agent) { showingCustomCommands = false }
+        #if DEBUG
+        .onAppear { CustomCommandsDebugHook.install() }
+        .onReceive(NotificationCenter.default.publisher(
+            for: .multiplexDebugCustomCommands
+        )) { _ in
+            guard isFocusOwner() else { return }
+            openCustomCommandEditor()
+        }
+        #endif
     }
 
     private var row: some View {
@@ -169,10 +181,7 @@ struct AgentHelperStrip: View {
             }
             Divider()
             Button {
-                // A fresh identity makes CANCEL genuinely discard drafts
-                // when the same editor is opened again.
-                customCommandEditorID = UUID()
-                showingCustomCommands = true
+                openCustomCommandEditor()
             } label: {
                 Label("Custom Commands…", systemImage: "slider.horizontal.3")
             }
@@ -183,6 +192,13 @@ struct AgentHelperStrip: View {
         .buttonStyle(.plain)
         .chassisHover(2)
         .accessibilityLabel("More \(agent.displayName) commands")
+    }
+
+    private func openCustomCommandEditor() {
+        // A fresh identity makes CANCEL genuinely discard drafts when the
+        // same editor is opened again, including a DEBUG notification reopen.
+        customCommandEditorID = UUID()
+        showingCustomCommands = true
     }
 
     private var barCustomCommands: [CustomAgentCommand] {
@@ -402,6 +418,31 @@ private struct CustomAgentCommandPopoverPresenter: UIViewRepresentable {
 #if DEBUG
 extension Notification.Name {
     static let multiplexDebugAgentChip = Notification.Name("MultiplexDebugAgentChip")
+    static let multiplexDebugCustomCommands = Notification.Name(
+        "MultiplexDebugCustomCommands"
+    )
+}
+
+/// Opens the focused terminal's real Custom Commands editor for layout
+/// capture. AgentHelperStrip performs the final focus-owner check so a Darwin
+/// notification never presents panels from several terminal scenes.
+@MainActor
+enum CustomCommandsDebugHook {
+    private static var installed = false
+
+    static func install() {
+        guard !installed else { return }
+        installed = true
+        var token: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.customcommands", &token, .main
+        ) { _ in
+            NotificationCenter.default.post(
+                name: .multiplexDebugCustomCommands,
+                object: nil
+            )
+        }
+    }
 }
 
 /// Headless-verification hook: `xcrun simctl spawn <udid> notifyutil -p

--- a/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
+++ b/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
@@ -186,51 +186,104 @@ struct CustomAgentCommandPanel: View {
                     .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
             }
 
-            HStack(spacing: 8) {
-                ChassisSwitch(
-                    "SUBMIT",
-                    isOn: command.autoSubmit,
-                    accessibilityLabel: "Auto Submit"
-                )
-                ChassisSwitch(
-                    "BAR",
-                    isOn: command.showInBar,
-                    accessibilityLabel: "Show in Bar"
-                )
-                ChassisSwitch(
-                    "SHARED",
-                    isOn: command.shared,
-                    accessibilityLabel: "Shared between Claude Code and Codex"
-                )
-
-                Spacer(minLength: 8)
-
-                ChassisLabel(
-                    placementLabel,
-                    size: 8,
-                    color: command.wrappedValue.showInBar
-                        ? Theme.customCommand
-                        : Theme.signal3
-                )
-
-                rowButton(
-                    "arrow.up",
-                    label: "Move command up",
-                    disabled: index == 0
-                ) { moveCommand(id: id, offset: -1) }
-                rowButton(
-                    "arrow.down",
-                    label: "Move command down",
-                    disabled: index >= drafts.commands.count - 1
-                ) { moveCommand(id: id, offset: 1) }
-                rowButton("trash", label: "Delete command") {
-                    deleteCommand(id: id)
-                }
-            }
+            commandControls(
+                command,
+                id: id,
+                index: index,
+                placementLabel: placementLabel
+            )
             .padding(.leading, 28)
         }
         .padding(10)
         .background(Theme.chassis)
+    }
+
+    /// Preserve the existing one-line iPad anatomy when it fits. Phone-width
+    /// panels fall back to two measured lines: switches first, then placement
+    /// and row actions. Fixed intrinsic switch widths make ViewThatFits choose
+    /// the fallback instead of satisfying the proposal by truncating captions.
+    private func commandControls(
+        _ command: Binding<CustomAgentCommand>,
+        id: UUID,
+        index: Int,
+        placementLabel: String
+    ) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                commandSwitches(command)
+                Spacer(minLength: 8)
+                commandPlacementLabel(placementLabel, command: command)
+                commandRowActions(id: id, index: index)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                commandSwitches(command)
+                HStack(spacing: 8) {
+                    commandPlacementLabel(placementLabel, command: command)
+                    Spacer(minLength: 8)
+                    commandRowActions(id: id, index: index)
+                }
+            }
+        }
+    }
+
+    private func commandSwitches(
+        _ command: Binding<CustomAgentCommand>
+    ) -> some View {
+        HStack(spacing: 8) {
+            ChassisSwitch(
+                "SUBMIT",
+                isOn: command.autoSubmit,
+                accessibilityLabel: "Auto Submit"
+            )
+            .fixedSize(horizontal: true, vertical: false)
+            ChassisSwitch(
+                "BAR",
+                isOn: command.showInBar,
+                accessibilityLabel: "Show in Bar"
+            )
+            .fixedSize(horizontal: true, vertical: false)
+            ChassisSwitch(
+                "SHARED",
+                isOn: command.shared,
+                accessibilityLabel: "Shared between Claude Code and Codex"
+            )
+            .fixedSize(horizontal: true, vertical: false)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func commandPlacementLabel(
+        _ placementLabel: String,
+        command: Binding<CustomAgentCommand>
+    ) -> some View {
+        ChassisLabel(
+            placementLabel,
+            size: 8,
+            color: command.wrappedValue.showInBar
+                ? Theme.customCommand
+                : Theme.signal3
+        )
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func commandRowActions(id: UUID, index: Int) -> some View {
+        HStack(spacing: 8) {
+            rowButton(
+                "arrow.up",
+                label: "Move command up",
+                disabled: index == 0
+            ) { moveCommand(id: id, offset: -1) }
+            rowButton(
+                "arrow.down",
+                label: "Move command down",
+                disabled: index >= drafts.commands.count - 1
+            ) { moveCommand(id: id, offset: 1) }
+            rowButton("trash", label: "Delete command") {
+                deleteCommand(id: id)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     private func rowButton(

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -13,6 +13,10 @@ struct SwiftTermView: UIViewRepresentable {
     /// Space between terminal content and the iPad key rail for app chrome
     /// such as the agent helper strip. The rail itself remains bottommost.
     var bottomChromeHeight: CGFloat = 0
+    /// Side safe areas this pane spans. The pane's screen and the rail's
+    /// bezel paint through them; the grid and the keys keep clear, because a
+    /// landscape Dynamic Island sits mid-edge — squarely over text rows.
+    var contentSafeArea = EdgeInsets()
     /// Only the window's active tab claims keyboard focus when it appears.
     var isActive: Bool = true
 
@@ -103,6 +107,8 @@ struct SwiftTermView: UIViewRepresentable {
                 controller?.finishTmuxCopyMode()
             }
         )
+        keyBar.contentSafeArea = contentSafeArea
+        context.coordinator.keyBar = keyBar
         container.addSubview(view)
         container.addSubview(keyBar)
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -116,10 +122,21 @@ struct SwiftTermView: UIViewRepresentable {
             equalTo: keyBar.topAnchor,
             constant: -(Self.terminalInsets.bottom + bottomChromeHeight)
         )
+        // The container spans whatever side safe areas the shell handed it,
+        // and the pane's screen paints across them. The grid does not: it
+        // rides these constants back inside the readable region.
+        let terminalLeading = view.leadingAnchor.constraint(
+            equalTo: container.leadingAnchor,
+            constant: Self.terminalInsets.left + contentSafeArea.leading
+        )
+        let terminalTrailing = view.trailingAnchor.constraint(
+            equalTo: container.trailingAnchor,
+            constant: -(Self.terminalInsets.right + contentSafeArea.trailing)
+        )
         NSLayoutConstraint.activate([
             terminalTop,
-            view.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: Self.terminalInsets.left),
-            view.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -Self.terminalInsets.right),
+            terminalLeading,
+            terminalTrailing,
             terminalBottom,
             keyBar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             keyBar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
@@ -130,7 +147,9 @@ struct SwiftTermView: UIViewRepresentable {
             container: container,
             constraint: keyBarBottom,
             terminalTopConstraint: terminalTop,
-            terminalBottomConstraint: terminalBottom
+            terminalBottomConstraint: terminalBottom,
+            terminalLeadingConstraint: terminalLeading,
+            terminalTrailingConstraint: terminalTrailing
         )
         container.onLayout = { [weak coordinator = context.coordinator] in
             coordinator?.containerDidLayout()
@@ -161,6 +180,10 @@ struct SwiftTermView: UIViewRepresentable {
         #if !os(visionOS)
         context.coordinator.updateBottomChromeHeight(
             Self.terminalInsets.bottom + bottomChromeHeight
+        )
+        context.coordinator.updateContentSafeArea(
+            leading: contentSafeArea.leading,
+            trailing: contentSafeArea.trailing
         )
         if fontChanged {
             context.coordinator.terminalMetricsDidChange()
@@ -206,10 +229,13 @@ struct SwiftTermView: UIViewRepresentable {
         }
 
         #if !os(visionOS)
+        weak var keyBar: TerminalKeyBar?
         private weak var avoidingContainer: UIView?
         private var bottomConstraint: NSLayoutConstraint?
         private var terminalTopConstraint: NSLayoutConstraint?
         private var terminalBottomConstraint: NSLayoutConstraint?
+        private var terminalLeadingConstraint: NSLayoutConstraint?
+        private var terminalTrailingConstraint: NSLayoutConstraint?
         private var keyboardObservers: [NSObjectProtocol] = []
         private var keyboardPresentation: KeyboardAvoidance.Presentation = .hidden
         private var keyboardSettleWorkItems: [DispatchWorkItem] = []
@@ -238,12 +264,16 @@ struct SwiftTermView: UIViewRepresentable {
             container: UIView,
             constraint: NSLayoutConstraint,
             terminalTopConstraint: NSLayoutConstraint,
-            terminalBottomConstraint: NSLayoutConstraint
+            terminalBottomConstraint: NSLayoutConstraint,
+            terminalLeadingConstraint: NSLayoutConstraint,
+            terminalTrailingConstraint: NSLayoutConstraint
         ) {
             avoidingContainer = container
             bottomConstraint = constraint
             self.terminalTopConstraint = terminalTopConstraint
             self.terminalBottomConstraint = terminalBottomConstraint
+            self.terminalLeadingConstraint = terminalLeadingConstraint
+            self.terminalTrailingConstraint = terminalTrailingConstraint
             // didChangeFrame too: some presentations deliver their final
             // geometry (accessory attach, dock/float transitions) only in
             // the did- pass — reacting to will- alone under-insets and the
@@ -271,6 +301,26 @@ struct SwiftTermView: UIViewRepresentable {
                   constraint.constant != -height
             else { return }
             constraint.constant = -height
+            avoidingContainer?.layoutIfNeeded()
+        }
+
+        /// Rotating a phone moves the Island's band from one long edge to the
+        /// other, and hiding the deck rail hands the leading band to this
+        /// pane. Both change the grid's clearance without rebuilding it.
+        func updateContentSafeArea(leading: CGFloat, trailing: CGFloat) {
+            keyBar?.contentSafeArea = EdgeInsets(
+                top: 0, leading: leading, bottom: 0, trailing: trailing
+            )
+            guard let leadingConstraint = terminalLeadingConstraint,
+                  let trailingConstraint = terminalTrailingConstraint
+            else { return }
+            let leadingConstant = SwiftTermView.terminalInsets.left + leading
+            let trailingConstant = -(SwiftTermView.terminalInsets.right + trailing)
+            guard leadingConstraint.constant != leadingConstant
+                    || trailingConstraint.constant != trailingConstant
+            else { return }
+            leadingConstraint.constant = leadingConstant
+            trailingConstraint.constant = trailingConstant
             avoidingContainer?.layoutIfNeeded()
         }
 

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -17,6 +17,11 @@ struct SwiftTermView: UIViewRepresentable {
     /// bezel paint through them; the grid and the keys keep clear, because a
     /// landscape Dynamic Island sits mid-edge — squarely over text rows.
     var contentSafeArea = EdgeInsets()
+    /// Whether this pane runs to the window's bottom edge, which makes the
+    /// rail rest there instead of on the safe-area boundary. Nothing else
+    /// derives that resting edge from the container's live frame: the helper
+    /// strip's clearance is measured from it, and would feed back.
+    var railOwnsBottomSafeArea = false
     /// Only the window's active tab claims keyboard focus when it appears.
     var isActive: Bool = true
 
@@ -185,6 +190,7 @@ struct SwiftTermView: UIViewRepresentable {
             leading: contentSafeArea.leading,
             trailing: contentSafeArea.trailing
         )
+        context.coordinator.railOwnsBottomSafeArea = railOwnsBottomSafeArea
         if fontChanged {
             context.coordinator.terminalMetricsDidChange()
         }
@@ -230,6 +236,7 @@ struct SwiftTermView: UIViewRepresentable {
 
         #if !os(visionOS)
         weak var keyBar: TerminalKeyBar?
+        var railOwnsBottomSafeArea = false
         private weak var avoidingContainer: UIView?
         private var bottomConstraint: NSLayoutConstraint?
         private var terminalTopConstraint: NSLayoutConstraint?
@@ -467,11 +474,14 @@ struct SwiftTermView: UIViewRepresentable {
             let screenSpace = window.screen.coordinateSpace
             let containerOnScreen = container.convert(container.bounds, to: screenSpace)
             let windowOnScreen = window.convert(window.bounds, to: screenSpace)
-            // The helper's interactive content rests on the window's bottom
-            // safe-area edge. Keep that stable reference even though its
-            // passive background paints through the protected rounded corner;
-            // the keyboard cannot move it, so this value cannot feed back.
-            let restingBottom = windowOnScreen.maxY - window.safeAreaInsets.bottom
+            // The helper's interactive content rests directly on the rail,
+            // which rests on the window's bottom safe-area edge — or on the
+            // window's edge itself where the shell hands its pane the home
+            // indicator's strip. Either way the reference comes from the
+            // window and a static fact about this pane, never from the
+            // container's live frame: the strip's own padding would feed back.
+            let restingBottom = windowOnScreen.maxY
+                - (railOwnsBottomSafeArea ? 0 : window.safeAreaInsets.bottom)
             var overlap: CGFloat = 0
             var obstruction: CGFloat = 0
             if let endFrame = lastKeyboardFrame {

--- a/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
+++ b/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
@@ -71,6 +71,42 @@ enum TerminalFocusArbiter {
         }
     }
 
+    /// Relinquish focus when an in-scene terminal stage navigates back to
+    /// the deck. Only the current owner may release the app-wide input
+    /// session; hidden/inactive tabs cannot disturb another terminal.
+    static func release(_ view: TerminalView) {
+        guard current === view else { return }
+        #if DEBUG
+        keyboardLogger.debug("kbd-focus-release")
+        #endif
+        _ = view.resignFirstResponder()
+        current = nil
+        keyboardVisible = false
+    }
+
+    /// Reassert a scene's prior focus only when its hosting surface is still
+    /// visible. A compact single-window shell keeps TerminalView mounted behind
+    /// its deck; UIKit can nevertheless restore that hidden responder while
+    /// foregrounding. In the disallowed case, resign even if UIKit restored
+    /// the responder after the arbiter owner had already been cleared.
+    static func restore(_ view: TerminalView, allowed: Bool) {
+        guard allowed else {
+            #if DEBUG
+            keyboardLogger.debug("kbd-focus-restore-refused hiddenStage=true")
+            #endif
+            _ = view.resignFirstResponder()
+            if current === view {
+                current = nil
+                keyboardVisible = false
+            } else if current == nil {
+                keyboardVisible = false
+            }
+            return
+        }
+        guard current === view || current == nil else { return }
+        claim(view)
+    }
+
     /// Explicit user request for the keyboard (tap or keyboard button).
     ///
     /// If the terminal already has focus but no input UI is on screen —

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -270,9 +270,10 @@ private enum TerminalKey {
 }
 
 /// The rail: modifiers left, shell symbols center, arrows + dismiss right.
-/// Fixed-size keys so ViewThatFits can actually measure — when the bar is
-/// narrow (a small Stage Manager window), keep the
-/// path essentials (`~` and `/`) while dropping the less-used symbols first.
+/// Fixed-size keys let ViewThatFits measure every tier honestly. The original
+/// iPad ladder stays first; phone tiers compact the key metric only after page
+/// keys and symbols are gone. Regular phones retain TMUX; the final 375-point
+/// tier drops it while every terminal lifeline key remains available.
 private struct KeyBarRow: View {
     var model: TerminalKeyBar.Model
     var press: (TerminalKey) -> Void
@@ -280,11 +281,28 @@ private struct KeyBarRow: View {
     var body: some View {
         ViewThatFits(in: .horizontal) {
             row(symbols: ["~", "|", "/", "-"], withPageKeys: true)
+                .padding(.horizontal, 8)
             row(symbols: ["~", "/"], withPageKeys: true)
+                .padding(.horizontal, 8)
             row(symbols: ["~", "/"], withPageKeys: false)
+                .padding(.horizontal, 8)
             row(symbols: [], withPageKeys: false)
+                .padding(.horizontal, 8)
+            row(
+                symbols: [],
+                withPageKeys: false,
+                showsTmux: true,
+                metric: .compactWithTmux
+            )
+            .padding(.horizontal, 1)
+            row(
+                symbols: [],
+                withPageKeys: false,
+                showsTmux: false,
+                metric: .compact
+            )
+            .padding(.horizontal, 8)
         }
-        .padding(.horizontal, 8)
         .padding(.vertical, 7)
         .frame(maxWidth: .infinity)
         .background(Theme.bezel)
@@ -293,58 +311,113 @@ private struct KeyBarRow: View {
         }
     }
 
-    private func row(symbols: [String], withPageKeys: Bool) -> some View {
-        HStack(spacing: 6) {
-            capsKey("ESC", .esc, "Escape")
-            capsKey("CTRL", .ctrl, "Control", latched: model.ctrlLatched)
-            capsKey("TAB", .tab, "Tab")
-            Spacer(minLength: 12)
+    private func row(
+        symbols: [String],
+        withPageKeys: Bool,
+        showsTmux: Bool = true,
+        metric: KeyMetric = .regular
+    ) -> some View {
+        HStack(spacing: metric.spacing) {
+            capsKey("ESC", .esc, "Escape", metric: metric)
+            capsKey(
+                "CTRL",
+                .ctrl,
+                "Control",
+                latched: model.ctrlLatched,
+                metric: metric
+            )
+            capsKey("TAB", .tab, "Tab", metric: metric)
+            Spacer(minLength: metric.groupGap)
             if !symbols.isEmpty {
                 ForEach(symbols, id: \.self) { symbol in
-                    Key(action: { press(.text(symbol)) }, accessibilityText: symbol) {
+                    Key(
+                        action: { press(.text(symbol)) },
+                        width: metric.keyWidth,
+                        accessibilityText: symbol
+                    ) {
                         Text(symbol).font(.mono(15))
                     }
                 }
-                Spacer(minLength: 12)
+                Spacer(minLength: metric.groupGap)
             }
             if withPageKeys {
                 // Page keys scroll pagers and CLI-agent transcripts
                 // (Claude Code pages with PgUp/PgDn); they autorepeat
                 // like the arrows.
-                arrowKey("arrow.up.to.line", .pageUp, "Page up")
-                arrowKey("arrow.down.to.line", .pageDown, "Page down")
+                arrowKey("arrow.up.to.line", .pageUp, "Page up", metric: metric)
+                arrowKey("arrow.down.to.line", .pageDown, "Page down", metric: metric)
             }
-            arrowKey("arrow.left", .left, "Arrow left")
-            arrowKey("arrow.down", .down, "Arrow down")
-            arrowKey("arrow.up", .up, "Arrow up")
-            arrowKey("arrow.right", .right, "Arrow right")
-            Key(action: { press(.dismiss) }, accessibilityText: "Hide keyboard") {
+            arrowKey("arrow.left", .left, "Arrow left", metric: metric)
+            arrowKey("arrow.down", .down, "Arrow down", metric: metric)
+            arrowKey("arrow.up", .up, "Arrow up", metric: metric)
+            arrowKey("arrow.right", .right, "Arrow right", metric: metric)
+            Key(
+                action: { press(.dismiss) },
+                width: metric.keyWidth,
+                accessibilityText: "Hide keyboard"
+            ) {
                 Image(systemName: "keyboard.chevron.compact.down")
                     .font(.system(size: 13, weight: .semibold))
             }
-            // Keep the tmux dropdown at the rail's trailing edge, directly
-            // right of the keyboard control at every width tier.
-            Key(
-                action: { press(.showTmuxShortcuts) },
-                accessibilityText: "Show tmux shortcuts"
-            ) {
-                Text("TMUX").font(.mono(9, weight: .semibold)).kerning(0.7)
+            if showsTmux {
+                // Keep the tmux dropdown at the rail's trailing edge until
+                // the essentials-only phone tier takes over.
+                Key(
+                    action: { press(.showTmuxShortcuts) },
+                    width: metric.keyWidth,
+                    accessibilityText: "Show tmux shortcuts"
+                ) {
+                    Text("TMUX").font(.mono(9, weight: .semibold)).kerning(0.7)
+                }
             }
         }
     }
 
     private func capsKey(
-        _ label: String, _ key: TerminalKey, _ accessibility: String, latched: Bool = false
+        _ label: String,
+        _ key: TerminalKey,
+        _ accessibility: String,
+        latched: Bool = false,
+        metric: KeyMetric = .regular
     ) -> some View {
-        Key(action: { press(key) }, latched: latched, accessibilityText: accessibility) {
+        Key(
+            action: { press(key) },
+            width: metric.keyWidth,
+            latched: latched,
+            accessibilityText: accessibility
+        ) {
             Text(label).font(.mono(11, weight: .semibold)).kerning(1.1)
         }
     }
 
-    private func arrowKey(_ icon: String, _ key: TerminalKey, _ accessibility: String) -> some View {
-        Key(action: { press(key) }, repeats: true, accessibilityText: accessibility) {
+    private func arrowKey(
+        _ icon: String,
+        _ key: TerminalKey,
+        _ accessibility: String,
+        metric: KeyMetric = .regular
+    ) -> some View {
+        Key(
+            action: { press(key) },
+            width: metric.keyWidth,
+            repeats: true,
+            accessibilityText: accessibility
+        ) {
             Image(systemName: icon).font(.system(size: 12, weight: .semibold))
         }
+    }
+
+    private struct KeyMetric {
+        let keyWidth: CGFloat
+        let spacing: CGFloat
+        let groupGap: CGFloat
+
+        static let regular = KeyMetric(keyWidth: 46, spacing: 6, groupGap: 12)
+        static let compactWithTmux = KeyMetric(
+            keyWidth: 40,
+            spacing: 3,
+            groupGap: 1
+        )
+        static let compact = KeyMetric(keyWidth: 40, spacing: 4, groupGap: 4)
     }
 }
 
@@ -352,6 +425,7 @@ private struct KeyBarRow: View {
 /// inverts the face — prominence, not color, marks the held modifier.
 private struct Key<Label: View>: View {
     var action: () -> Void
+    var width: CGFloat = 46
     var repeats = false
     var latched = false
     var accessibilityText: String
@@ -360,7 +434,7 @@ private struct Key<Label: View>: View {
     var body: some View {
         Button(action: action) {
             label()
-                .frame(width: 46, height: 34)
+                .frame(width: width, height: 34)
                 .contentShape(Rectangle())
         }
         .buttonStyle(KeyFace(latched: latched))

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -22,9 +22,19 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     @Observable @MainActor
     final class Model {
         var ctrlLatched = false
+        /// Side safe areas the pane spans. The rail's bezel fills them; the
+        /// keys stay inside, clear of the Dynamic Island and the corners.
+        var contentSafeArea = EdgeInsets()
     }
 
     static let barHeight: CGFloat = 48
+
+    /// Set by `SwiftTermView` whenever the shell's pane spans a side safe
+    /// area — the keys inset, the bezel does not.
+    var contentSafeArea: EdgeInsets {
+        get { model.contentSafeArea }
+        set { model.contentSafeArea = newValue }
+    }
 
     private weak var terminal: TerminalView?
     private let performTmuxShortcut: (TmuxShortcut) -> Void
@@ -304,6 +314,11 @@ private struct KeyBarRow: View {
             .padding(.horizontal, 8)
         }
         .padding(.vertical, 7)
+        // Inside the ViewThatFits' proposal, so a pane spanning the Island's
+        // band still measures its tiers against the width the keys can use —
+        // and outside the background, which keeps running to the edge.
+        .padding(.leading, model.contentSafeArea.leading)
+        .padding(.trailing, model.contentSafeArea.trailing)
         .frame(maxWidth: .infinity)
         .background(Theme.bezel)
         .overlay(alignment: .top) {

--- a/Multiplex/Views/Terminal/TerminalTabStrip.swift
+++ b/Multiplex/Views/Terminal/TerminalTabStrip.swift
@@ -19,6 +19,7 @@ struct TerminalTabStrip: View {
     let activate: (UUID) -> Void
     let split: (UUID) -> Void
     let close: (UUID) -> Void
+    var allowsSplit = true
 
     var body: some View {
         HStack(spacing: 4) {
@@ -56,7 +57,7 @@ struct TerminalTabStrip: View {
         .buttonStyle(.plain)
         .chassisHover(3)
         .contextMenu {
-            if items.count > 1 {
+            if items.count > 1, allowsSplit {
                 Button {
                     split(item.id)
                 } label: {

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -22,6 +22,9 @@ struct TerminalWindowRoot: View {
         /// the physical edge; the grid, the UMD chips, the tabs, and the key
         /// rail all keep their content inside these.
         var contentSafeArea = EdgeInsets()
+        /// The shell's pane runs to the window's bottom edge, so the rail
+        /// rests there rather than on the safe-area boundary.
+        var railOwnsBottomSafeArea = false
         var showDeck: () -> Void
         var openTerminalRoute: (TerminalWindowRoute) -> Void
         var revealTab: (UUID) -> Void
@@ -90,6 +93,9 @@ struct TerminalWindowRoot: View {
     /// classic terminal scene is laid out inside them already.
     private var contentSafeArea: EdgeInsets {
         shell?.contentSafeArea ?? EdgeInsets()
+    }
+    private var railOwnsBottomSafeArea: Bool {
+        shell?.railOwnsBottomSafeArea ?? false
     }
     private var showsAgentHelper: Bool {
         shownAgent != nil && activeController?.status == .live
@@ -573,6 +579,7 @@ struct TerminalWindowRoot: View {
                     fontSize: fontSize,
                     bottomChromeHeight: terminalBottomChromeHeight,
                     contentSafeArea: contentSafeArea,
+                    railOwnsBottomSafeArea: railOwnsBottomSafeArea,
                     isActive: isActive,
                     focusAllowed: terminalFocusAllowed,
                     close: { close(tab.id) }
@@ -925,6 +932,7 @@ private struct TerminalPane: View {
     let fontSize: CGFloat
     let bottomChromeHeight: CGFloat
     var contentSafeArea = EdgeInsets()
+    var railOwnsBottomSafeArea = false
     let isActive: Bool
     let focusAllowed: Bool
     let close: () -> Void
@@ -954,6 +962,7 @@ private struct TerminalPane: View {
                     theme: themes.selected,
                     bottomChromeHeight: bottomChromeHeight,
                     contentSafeArea: contentSafeArea,
+                    railOwnsBottomSafeArea: railOwnsBottomSafeArea,
                     isActive: isActive && focusAllowed
                 )
                 statusOverlay(for: controller)

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -17,6 +17,11 @@ struct TerminalWindowRoot: View {
     struct ShellConfiguration {
         var deckControlLabel: String
         var availableWidth: CGFloat
+        /// Safe-area insets the shell hands to this pane rather than
+        /// reserving them. The pane's screen and every bar's bezel paint to
+        /// the physical edge; the grid, the UMD chips, the tabs, and the key
+        /// rail all keep their content inside these.
+        var contentSafeArea = EdgeInsets()
         var showDeck: () -> Void
         var openTerminalRoute: (TerminalWindowRoute) -> Void
         var revealTab: (UUID) -> Void
@@ -80,6 +85,11 @@ struct TerminalWindowRoot: View {
     }
     private var terminalFocusAllowed: Bool {
         shell?.terminalFocusAllowed ?? true
+    }
+    /// Only the in-scene shell spends the side safe areas on its panes; a
+    /// classic terminal scene is laid out inside them already.
+    private var contentSafeArea: EdgeInsets {
+        shell?.contentSafeArea ?? EdgeInsets()
     }
     private var showsAgentHelper: Bool {
         shownAgent != nil && activeController?.status == .live
@@ -487,12 +497,14 @@ struct TerminalWindowRoot: View {
                     ? { confirmingCloseActiveSession = true } : nil,
                 style: .shell,
                 deckControlLabel: configuration.deckControlLabel,
-                availableWidth: configuration.availableWidth
+                availableWidth: configuration.availableWidth,
+                contentSafeArea: configuration.contentSafeArea
             )
             if route.tabs.count > 1 {
                 ScrollView(.horizontal, showsIndicators: false) {
                     tabStrip
-                        .padding(.horizontal, 10)
+                        .padding(.leading, 10 + configuration.contentSafeArea.leading)
+                        .padding(.trailing, 10 + configuration.contentSafeArea.trailing)
                         .padding(.vertical, 6)
                 }
                 .background(Theme.chassis)
@@ -560,6 +572,7 @@ struct TerminalWindowRoot: View {
                     hostExists: store.host(id: tab.hostID) != nil,
                     fontSize: fontSize,
                     bottomChromeHeight: terminalBottomChromeHeight,
+                    contentSafeArea: contentSafeArea,
                     isActive: isActive,
                     focusAllowed: terminalFocusAllowed,
                     close: { close(tab.id) }
@@ -595,6 +608,7 @@ struct TerminalWindowRoot: View {
                 customCommands: customAgentCommands.commands(for: agent),
                 floating: floating,
                 floatingMaximumWidth: floatingMaximumWidth,
+                contentSafeArea: floating ? EdgeInsets() : contentSafeArea,
                 send: { send($0, via: controller) },
                 saveCustomCommands: { customAgentCommands.replace($0, for: agent) },
                 openPaywall: { showingPaywall = true },
@@ -910,6 +924,7 @@ private struct TerminalPane: View {
     let hostExists: Bool
     let fontSize: CGFloat
     let bottomChromeHeight: CGFloat
+    var contentSafeArea = EdgeInsets()
     let isActive: Bool
     let focusAllowed: Bool
     let close: () -> Void
@@ -938,6 +953,7 @@ private struct TerminalPane: View {
                     fontSize: fontSize,
                     theme: themes.selected,
                     bottomChromeHeight: bottomChromeHeight,
+                    contentSafeArea: contentSafeArea,
                     isActive: isActive && focusAllowed
                 )
                 statusOverlay(for: controller)

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -14,6 +14,16 @@ import notify
 /// Chrome is the Tally identity: a chassis-framed screen with multiviewer
 /// source-label tabs on top and the under-monitor display (UMD) below.
 struct TerminalWindowRoot: View {
+    struct ShellConfiguration {
+        var deckControlLabel: String
+        var availableWidth: CGFloat
+        var showDeck: () -> Void
+        var openTerminalRoute: (TerminalWindowRoute) -> Void
+        var revealTab: (UUID) -> Void
+        var tabsEmptied: () -> Void
+        var terminalFocusAllowed: Bool
+    }
+
     @Environment(HostStore.self) private var store
     @Environment(ConnectionHub.self) private var hub
     @Environment(CustomAgentCommandStore.self) private var customAgentCommands
@@ -24,8 +34,24 @@ struct TerminalWindowRoot: View {
     @Environment(\.scenePhase) private var scenePhase
 
     @Binding var route: TerminalWindowRoute
+    var shell: ShellConfiguration?
 
-    @State private var fontSize: CGFloat = 14
+    init(
+        route: Binding<TerminalWindowRoute>,
+        shell: ShellConfiguration? = nil
+    ) {
+        _route = route
+        self.shell = shell
+        #if os(visionOS)
+        _fontSize = State(initialValue: 14)
+        #else
+        _fontSize = State(
+            initialValue: UIDevice.current.userInterfaceIdiom == .phone ? 12 : 14
+        )
+        #endif
+    }
+
+    @State private var fontSize: CGFloat
     /// Agent shown by the helper strip. Trails `detectedAgent` with a short
     /// grace on loss (two probe ticks) so a transient probe miss doesn't
     /// flap the strip — but never across a tab or pane switch.
@@ -52,6 +78,9 @@ struct TerminalWindowRoot: View {
     private var activeController: TerminalSessionController? {
         activeTab.flatMap { workspace.controller(for: $0.id) }
     }
+    private var terminalFocusAllowed: Bool {
+        shell?.terminalFocusAllowed ?? true
+    }
     private var showsAgentHelper: Bool {
         shownAgent != nil && activeController?.status == .live
     }
@@ -63,7 +92,7 @@ struct TerminalWindowRoot: View {
         #endif
     }
     private var mergeSources: [TerminalWorkspace.WindowEntry] {
-        workspace.mergeSources(for: route.id)
+        shell == nil ? workspace.mergeSources(for: route.id) : []
     }
     /// Whether the detach control can offer CLOSE SESSION for the active
     /// tab: there must be a tmux session to kill and a host record to kill
@@ -95,14 +124,26 @@ struct TerminalWindowRoot: View {
                 await DeckScene.autoAttachIfRequested(
                     store: store,
                     workspace: workspace,
-                    openTerminalWindow: { openWindow(id: "terminal", value: $0) }
+                    openTerminalWindow: { route in
+                        if let shell {
+                            shell.openTerminalRoute(route)
+                        } else {
+                            openWindow(id: "terminal", value: route)
+                        }
+                    }
                 )
             }
             #endif
             .onChange(of: route.tabs) { syncTabs() }
+            .onChange(of: terminalFocusAllowed) { _, allowed in
+                guard !allowed else { return }
+                activeController?.restoreFocusIfOwner(allowed: false)
+            }
             // Keyboard focus follows the visible tab…
             .onChange(of: route.activeTabID) {
-                activeController?.focusTerminal()
+                if terminalFocusAllowed {
+                    activeController?.focusTerminal()
+                }
                 // No detection grace across tabs — chips must describe the
                 // pane on screen, immediately.
                 hideAgentTask?.cancel()
@@ -127,7 +168,9 @@ struct TerminalWindowRoot: View {
             .onChange(of: scenePhase) { _, phase in
                 if phase == .active {
                     entitlements.refreshSlashChipMeter()
-                    activeController?.restoreFocusIfOwner()
+                    activeController?.restoreFocusIfOwner(
+                        allowed: terminalFocusAllowed
+                    )
                     for tab in route.tabs {
                         workspace.controller(for: tab.id)?.transportForegrounded()
                     }
@@ -333,8 +376,17 @@ struct TerminalWindowRoot: View {
 
     // MARK: Layout
 
-    #if os(visionOS)
+    @ViewBuilder
     private var platformBody: some View {
+        if let shell {
+            shellBody(shell)
+        } else {
+            classicPlatformBody
+        }
+    }
+
+    #if os(visionOS)
+    private var classicPlatformBody: some View {
         GeometryReader { geometry in
             paneStack
                 .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
@@ -396,7 +448,7 @@ struct TerminalWindowRoot: View {
         }
     }
     #else
-    private var platformBody: some View {
+    private var classicPlatformBody: some View {
         NavigationStack {
             VStack(spacing: 0) {
                 if route.tabs.count > 1 {
@@ -408,42 +460,92 @@ struct TerminalWindowRoot: View {
                     .background(Theme.chassis)
                     Rectangle().fill(Theme.bezelHi).frame(height: 1)
                 }
-                paneStack
-                    .overlay(alignment: .bottom) {
-                        // Reserve this height inside SwiftTermView, then paint
-                        // the helper into that gap immediately above the
-                        // bottommost key rail. Keeping the rail inside the
-                        // UIKit container avoids both TextInputUI accessory
-                        // hosting and a controller-observing SwiftUI cycle.
-                        helperStrip(floating: false)
-                            .padding(
-                                .bottom,
-                                (activeController?.keyboardObstruction ?? 0)
-                                    + TerminalKeyBar.barHeight
-                            )
-                    }
-                    // A real docked keyboard makes SwiftUI apply the window's
-                    // bottom safe area twice: once to this surface and once
-                    // to the helper's published clearance. Extend through
-                    // that region only while docked so the tmux row, helper,
-                    // and UIKit rail share one baseline. Hidden/floating
-                    // modes keep controls inside the rounded-corner boundary.
-                    .ignoresSafeArea(
-                        .container,
-                        edges: (activeController?.keyboardObstruction ?? 0) > 0
-                            ? .bottom : []
-                    )
-                    // SwiftUI's automatic keyboard avoidance must not touch
-                    // the terminal: floating keyboards reserve no space. The
-                    // terminal container is the single owner of docked
-                    // clearance and publishes the helper-strip obstruction.
-                    .ignoresSafeArea(.keyboard)
+                iOSPaneSurface
             }
             .navigationTitle(windowTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(Theme.chassis, for: .navigationBar)
             .toolbar { toolbarContent }
         }
+    }
+    #endif
+
+    private func shellBody(_ configuration: ShellConfiguration) -> some View {
+        VStack(spacing: 0) {
+            UMDBar(
+                controller: activeController,
+                title: umdTitle,
+                mergeSources: [],
+                showDeck: configuration.showDeck,
+                summonKeyboard: { activeController?.summonKeyboard() },
+                fontDown: { fontSize = max(9, fontSize - 1) },
+                fontUp: { fontSize = min(32, fontSize + 1) },
+                newSession: { openNewTab(launching: $0) },
+                merge: { _ in },
+                detach: { detachActiveTab() },
+                closeSession: activeTabHasSession
+                    ? { confirmingCloseActiveSession = true } : nil,
+                style: .shell,
+                deckControlLabel: configuration.deckControlLabel,
+                availableWidth: configuration.availableWidth
+            )
+            if route.tabs.count > 1 {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    tabStrip
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                }
+                .background(Theme.chassis)
+                Rectangle().fill(Theme.bezelHi).frame(height: 1)
+            }
+            #if os(visionOS)
+            paneStack
+                .overlay(alignment: .bottom) {
+                    VStack(spacing: 8) {
+                        helperStrip(
+                            floating: true,
+                            floatingMaximumWidth: max(
+                                1,
+                                configuration.availableWidth - 24
+                            )
+                        )
+                        TerminalKeyCluster(controller: activeController)
+                    }
+                    .padding(.bottom, 10)
+                }
+            #else
+            iOSPaneSurface
+            #endif
+        }
+        .background(Theme.chassis)
+    }
+
+    #if !os(visionOS)
+    private var iOSPaneSurface: some View {
+        paneStack
+            .overlay(alignment: .bottom) {
+                // Reserve this height inside SwiftTermView, then paint the
+                // helper into that gap immediately above the bottommost key
+                // rail. Keeping the rail inside the UIKit container avoids
+                // both TextInputUI accessory hosting and a controller cycle.
+                helperStrip(floating: false)
+                    .padding(
+                        .bottom,
+                        (activeController?.keyboardObstruction ?? 0)
+                            + TerminalKeyBar.barHeight
+                    )
+            }
+            // A real docked keyboard makes SwiftUI apply the window's bottom
+            // safe area twice. Extend through it only while docked so the
+            // tmux row, helper, and UIKit rail share one baseline.
+            .ignoresSafeArea(
+                .container,
+                edges: (activeController?.keyboardObstruction ?? 0) > 0
+                    ? .bottom : []
+            )
+            // SwiftUI's automatic avoidance must not touch the terminal:
+            // the container is the sole owner of docked clearance.
+            .ignoresSafeArea(.keyboard)
     }
     #endif
 
@@ -459,6 +561,7 @@ struct TerminalWindowRoot: View {
                     fontSize: fontSize,
                     bottomChromeHeight: terminalBottomChromeHeight,
                     isActive: isActive,
+                    focusAllowed: terminalFocusAllowed,
                     close: { close(tab.id) }
                 )
                 .opacity(isActive ? 1 : 0)
@@ -494,7 +597,11 @@ struct TerminalWindowRoot: View {
                 floatingMaximumWidth: floatingMaximumWidth,
                 send: { send($0, via: controller) },
                 saveCustomCommands: { customAgentCommands.replace($0, for: agent) },
-                openPaywall: { showingPaywall = true }
+                openPaywall: { showingPaywall = true },
+                isFocusOwner: {
+                    guard let terminalView = controller.terminalView else { return false }
+                    return TerminalFocusArbiter.current === terminalView
+                }
             )
         }
     }
@@ -517,7 +624,8 @@ struct TerminalWindowRoot: View {
             items: tabItems,
             activate: { route.activate($0) },
             split: { split($0) },
-            close: { close($0) }
+            close: { close($0) },
+            allowsSplit: shell == nil
         )
     }
 
@@ -679,6 +787,10 @@ struct TerminalWindowRoot: View {
     /// iPad uses the deck's stable data value, which raises the matching
     /// window and creates it only when none exists.
     private func showDeck() {
+        if let shell {
+            shell.showDeck()
+            return
+        }
         #if os(visionOS)
         if let session = DeckScene.session {
             UIApplication.shared.activateSceneSession(
@@ -701,10 +813,14 @@ struct TerminalWindowRoot: View {
     private func syncTabs() {
         if route.tabs.isEmpty {
             workspace.unregisterWindow(id: route.id)
-            // Plain DismissAction, not dismissWindow(id:value:) — the scene's
-            // committed value can lag the just-emptied binding, and a value
-            // mismatch would silently leave a ghost window behind.
-            dismiss()
+            if let shell {
+                shell.tabsEmptied()
+            } else {
+                // Plain DismissAction, not dismissWindow(id:value:) — the
+                // scene's committed value can lag the just-emptied binding,
+                // and a mismatch would silently leave a ghost window behind.
+                dismiss()
+            }
             return
         }
         for tab in route.tabs {
@@ -714,9 +830,13 @@ struct TerminalWindowRoot: View {
             id: route.id,
             tabs: route.tabs,
             label: windowLabel,
-            reveal: { [route = $route, workspace] tabID in
+            reveal: { [route = $route, workspace, shell] tabID in
                 route.wrappedValue.activate(tabID)
-                workspace.controller(for: tabID)?.revealWindow()
+                if let shell {
+                    shell.revealTab(tabID)
+                } else {
+                    workspace.controller(for: tabID)?.revealWindow()
+                }
             },
             surrender: { [route = $route] in
                 let tabs = route.wrappedValue.tabs
@@ -742,8 +862,14 @@ struct TerminalWindowRoot: View {
     }
 
     private func close(_ tabID: UUID) {
+        if shell != nil {
+            workspace.controller(for: tabID)?.releaseFocus()
+        }
         workspace.closeTab(tabID)
         route.removeTab(id: tabID)
+        if shell != nil, route.tabs.isEmpty {
+            syncTabs()
+        }
     }
 
     /// Kill the tmux session on the host over its control connection
@@ -768,6 +894,7 @@ struct TerminalWindowRoot: View {
     }
 
     private func split(_ tabID: UUID) {
+        guard shell == nil else { return }
         guard route.tabs.count > 1, let tab = route.removeTab(id: tabID) else { return }
         openWindow(id: "terminal", value: TerminalWindowRoute(tab: tab))
     }
@@ -784,6 +911,7 @@ private struct TerminalPane: View {
     let fontSize: CGFloat
     let bottomChromeHeight: CGFloat
     let isActive: Bool
+    let focusAllowed: Bool
     let close: () -> Void
 
     @State private var dropTargeted = false
@@ -810,7 +938,7 @@ private struct TerminalPane: View {
                     fontSize: fontSize,
                     theme: themes.selected,
                     bottomChromeHeight: bottomChromeHeight,
-                    isActive: isActive
+                    isActive: isActive && focusAllowed
                 )
                 statusOverlay(for: controller)
             } else if !hostExists {
@@ -820,7 +948,9 @@ private struct TerminalPane: View {
         // A shell that (re)connects claims focus outright — if its tab is
         // the one on screen.
         .onChange(of: controller?.status) { _, status in
-            if status == .live, isActive { controller?.focusTerminal() }
+            if status == .live, isActive, focusAllowed {
+                controller?.focusTerminal()
+            }
         }
         // Dropped files upload into the pane's cwd, then their paths get
         // typed into the session (never submitted). tmux tabs only — a

--- a/Multiplex/Views/Terminal/UMDBar.swift
+++ b/Multiplex/Views/Terminal/UMDBar.swift
@@ -28,6 +28,9 @@ struct UMDBar: View {
     var style: Style = .regular
     var deckControlLabel = "DECK"
     var availableWidth: CGFloat?
+    /// Shell panes may span a landscape screen's side safe areas. The bar's
+    /// bezel fills them; its chips keep clear of the rounded corners.
+    var contentSafeArea = EdgeInsets()
 
     @State private var showingTmuxShortcuts = false
 
@@ -115,7 +118,8 @@ struct UMDBar: View {
             shellRow(showsDirectActions: true)
             shellRow(showsDirectActions: false)
         }
-        .padding(.horizontal, 10)
+        .padding(.leading, 10 + contentSafeArea.leading)
+        .padding(.trailing, 10 + contentSafeArea.trailing)
         .padding(.vertical, 8)
         .background(Theme.bezel)
         .overlay(alignment: .bottom) {

--- a/Multiplex/Views/Terminal/UMDBar.swift
+++ b/Multiplex/Views/Terminal/UMDBar.swift
@@ -4,6 +4,11 @@ import SwiftUI
 /// label, captioned status lamp, and the window's controls as chassis
 /// chips. Deliberately opaque — the UMD is hardware, not glass.
 struct UMDBar: View {
+    enum Style {
+        case regular
+        case shell
+    }
+
     var controller: TerminalSessionController?
     var title: String
     var mergeSources: [TerminalWorkspace.WindowEntry]
@@ -20,10 +25,23 @@ struct UMDBar: View {
     /// dropdown's destructive alternative. nil when there's no session to
     /// kill (plain shell tab, or the host record is gone).
     var closeSession: (() -> Void)?
+    var style: Style = .regular
+    var deckControlLabel = "DECK"
+    var availableWidth: CGFloat?
 
     @State private var showingTmuxShortcuts = false
 
+    @ViewBuilder
     var body: some View {
+        switch style {
+        case .regular:
+            regularBar
+        case .shell:
+            shellBar
+        }
+    }
+
+    private var regularBar: some View {
         HStack(spacing: 14) {
             ChassisChip("DECK", action: showDeck)
             divider
@@ -33,42 +51,10 @@ struct UMDBar: View {
             ChassisChip("KBD", action: summonKeyboard)
             ChassisChip("A−", action: fontDown)
             ChassisChip("A+", action: fontUp)
-            // Dropdown: a fresh session in the same directory, plain or
-            // launching an agent — mirrors the deck's New Session options.
-            Menu {
-                Button("New Session") { newSession(nil) }
-                Button(AgentKind.claudeCode.displayName) { newSession(.claudeCode) }
-                Button(AgentKind.codex.displayName) { newSession(.codex) }
-            } label: {
-                ChassisBadge("TAB", systemImage: "plus")
-            }
-            .menuStyle(.button)
-            .buttonStyle(.plain)
-            .chassisHover(2)
-            .accessibilityLabel("New tab: another session in this window")
+            newTabMenu
             // Custom TALLY dropdown, immediately right of + TAB. Each choice
             // sends the stock tmux prefix binding through the ordered pump.
-            Button {
-                showingTmuxShortcuts = true
-            } label: {
-                ChassisBadge("TMUX", systemImage: "command")
-            }
-            .buttonStyle(.plain)
-            .chassisHover(2)
-            .disabled(controller?.status != .live)
-            .accessibilityLabel("Show tmux shortcuts")
-            .popover(
-                isPresented: $showingTmuxShortcuts,
-                attachmentAnchor: .rect(.bounds),
-                arrowEdge: .bottom
-            ) {
-                TmuxShortcutPanel { shortcut in
-                    showingTmuxShortcuts = false
-                    controller?.performTmuxShortcut(shortcut)
-                }
-                .presentationCompactAdaptation(.popover)
-                .tmuxShortcutPresentationSizing()
-            }
+            tmuxShortcutButton
             if !mergeSources.isEmpty {
                 Menu {
                     ForEach(mergeSources) { entry in
@@ -119,6 +105,142 @@ struct UMDBar: View {
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .strokeBorder(Theme.bezelHi, lineWidth: 1))
+    }
+
+    /// Slim in-scene UMD. The common path stays visible at phone width;
+    /// secondary actions move into one neutral overflow menu. At a genuinely
+    /// wide terminal pane ViewThatFits restores the direct chips.
+    private var shellBar: some View {
+        ViewThatFits(in: .horizontal) {
+            shellRow(showsDirectActions: true)
+            shellRow(showsDirectActions: false)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Theme.bezel)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.bezelHi).frame(height: 1)
+        }
+    }
+
+    private func shellRow(showsDirectActions: Bool) -> some View {
+        HStack(spacing: 9) {
+            ChassisChip(deckControlLabel, action: showDeck)
+                .fixedSize()
+            ChassisLabel(title, size: 11)
+                .layoutPriority(1)
+            statusCluster
+                .fixedSize()
+            Spacer(minLength: 4)
+            ChassisChip("KBD", action: summonKeyboard)
+                .fixedSize()
+            if showsDirectActions {
+                ChassisChip("A−", action: fontDown).fixedSize()
+                ChassisChip("A+", action: fontUp).fixedSize()
+                newTabMenu.fixedSize()
+                tmuxShortcutButton.fixedSize()
+                detachControl.fixedSize()
+            } else {
+                overflowMenu.fixedSize()
+            }
+        }
+    }
+
+    private var newTabMenu: some View {
+        Menu {
+            Button("New Session") { newSession(nil) }
+            Button(AgentKind.claudeCode.displayName) { newSession(.claudeCode) }
+            Button(AgentKind.codex.displayName) { newSession(.codex) }
+        } label: {
+            ChassisBadge("TAB", systemImage: "plus")
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .chassisHover(2)
+        .accessibilityLabel("New tab: another session in this window")
+    }
+
+    private var tmuxShortcutButton: some View {
+        tmuxPopover(
+            Button {
+                showingTmuxShortcuts = true
+            } label: {
+                ChassisBadge("TMUX", systemImage: "command")
+            }
+            .buttonStyle(.plain)
+            .chassisHover(2)
+            .disabled(controller?.status != .live)
+            .accessibilityLabel("Show tmux shortcuts")
+        )
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            Section("Text Size") {
+                Button("Smaller Text", action: fontDown)
+                Button("Larger Text", action: fontUp)
+            }
+            Menu("New Tab") {
+                Button("New Session") { newSession(nil) }
+                Button(AgentKind.claudeCode.displayName) {
+                    newSession(.claudeCode)
+                }
+                Button(AgentKind.codex.displayName) {
+                    newSession(.codex)
+                }
+            }
+            Divider()
+            Button("Detach", action: detach)
+            if let closeSession {
+                Button("Close Session", role: .destructive, action: closeSession)
+            }
+        } label: {
+            ChassisBadge("", systemImage: "ellipsis")
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .chassisHover(2)
+        .accessibilityLabel("Terminal actions")
+    }
+
+    @ViewBuilder
+    private var detachControl: some View {
+        if let closeSession {
+            Menu {
+                Button("Detach", action: detach)
+                Button("Close Session", role: .destructive, action: closeSession)
+            } label: {
+                ChassisBadge("DETACH", prominent: true)
+            }
+            .menuStyle(.button)
+            .buttonStyle(.plain)
+            .chassisHover(2)
+            .accessibilityLabel("Detach or close the session")
+        } else {
+            ChassisChip("DETACH", prominent: true, action: detach)
+        }
+    }
+
+    private func tmuxPopover<Control: View>(_ control: Control) -> some View {
+        control.popover(
+            isPresented: $showingTmuxShortcuts,
+            attachmentAnchor: .rect(.bounds),
+            arrowEdge: .bottom
+        ) {
+            TmuxShortcutPanel(width: shortcutPanelWidth) { shortcut in
+                showingTmuxShortcuts = false
+                controller?.performTmuxShortcut(shortcut)
+            }
+            .presentationCompactAdaptation(.popover)
+            .tmuxShortcutPresentationSizing()
+        }
+    }
+
+    private var shortcutPanelWidth: CGFloat {
+        min(
+            TmuxShortcutPanel.preferredWidth,
+            max(280, (availableWidth ?? TmuxShortcutPanel.preferredWidth + 24) - 24)
+        )
     }
 
     private var divider: some View {

--- a/MultiplexTests/SingleWindowShellPolicyTests.swift
+++ b/MultiplexTests/SingleWindowShellPolicyTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import Multiplex
+
+final class SingleWindowShellPolicyTests: XCTestCase {
+    func testDefaultDecisionMatrix() {
+        let cases: [(
+            platform: ShellModeDecision.Platform,
+            idiom: ShellModeDecision.Idiom,
+            fullScreen: Bool,
+            expected: Bool
+        )] = [
+            (.iOS, .phone, false, true),
+            (.iOS, .phone, true, true),
+            (.iOS, .pad, false, false),
+            (.iOS, .pad, true, true),
+            (.iOS, .other, false, false),
+            (.iOS, .other, true, false),
+            (.visionOS, .other, false, false),
+            (.visionOS, .pad, true, false),
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                ShellModeDecision.usesSingleWindowShell(
+                    platform: testCase.platform,
+                    idiom: testCase.idiom,
+                    isFullScreen: testCase.fullScreen,
+                    environmentOverride: nil
+                ),
+                testCase.expected,
+                "\(testCase.platform) \(testCase.idiom) fullScreen=\(testCase.fullScreen)"
+            )
+        }
+    }
+
+    func testForceOnOverridesEveryPlatformAndIdiom() {
+        for platform in [ShellModeDecision.Platform.iOS, .visionOS] {
+            for idiom in [
+                ShellModeDecision.Idiom.phone,
+                .pad,
+                .other,
+            ] {
+                for fullScreen in [false, true] {
+                    XCTAssertTrue(ShellModeDecision.usesSingleWindowShell(
+                        platform: platform,
+                        idiom: idiom,
+                        isFullScreen: fullScreen,
+                        environmentOverride: "1"
+                    ))
+                }
+            }
+        }
+    }
+
+    func testForceOffOverridesEveryPlatformAndIdiom() {
+        for platform in [ShellModeDecision.Platform.iOS, .visionOS] {
+            for idiom in [
+                ShellModeDecision.Idiom.phone,
+                .pad,
+                .other,
+            ] {
+                for fullScreen in [false, true] {
+                    XCTAssertFalse(ShellModeDecision.usesSingleWindowShell(
+                        platform: platform,
+                        idiom: idiom,
+                        isFullScreen: fullScreen,
+                        environmentOverride: "0"
+                    ))
+                }
+            }
+        }
+    }
+
+    func testUnknownOverrideFallsBackToScenePolicy() {
+        XCTAssertTrue(ShellModeDecision.usesSingleWindowShell(
+            platform: .iOS,
+            idiom: .phone,
+            isFullScreen: false,
+            environmentOverride: "yes"
+        ))
+        XCTAssertFalse(ShellModeDecision.usesSingleWindowShell(
+            platform: .iOS,
+            idiom: .pad,
+            isFullScreen: false,
+            environmentOverride: "yes"
+        ))
+    }
+
+    func testExpandedLayoutStartsAt620Points() {
+        XCTAssertFalse(SingleWindowShellLayout.isExpanded(width: 619.999))
+        XCTAssertTrue(SingleWindowShellLayout.isExpanded(width: 620))
+        XCTAssertTrue(SingleWindowShellLayout.isExpanded(width: 1_024))
+        XCTAssertEqual(SingleWindowShellLayout.deckRailWidth, 316)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -76,8 +76,20 @@ targets:
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: true
           UISceneConfigurations: {}
+        # iPhone is single-scene: without this override iOS 27 connects a
+        # second (empty) scene on phones, composing two windows into one
+        # screen. iPad/visionOS keep multi-scene from the base manifest.
+        UIApplicationSceneManifest~iphone:
+          UIApplicationSupportsMultipleScenes: false
+          UISceneConfigurations: {}
         UILaunchScreen:
           UIColorName: AppBackground
+        # iPhone (Debug-only device family, see TARGETED_DEVICE_FAMILY below):
+        # the un-suffixed key applies to iPhone; the ~ipad override wins on iPad.
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
         UISupportedInterfaceOrientations~ipad:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationPortraitUpsideDown
@@ -100,6 +112,12 @@ targets:
         CURRENT_PROJECT_VERSION: "202607130"
         TARGETED_DEVICE_FAMILY: "2,7"
         SUPPORTS_MACCATALYST: NO
+      configs:
+        # iPhone remains a Debug-only destination for single-window shell
+        # verification. Release archives stay iPad + Vision Pro until phone
+        # distribution is deliberately enabled.
+        Debug:
+          TARGETED_DEVICE_FAMILY: "1,2,7"
         # Export compliance: Multiplex implements only published,
         # industry-standard crypto (SSH and AES-OCB). Apple's NO value means
         # "no non-exempt encryption," not "no encryption"; no Apple


### PR DESCRIPTION
## Summary

One window with navigation for iPhone — and for iPads running **Full Screen Apps** mode (no windowed multitasking) — instead of the multi-window deck/terminal split. The shell hosts the **real** `FleetWall` and **real** `TerminalWorkspace` tab controllers in a single scene:

- **Compact**: deck is home; tapping a tile pushes the live terminal (`‹ DECK` returns). Deck and terminal stay mounted, so shells, buffers, and scrollback survive navigation.
- **Expanded (≥ 620 pt — resizable canvas / fold-open rehearsal)**: deck compresses to a collapsible one-session-width rail beside the terminal (`◧ HIDE`), with full tab support (MERGE hidden — there are no other windows).

### Gating (pure + unit-tested, logged under category `shell`)
| Platform | Shell? |
|---|---|
| iPhone | always |
| iPad | only when `UIWindowScene.isFullScreen` at scene connect |
| iPad windowed / Stage Manager | never — classic multi-window untouched |
| visionOS | never — untouched |

`MULTIPLEX_FORCE_SHELL=1|0` (DEBUG) overrides for testing. The deck's attach paths go through an injected `TerminalRouteOpener`, so classic mode keeps today's `openWindow` behavior byte-for-byte.

### Ship guard
iPhone stays a **Debug-only** device family (Release remains iPad + Vision Pro), plus a `UIApplicationSceneManifest~iphone` single-scene override (iOS 27 otherwise connects a second empty scene on phones).

### Phone chrome adaptations
Key-rail phone tiers (TMUX key kept down to 390 pt, essentials-only floor 372 pt; iPad tiers byte-identical) · Custom Commands control row rewraps with full captions · pinned deck header · centered tile column · bottom slide-under scrolling · 12 pt default terminal font (phone only) · arbiter-level focus-restoration gate fixing the keyboard re-appearing over the deck after app switches · new `….debug.customcommands` notification hook · AGENTS.md updated (hooks, iOS 27 sim notes).

## Validation

- 299/299 unit tests (visionOS destination); iPhone + iPad + visionOS builds green
- Live dev-sshd E2E through the shell: SSH→tmux attach, `echo $((6*7))` round-trip rendered `42`, Copy Mode via the ordered pump (`pane_in_mode=1`)
- iPad windowed default: classic deck + separate terminal scene (regression clean); forced shell renders the expanded rail split; visionOS classic deck unchanged
- Key rail + Custom Commands verified at 402 pt and 375 pt

## Follow-ups (non-blocking)

- Confirm `isFullScreen == true` on an iPad in Full Screen Apps mode (windowed `false` verified; sims pin the mode headlessly)
- Keyboard-after-app-switch fix needs one real-device confirmation
- `MULTIPLEX_AUTO_ATTACH` adds a duplicate tab for an already-open session (interactive path dedupes)
- Host-rail address wraps awkwardly at phone width

Implementation by Codex through the codex plugin, briefed and validated in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)