### PR TITLE
Sync SwiftTerm 1.14.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,11 +256,10 @@ views.
   - `swift-nio-ssh` — Citadel 0.12.0's resolved fork (`Joannis` 0.3.5), patched
     to declare the `NIO` product it imports (Xcode 27's module resolution
     rejects the undeclared import). Also freezes the SSH transport supply chain.
-  - `SwiftTerm` — 1.13.0, patched four times (all marked `Multiplex patch`):
+  - `SwiftTerm` — 1.14.0 (rev `849e8a4`), patched four times (all marked
+    `Multiplex patch`):
     `keyboardType` is settable (upstream is get-only), letting terminals
-    default to `.asciiCapable` (English) instead of the user's IME; UIKit taps
-    encode xterm button 0 (primary/left), not button 1 (middle), so mouse-aware
-    TUI click targets receive them; pans scroll the *remote* instead of
+    default to `.asciiCapable` (English) instead of the user's IME; pans scroll the *remote* instead of
     reporting click-drags — wheel button
     events when the client requested mouse tracking (tmux `mouse on` scrolls
     its own scrollback), DECCKM-aware arrows in the alternate screen with
@@ -277,7 +276,9 @@ views.
     (`wantsPriorityOverSystemBehavior` included) ever run. The bridge sends the
     control byte (kitty-encoded when enhancement flags are on) to the
     first-responder TerminalView in the key window and never installs on real
-    iPads. Sample apps trimmed.
+    iPads. Upstream 1.14.0 now encodes UIKit taps as xterm button 0
+    (primary/left), so that former Multiplex patch was retired. Sample apps
+    trimmed.
   - When bumping either, re-apply the patches and diff before trusting it.
 - **Citadel pinned to exactly 0.12.0**: 0.12.1 moved its swift-nio-ssh dep to an
   unaudited personal fork. Don't bump without review — this is the transport.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ with any POSIX-ish login shell, and channel close = clean detach.
 
 | Library | Version | Why |
 | --- | --- | --- |
-| [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) | 1.13.0, vendored | The only mature native-Swift terminal emulator view; declares visionOS support; MIT. Vendored at `Vendor/SwiftTerm` (rev `8e7a1e1`) with Multiplex input patches for the ASCII keyboard default, primary-button taps, remote scrolling, copy-mode selection, and iOS-app-on-Mac hardware keys. |
+| [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) | 1.14.0, vendored | The only mature native-Swift terminal emulator view; declares visionOS support; MIT. Vendored at `Vendor/SwiftTerm` (rev `849e8a4`) with upstream primary-button taps plus Multiplex input patches for the ASCII keyboard default, remote scrolling, copy-mode selection, and iOS-app-on-Mac hardware keys. |
 | [Citadel](https://github.com/orlandos-nl/Citadel) | 0.12.0 (exact) | Async/await SSH on SwiftNIO: PTY shell + resize, exec, and OpenSSH key parsing (ed25519/RSA, encrypted keys included). |
 
 **Supply-chain note.** Citadel is deliberately pinned to **0.12.0**: 0.12.1

--- a/Vendor/SwiftTerm/Package.resolved
+++ b/Vendor/SwiftTerm/Package.resolved
@@ -1,33 +1,5 @@
 {
-  "originHash" : "b5ff689c86958c5a25a1a8946ddd3297f24a4ac1033e88edd10786f2c69a6415",
   "pins" : [
-    {
-      "identity" : "hdrhistogram-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift.git",
-      "state" : {
-        "revision" : "de0b9b8a27956b9bfc9b4dce7d1c38ad7c579f19",
-        "version" : "0.1.4"
-      }
-    },
-    {
-      "identity" : "package-benchmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-benchmark",
-      "state" : {
-        "revision" : "a1075611342d4b164bf6e977edb02a3db4434afd",
-        "version" : "1.29.11"
-      }
-    },
-    {
-      "identity" : "package-jemalloc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-jemalloc.git",
-      "state" : {
-        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
-        "version" : "1.0.0"
-      }
-    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -35,15 +7,6 @@
       "state" : {
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
       }
     },
     {
@@ -63,34 +26,7 @@
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "texttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/TextTable.git",
-      "state" : {
-        "revision" : "a27a07300cf4ae322e0079ca0a475c5583dd575f",
-        "version" : "0.0.2"
-      }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Vendor/SwiftTerm/Package.swift
+++ b/Vendor/SwiftTerm/Package.swift
@@ -10,7 +10,8 @@ let platformExcludes: [String] = []
 #endif
 
 let isGitHubActions = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
-let benchmarkDependencies: [Package.Dependency] = isGitHubActions ? [] : [
+let disableBenchmark = true
+let benchmarkDependencies: [Package.Dependency] = (isGitHubActions || disableBenchmark) ? [] : [
     .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.29.11"))
 ]
 
@@ -54,7 +55,7 @@ let products: [Product] = [
     ),
 ]
 
-let benchmarkTargets: [Target] = isGitHubActions ? [] : [
+let benchmarkTargets: [Target] = (isGitHubActions || disableBenchmark) ? [] : [
     .executableTarget(
         name: "SwiftTermBenchmarks",
         dependencies: [
@@ -111,7 +112,7 @@ let package = Package(
     name: "SwiftTerm",
     platforms: [
         .iOS(.v14),
-        .macOS(.v13),
+        (disableBenchmark ? .macOS(.v11) : .macOS(.v13)),
         .tvOS(.v13),
         .visionOS(.v1)
     ],

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -83,9 +83,55 @@ struct ViewLineInfo {
     var boxDrawings: [BoxDrawingRenderItem]
 }
 
+/// How to place a single glyph within its `columnWidth`-cell slot.
+///
+/// Full-width (CJK) and other substituted glyphs would otherwise be pinned to
+/// the left edge of their slot, which dumps the slack between the glyph's
+/// advance and the slot width onto the right of every cell — the phantom gap
+/// reported for CJK text. ``GlyphSlotFit`` centers the glyph's advance box in
+/// the slot so the slack is split evenly instead, matching Terminal.app and the
+/// centering Ghostty applies to wide glyphs (its glyph constraint with
+/// `align: .center`). As a safety net it also constrains a glyph whose ink
+/// overflows its slot — too wide for the columns, or too tall for the cell —
+/// scaling it down to fit and re-centering it vertically. That fit-to-cell guard
+/// is in the spirit of Ghostty's `size` constraint; it is not Ghostty's
+/// cap-height CJK down-scaling (#8709), which corrects an up-scaling we never do.
+/// `dx`/`dy` are point offsets applied to the glyph origin; `scale` is a uniform
+/// downscale (`<= 1`).
+struct GlyphSlotFit {
+    var dx: CGFloat = 0
+    var dy: CGFloat = 0
+    var scale: CGFloat = 1
+
+    static let identity = GlyphSlotFit()
+
+    var isIdentity: Bool { dx == 0 && dy == 0 && scale == 1 }
+}
+
 extension TerminalView {
     typealias CellDimension = CGSize
-    
+
+#if os(macOS)
+    /// Controls whether font smoothing (sub-pixel rendering) is enabled during glyph drawing.
+    /// Set to `false` to get thinner strokes on Retina displays, matching iTerm2's "Thin strokes" setting.
+    /// Defaults to `true` (standard macOS font smoothing).
+    @objc open var fontSmoothing: Bool {
+        get { _fontSmoothing }
+        set { _fontSmoothing = newValue }
+    }
+#endif
+
+    /// Multiplier for vertical line spacing. 1.0 = default (ascent + descent + leading).
+    /// Set to 1.1 for 110% vertical spacing (matches iTerm2's vertical spacing setting).
+    /// Triggers a font reset and terminal resize when changed.
+    @objc open var lineSpacing: CGFloat {
+        get { _lineSpacing }
+        set {
+            _lineSpacing = newValue
+            resetFont()
+        }
+    }
+
     func resetCaches ()
     {
         self.attributes = [:]
@@ -99,9 +145,11 @@ extension TerminalView {
     {
         resetCaches()
         self.cellDimension = computeFontDimensions ()
-        let newCols = Int(frame.width / cellDimension.width)
-        let newRows = Int(frame.height / cellDimension.height)
-        resize(cols: newCols, rows: newRows)
+        if (frame.width > 0) && (frame.height > 0) {
+            let newCols = Int(frame.width / cellDimension.width)
+            let newRows = Int(frame.height / cellDimension.height)
+            resize(cols: newCols, rows: newRows)
+        }
         updateCaretView()
         
         #if os(macOS)
@@ -129,13 +177,16 @@ extension TerminalView {
         // Calculation assume that all glyphs in the font have the same advancement.
         // Get the ascent + descent + leading from the font, already scaled for the font's size
         self.cellDimension = computeFontDimensions ()
-        
-        let terminalOptions = TerminalOptions(cols: Int(width / cellDimension.width),
-                                              rows: Int(height / cellDimension.height))
-        
+
+        let zeroSizedView = width == 0 && height == 0
+        let terminalOptions = zeroSizedView
+            ? (terminal?.options ?? .default)
+            : TerminalOptions(cols: Int(width / cellDimension.width),
+                              rows: Int(height / cellDimension.height))
+
         if terminal == nil {
             terminal = Terminal(delegate: self, options: terminalOptions)
-        } else {
+        } else if !zeroSizedView {
             terminal.options = terminalOptions
             terminal.setup(isReset: false)
         }
@@ -172,6 +223,9 @@ extension TerminalView {
     /// Returns true if this changed the number of columns/rows, false otherwise
     @discardableResult
     func processSizeChange (newSize: CGSize) -> Bool {
+        if newSize.width == 0 && newSize.height == 0 {
+            return false
+        }
         let newRows = Int (newSize.height / cellDimension.height)
         let newCols = Int (getEffectiveWidth (size: newSize) / cellDimension.width)
         
@@ -197,7 +251,7 @@ extension TerminalView {
         let lineAscent = CTFontGetAscent (fontSet.normal)
         let lineDescent = CTFontGetDescent (fontSet.normal)
         let lineLeading = CTFontGetLeading (fontSet.normal)
-        let cellHeight = ceil(lineAscent + lineDescent + lineLeading)
+        let cellHeight = ceil((lineAscent + lineDescent + lineLeading) * _lineSpacing)
         #if os(macOS)
         // The following is a more robust way of getting the largest ascii character width, but comes with a performance hit.
         // See: https://github.com/migueldeicaza/SwiftTerm/issues/286
@@ -222,7 +276,54 @@ extension TerminalView {
         let snappedHeight = ceil(cellHeight * scale) / scale
         return CellDimension(width: max(1, snappedWidth), height: max(min(snappedHeight, 8192), 1))
     }
-    
+
+    /// Computes how to center `glyph` within its `columnWidth`-cell slot (and
+    /// scale it down if its ink overflows). Returns ``GlyphSlotFit/identity`` for
+    /// ordinary single-cell glyphs, so Latin text in a monospace font is rendered
+    /// exactly as before and the hot path stays untouched. Shared by the
+    /// CoreGraphics and Metal glyph renderers so they stay pixel-consistent.
+    func glyphSlotFit (font: CTFont, glyph: CGGlyph, columnWidth: Int) -> GlyphSlotFit
+    {
+        // Only wide cells need adjusting: a single-width glyph in a monospace
+        // font already fills its cell, so we skip the metric lookups entirely.
+        guard columnWidth >= 2, cellDimension != nil else { return .identity }
+
+        let cellWidth = cellDimension.width
+        let cellHeight = cellDimension.height
+        let slotWidth = CGFloat(columnWidth) * cellWidth
+
+        var g = glyph
+        var advance = CGSize.zero
+        CTFontGetAdvancesForGlyphs(font, .horizontal, &g, &advance, 1)
+        guard advance.width > 0 else { return .identity }
+
+        var ink = CGRect.zero
+        CTFontGetBoundingRectsForGlyphs(font, .horizontal, &g, &ink, 1)
+
+        // Scale down only when the ink would spill outside its slot (rare; this
+        // protects oversized substitute glyphs). Never enlarge.
+        var scale: CGFloat = 1
+        if ink.width > slotWidth || ink.height > cellHeight, ink.width > 0, ink.height > 0 {
+            scale = max(0.1, min(min(slotWidth / ink.width, cellHeight / ink.height), 1))
+        }
+
+        // Center the (scaled) advance box horizontally in the slot. Centering by
+        // advance rather than ink keeps glyphs that are intentionally off-center
+        // within their em square — e.g. the CJK comma `、` — in their place.
+        let dx = (slotWidth - advance.width * scale) / 2
+
+        // Preserve the natural Latin baseline unless the glyph was scaled, in
+        // which case center its ink vertically so it doesn't sit too low/high.
+        var dy: CGFloat = 0
+        if scale < 1, ink.height > 0 {
+            let baselineFromBottom = ceil(CTFontGetDescent(fontSet.normal) + CTFontGetLeading(fontSet.normal))
+            let inkCenterFromBaseline = (ink.origin.y + ink.height / 2) * scale
+            dy = (cellHeight / 2 - baselineFromBottom) - inkCenterFromBaseline
+        }
+
+        return GlyphSlotFit(dx: dx, dy: dy, scale: scale)
+    }
+
     func mapColor (color: Attribute.Color, isFg: Bool, isBold: Bool, useBrightColors: Bool = true) -> TTColor
     {
         switch color {
@@ -326,8 +427,11 @@ extension TerminalView {
 
     public func synchronizedOutputChanged (source: Terminal, active: Bool)
     {
-        updateScroller()
-        queuePendingDisplay()
+        if !active {
+            updateScroller()
+            queuePendingDisplay()
+            terminalDelegate?.scrolled(source: self, position: scrollPosition)
+        }
     }
 
     public func setBackgroundColor(source: Terminal, color: Color) {
@@ -696,6 +800,11 @@ extension TerminalView {
             } else {
                 // Common path: just accumulate into the batch
                 pendingText.append(character)
+                if UnicodeUtil.prefersTextPresentation(character) {
+                    // Steer font fallback away from Apple Color Emoji for
+                    // default-text-presentation symbols (see prefersTextPresentation).
+                    pendingText.append("\u{FE0E}")
+                }
                 previousPlaceholder = nil
                 previousPlaceholderAttribute = nil
             }
@@ -1174,6 +1283,16 @@ extension TerminalView {
         }
         var placeholderImageCache: [UInt32: TTImage] = [:]
 
+        #if os(macOS)
+        // Clear the invalidated region before painting. We fill only cells that carry
+        // an explicit background; default-background cells rely on transparent backing-
+        // store pixels showing the layer's background color. AppKit clears the backing
+        // store only on a full-view redraw, so a partial repaint (a restricted DECSTBM
+        // scroll region, line insert/delete) otherwise keeps stale glyphs/backgrounds.
+        // Clear to transparent — not fill — so a translucent background is preserved.
+        context.clear(dirtyRect)
+        #endif
+
         for row in firstRow...lastRow {
             if row < 0 {
                 continue
@@ -1184,7 +1303,7 @@ extension TerminalView {
             let renderMode = displayBuffer.lines [row].renderMode
             let lineOffset = calcLineOffset(forRow: row)
             let lineOrigin = CGPoint(x: 0, y: frame.height - lineOffset)
-            
+
             switch renderMode {
             case .single:
                 break
@@ -1319,13 +1438,28 @@ extension TerminalView {
                             #endif
 
                             if endColumn >= terminal.cols {
-                                rect.size.width = frame.width - rect.origin.x
+                                if backgroundColor == nativeBackgroundColor {
+                                    rect.size.width = frame.width - rect.origin.x
+                                } else {
+                                    let marginX = rect.origin.x + rect.size.width
+                                    if marginX < frame.width {
+                                        let marginRect = CGRect(x: marginX, y: rect.origin.y, width: frame.width - marginX, height: rect.size.height)
+                                        #if os(macOS)
+                                        nativeBackgroundColor.setFill()
+                                        marginRect.fill()
+                                        #else
+                                        context.setFillColor(nativeBackgroundColor.cgColor)
+                                        context.fill(marginRect)
+                                        #endif
+                                    }
+                                }
                             }
 
                             #if os(macOS)
                             backgroundColor.setFill()
                             rect.fill()
                             #else
+                            context.setFillColor(backgroundColor.cgColor)
                             context.fill(rect)
                             #endif
                         }
@@ -1361,8 +1495,8 @@ extension TerminalView {
             context.setShouldAntialias(true)
             context.setAllowsAntialiasing(true)
             #if os(macOS)
-            context.setShouldSmoothFonts(true)
-            context.setAllowsFontSmoothing(true)
+            context.setShouldSmoothFonts(fontSmoothing)
+            context.setAllowsFontSmoothing(fontSmoothing)
             #endif
 
             // Glyph drawing loop — reuses cached CTLines
@@ -1394,20 +1528,50 @@ extension TerminalView {
                             y: lineOrigin.y + yOffset + ctPosition.y)
                     }
 
-                    nativeForegroundColor.set()
+                    nativeForegroundColor.setFill()
 
                     if runAttributes.keys.contains(.foregroundColor) {
                         let color = runAttributes[.foregroundColor] as! TTColor
-                        let cgColor = color.cgColor
-                        if let colorSpace = cgColor.colorSpace {
-                            context.setFillColorSpace(colorSpace)
-                        }
-                        context.setFillColor(cgColor)
+                        color.setFill()
                     }
 
-                    CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
+                    // Center full-width (CJK) and substituted glyphs within their
+                    // multi-cell slot instead of pinning them to the cell's left
+                    // edge. `positions` stays grid-aligned for the decorations
+                    // below; only `glyphPositions` is shifted/scaled.
+                    let ctRunFont = runFont as CTFont
+                    var glyphPositions = positions
+                    var scaledFits: [GlyphSlotFit]? = nil
+                    if prepared.segment.columnWidth >= 2 {
+                        var computed = [GlyphSlotFit](repeating: .identity, count: runGlyphsCount)
+                        var anyScaled = false
+                        for i in 0..<runGlyphsCount {
+                            let fit = glyphSlotFit(font: ctRunFont, glyph: runGlyphs[i], columnWidth: prepared.segment.columnWidth)
+                            computed[i] = fit
+                            glyphPositions[i].x += fit.dx
+                            glyphPositions[i].y += fit.dy
+                            if fit.scale != 1 { anyScaled = true }
+                        }
+                        if anyScaled { scaledFits = computed }
+                    }
 
-                    // Draw other attributes
+                    if let scaledFits {
+                        // Rare path: at least one glyph overflowed its slot and is
+                        // drawn individually at a reduced point size.
+                        for i in 0..<runGlyphsCount {
+                            let s = scaledFits[i].scale
+                            let drawFont: CTFont = s == 1
+                                ? ctRunFont
+                                : CTFontCreateCopyWithAttributes(ctRunFont, CTFontGetSize(ctRunFont) * s, nil, nil)
+                            var g = runGlyphs[i]
+                            var p = glyphPositions[i]
+                            CTFontDrawGlyphs(drawFont, &g, &p, 1, context)
+                        }
+                    } else {
+                        CTFontDrawGlyphs(runFont, runGlyphs, &glyphPositions, glyphPositions.count, context)
+                    }
+
+                    // Draw other attributes (decorations stay grid-aligned)
                     drawRunAttributes(runAttributes, glyphPositions: positions, in: context)
 
                     processedGlyphs += runGlyphsCount
@@ -1568,6 +1732,9 @@ extension TerminalView {
     func updateDisplay (notifyAccessibility: Bool)
     {
         defer { pendingDisplay = false }
+        if terminal.synchronizedOutputActive {
+            return
+        }
         updateCursorPosition()
         guard let (rowStart, rowEnd) = terminal.getUpdateRange () else {
             if notifyUpdateChanges {
@@ -1575,6 +1742,22 @@ extension TerminalView {
                 let y = buffer.yDisp+buffer.y
                 terminalDelegate?.rangeChanged (source: self, startY: y, endY: y)
             }
+            // Pure cursor moves (e.g. CSI C / CSI D from word-jumps) don't
+            // mark any row dirty, so getUpdateRange() returns nil. With Metal
+            // the cursor is drawn by the renderer reading buffer.x/y at draw
+            // time, and MTKView is paused — without an explicit redraw the
+            // cursor stays at its old screen position until something else
+            // dirties a row. Trigger a redraw if the cursor moved.
+            #if canImport(MetalKit)
+            if metalView != nil {
+                let buffer = terminal.displayBuffer
+                let cursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
+                if lastRenderedCursor == nil || lastRenderedCursor! != cursor {
+                    lastRenderedCursor = cursor
+                    requestMetalDisplay()
+                }
+            }
+            #endif
             return
         }
         if notifyUpdateChanges {
@@ -1582,7 +1765,7 @@ extension TerminalView {
         }
 
         terminal.clearUpdateRange ()
-                
+
         #if os(macOS)
         let baseLine = frame.height
         var region = CGRect (x: 0,
@@ -1596,6 +1779,14 @@ extension TerminalView {
             let oh = region.height
             let oy = region.origin.y
             region = CGRect (x: 0, y: 0, width: frame.width, height: oh + oy)
+        } else {
+            // Region ends mid-screen (a restricted DECSTBM region): extend the
+            // invalidation down by one cell so the sub-cell remainder just below the
+            // band's bottom row (descenders / tall unicode) is cleared too. Previously
+            // only rowEnd == rows-1 got this, leaving a one-row ghost below the region.
+            let extra = cellDimension.height
+            let newY = max (0, region.origin.y - extra)
+            region = CGRect (x: 0, y: newY, width: frame.width, height: region.maxY - newY)
         }
 #if canImport(MetalKit)
         if metalView != nil {
@@ -1624,6 +1815,7 @@ extension TerminalView {
                     metalDirtyRange = nil
                 }
             }
+            lastRenderedCursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
             requestMetalDisplay()
         } else {
             setNeedsDisplay(region)
@@ -1637,6 +1829,8 @@ extension TerminalView {
         #if canImport(MetalKit)
         if metalView != nil {
             metalDirtyRange = metalVisibleRange()
+            let buffer = terminal.displayBuffer
+            lastRenderedCursor = (x: buffer.x, y: buffer.yBase + buffer.y, hidden: terminal.cursorHidden)
             requestMetalDisplay()
         } else {
             setNeedsDisplay(bounds)
@@ -1650,6 +1844,9 @@ extension TerminalView {
         
         if (notifyAccessibility) {
             accessibility.invalidate ()
+            #if os(iOS)
+            UIAccessibility.post(notification: .layoutChanged, argument: nil)
+            #endif
             #if os(macOS)
             NSAccessibility.post (element: self, notification: .valueChanged)
             NSAccessibility.post (element: self, notification: .selectedTextChanged)
@@ -1681,8 +1878,13 @@ extension TerminalView {
         let offset = (cellDimension.height * (CGFloat(buffer.y-(buffer.yDisp-buffer.yBase)+1)))
         let lineOrigin = CGPoint(x: 0, y: frame.height - offset)
         #endif
+        let charUnderCursor = buffer.lines [vy][buffer.x]
+        // Span the caret across the full character so a block cursor covers a
+        // full-width (CJK) glyph instead of only its left half.
+        let cursorColumnWidth = max(1, Int(charUnderCursor.width))
         caretView.frame.origin = CGPoint(x: lineOrigin.x + (cellDimension.width * doublePosition * CGFloat(buffer.x)), y: lineOrigin.y)
-        caretView.setText (ch: buffer.lines [vy][buffer.x])
+        caretView.frame.size.width = cellDimension.width * doublePosition * CGFloat(cursorColumnWidth)
+        caretView.setText (ch: charUnderCursor)
     }
     
     // Does not use a default argument and merge, because it is called back
@@ -1702,6 +1904,9 @@ extension TerminalView {
     // It is also cheap, so should be called when new data has been posted or received.
     func queuePendingDisplay ()
     {
+        if terminal.synchronizedOutputActive {
+            return
+        }
         // throttle
         if !pendingDisplay {
             let fps60 = 16670000
@@ -1711,6 +1916,7 @@ extension TerminalView {
             DispatchQueue.main.asyncAfter(
                 deadline: DispatchTime (uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + UInt64 (fpsDelay)),
                 execute: updateDisplay)
+        } else {
         }
     }
 
@@ -1823,11 +2029,10 @@ extension TerminalView {
     
     public func scroll (toPosition: Double)
     {
-        userScrolling = true
         let displayBuffer = terminal.displayBuffer
         let oldPosition = displayBuffer.yDisp
         
-        let maxScrollback = displayBuffer.lines.count - displayBuffer.rows
+        let maxScrollback = max(0, displayBuffer.lines.count - displayBuffer.rows)
         var newScrollPosition = Int (Double (maxScrollback) * toPosition)
         
         if newScrollPosition < 0 {
@@ -1839,25 +2044,48 @@ extension TerminalView {
 
         if newScrollPosition != oldPosition {
             scrollTo(row: newScrollPosition)
+        } else {
+            updateUserScrollingState(for: newScrollPosition, in: displayBuffer)
         }
-        userScrolling = false
+    }
+
+    private func updateUserScrollingState(for row: Int, in displayBuffer: Buffer) {
+        let maxScrollback = max(0, displayBuffer.lines.count - displayBuffer.rows)
+        let isUserScrolling = row < maxScrollback
+        userScrolling = isUserScrolling
+        terminal.userScrolling = isUserScrolling
     }
     
     public func scrollTo (row: Int, notifyAccessibility: Bool = true)
     {
         let displayBuffer = terminal.displayBuffer
-        if row != displayBuffer.yDisp {
-            terminal.setViewYDisp (row)
-            
+        let maxScrollback = max(0, displayBuffer.lines.count - displayBuffer.rows)
+        let targetRow = max(0, min(row, maxScrollback))
+#if os(iOS) || os(visionOS)
+        resetManualScrollOffsetWithinRow()
+#endif
+        updateUserScrollingState(for: targetRow, in: displayBuffer)
+
+        if targetRow != displayBuffer.yDisp {
+            terminal.setViewYDisp (targetRow)
+
             // tell the terminal we want to refresh all the rows
             terminal.refresh (startRow: 0, endRow: terminal.rows)
-            
+
             // do the display update
             updateDisplay (notifyAccessibility: notifyAccessibility)
             //selectionView.notifyScrolled(source: terminal)
             terminalDelegate?.scrolled (source: self, position: scrollPosition)
             updateScroller()
             setNeedsDisplay(frame)
+        } else {
+#if os(iOS) || os(visionOS)
+            // The row did not change, but we just cleared any sub-row manual
+            // scroll offset above; resync contentOffset so a later output-driven
+            // updateScroller does not snap the view up by that stale fractional
+            // amount.
+            updateScroller()
+#endif
         }
     }
     
@@ -1909,9 +2137,57 @@ extension TerminalView {
     func feedFinish ()
     {
         suspendDisplayUpdates ()
+        if shouldDisplayImmediatelyAfterUserInput() {
+            displayImmediately()
+            return
+        }
         queuePendingDisplay()
     }
-    
+
+    private func shouldDisplayImmediatelyAfterUserInput() -> Bool {
+        guard !terminal.synchronizedOutputActive else { return false }
+        let last = loadLastUserInputUptimeNs()
+        guard last > 0 else { return false }
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard now >= last else { return false }
+        return now - last <= interactiveInputDisplayWindowNs
+    }
+
+    /// Records that the user just produced input, opening the immediate-display
+    /// window. `lastUserInputUptimeNs` is written here on the main thread but
+    /// read from the (possibly background) feed thread in feedFinish(), so both
+    /// accesses go through userInputLock to avoid a data race / torn read.
+    func recordUserInput() {
+        let now = DispatchTime.now().uptimeNanoseconds
+        userInputLock.lock()
+        lastUserInputUptimeNs = now
+        userInputLock.unlock()
+    }
+
+    private func loadLastUserInputUptimeNs() -> UInt64 {
+        userInputLock.lock()
+        defer { userInputLock.unlock() }
+        return lastUserInputUptimeNs
+    }
+
+    private func displayImmediately() {
+        guard !Thread.isMainThread else {
+            updateDisplay()
+            return
+        }
+        // Coalesce with the throttled path: if a redraw is already scheduled
+        // (either here or via queuePendingDisplay), don't post another. This
+        // bypasses the 16.67ms frame-rate timer so echo feels responsive, while
+        // still collapsing a burst of feed chunks into a single main-thread
+        // redraw instead of flooding the main queue with one updateDisplay per
+        // chunk. updateDisplay() clears pendingDisplay, reopening the gate.
+        guard !pendingDisplay else { return }
+        pendingDisplay = true
+        DispatchQueue.main.async { [weak self] in
+            self?.updateDisplay()
+        }
+    }
+
     /// Sends data to the terminal emulator for interpretation, this can be invoked from a background thread
     public func feed (byteArray: ArraySlice<UInt8>)
     {
@@ -1957,6 +2233,7 @@ extension TerminalView {
      */
     public func send(data: ArraySlice<UInt8>)
     {
+        recordUserInput()
         ensureCaretIsVisible ()
         #if os(iOS) || os(visionOS)
         if TerminalView.textInputDebugEnabled {
@@ -2265,7 +2542,7 @@ extension TerminalView {
     public func selectNone () {
         selection.selectNone()
     }
-    
+
 }
 
 #if canImport(UIKit) && DEBUG

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/CaretView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/CaretView.swift
@@ -52,16 +52,33 @@ extension CaretView {
             let runGlyphsCount = CTRunGetGlyphCount(run)
             let runAttributes = CTRunGetAttributes(run) as? [NSAttributedString.Key: Any] ?? [:]
             let runFont = runAttributes[.font] as! TTFont
+            let ctRunFont = runFont as CTFont
 
             let runGlyphs = [CGGlyph](unsafeUninitializedCapacity: runGlyphsCount) { (bufferPointer, count) in
                 CTRunGetGlyphs(run, CFRange(), bufferPointer.baseAddress!)
                 count = runGlyphsCount
             }
 
-            var positions = runGlyphs.enumerated().map { (i: Int, glyph: CGGlyph) -> CGPoint in
-                CGPoint(x: 0, y: yOffset)
+            // Center full-width (CJK) glyphs within the caret the same way as the
+            // surrounding text so the character doesn't shift under the cursor,
+            // and scale an oversized glyph down to match (drawTerminalContents
+            // does the same via CTFontCreateCopyWithAttributes). The caret bounds
+            // span `glyphColumnWidth` cells, so the centered glyph isn't clipped.
+            let fits = runGlyphs.map { terminal.glyphSlotFit(font: ctRunFont, glyph: $0, columnWidth: glyphColumnWidth) }
+            var positions = fits.map { CGPoint(x: $0.dx, y: yOffset + $0.dy) }
+            if fits.contains(where: { $0.scale != 1 }) {
+                for i in 0..<runGlyphsCount {
+                    let s = fits[i].scale
+                    let drawFont: CTFont = s == 1
+                        ? ctRunFont
+                        : CTFontCreateCopyWithAttributes(ctRunFont, CTFontGetSize(ctRunFont) * s, nil, nil)
+                    var g = runGlyphs[i]
+                    var p = positions[i]
+                    CTFontDrawGlyphs(drawFont, &g, &p, 1, context)
+                }
+            } else {
+                CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
             }
-            CTFontDrawGlyphs(runFont, runGlyphs, &positions, positions.count, context)
         }
         context.restoreGState()
     }

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/Metal/CoreTextGlyphRasterizer.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/Metal/CoreTextGlyphRasterizer.swift
@@ -3,6 +3,8 @@ import CoreGraphics
 import CoreText
 
 final class CoreTextGlyphRasterizer {
+    var fontSmoothing: Bool = true
+
     func rasterize(font: CTFont, glyph: CGGlyph) -> GlyphBitmap? {
         var glyphVar = glyph
         let rect = CTFontGetBoundingRectsForGlyphs(font, .default, &glyphVar, nil, 1)
@@ -46,8 +48,13 @@ final class CoreTextGlyphRasterizer {
             context.setShouldSubpixelPositionFonts(true)
             context.setAllowsFontSubpixelQuantization(false)
             context.setShouldSubpixelQuantizeFonts(false)
-            context.setAllowsFontSmoothing(true)
-            context.setShouldSmoothFonts(true)
+#if os(macOS)
+            context.setAllowsFontSmoothing(fontSmoothing)
+            context.setShouldSmoothFonts(fontSmoothing)
+#else
+            context.setAllowsFontSmoothing(false)
+            context.setShouldSmoothFonts(false)
+#endif
 
             context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
             context.setStrokeColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/Metal/GlyphAtlas.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/Metal/GlyphAtlas.swift
@@ -41,6 +41,8 @@ enum GlyphAtlasFormat {
 }
 
 final class GlyphAtlas {
+    private static let glyphPadding = 1
+
     private let device: MTLDevice
     private let format: GlyphAtlasFormat
     private let bytesPerPixel: Int
@@ -72,14 +74,16 @@ final class GlyphAtlas {
         if width <= 0 || height <= 0 {
             return nil
         }
-        if let region = reserve(width: width, height: height) {
-            return region
+        let paddedWidth = width + (Self.glyphPadding * 2)
+        let paddedHeight = height + (Self.glyphPadding * 2)
+        if let region = reserve(width: paddedWidth, height: paddedHeight) {
+            return contentRegion(in: region, width: width, height: height)
         }
-        if width > maxSize || height > maxSize {
+        if paddedWidth > maxSize || paddedHeight > maxSize {
             return nil
         }
         var newSize = size
-        while newSize < maxSize && (newSize < max(width, height) || !canFit(width: width, height: height, size: newSize)) {
+        while newSize < maxSize && (newSize < max(paddedWidth, paddedHeight) || !canFit(width: paddedWidth, height: paddedHeight, size: newSize)) {
             newSize *= 2
         }
         if newSize > maxSize {
@@ -87,11 +91,15 @@ final class GlyphAtlas {
         }
         if newSize > size {
             grow(to: newSize)
-            return reserve(width: width, height: height)
+            return reserve(width: paddedWidth, height: paddedHeight).map {
+                contentRegion(in: $0, width: width, height: height)
+            }
         }
         reset()
         didReset = true
-        return reserve(width: width, height: height)
+        return reserve(width: paddedWidth, height: paddedHeight).map {
+            contentRegion(in: $0, width: width, height: height)
+        }
     }
 
     func write(region: AtlasRegion, pixels: [UInt8], width: Int, height: Int) {
@@ -100,6 +108,19 @@ final class GlyphAtlas {
         }
         let atlasStride = size * bytesPerPixel
         let srcStride = width * 4
+        let padding = Self.glyphPadding
+
+        // ensureRegion guarantees `padding` of slack on every side; the
+        // clamps below are defensive against direct misuse.
+        let paddedX = max(0, region.x - padding)
+        let paddedY = max(0, region.y - padding)
+        let paddedRight = min(size, region.x + width + padding)
+        let paddedBottom = min(size, region.y + height + padding)
+        let paddedWidth = paddedRight - paddedX
+        let paddedHeight = paddedBottom - paddedY
+
+        // 1) Bulk-copy the content rows. This is the hot path for color
+        //    glyphs and matches the pre-padding behavior.
         for row in 0..<height {
             let srcRow = height - 1 - row
             let srcOffset = srcRow * srcStride
@@ -109,17 +130,65 @@ final class GlyphAtlas {
                 data[dstOffset..<dstOffset + srcStride] = pixels[srcOffset..<srcOffset + srcStride]
             case .grayscale:
                 for col in 0..<width {
-                    let srcIndex = srcOffset + (col * 4)
-                    data[dstOffset + col] = pixels[srcIndex + 3]
+                    data[dstOffset + col] = pixels[srcOffset + col * 4 + 3]
                 }
             }
         }
-        let regionMTL = MTLRegionMake2D(region.x, region.y, region.width, region.height)
-        let offset = (region.y * atlasStride) + (region.x * bytesPerPixel)
+
+        // 2) Replicate the first/last content rows into the top/bottom
+        //    padding strips.
+        let contentRowBytes = width * bytesPerPixel
+        let firstRowOffset = (region.y * atlasStride) + (region.x * bytesPerPixel)
+        let lastRowOffset = ((region.y + height - 1) * atlasStride) + (region.x * bytesPerPixel)
+        for row in paddedY..<region.y {
+            let dst = (row * atlasStride) + (region.x * bytesPerPixel)
+            for i in 0..<contentRowBytes {
+                data[dst + i] = data[firstRowOffset + i]
+            }
+        }
+        for row in (region.y + height)..<paddedBottom {
+            let dst = (row * atlasStride) + (region.x * bytesPerPixel)
+            for i in 0..<contentRowBytes {
+                data[dst + i] = data[lastRowOffset + i]
+            }
+        }
+
+        // 3) Replicate the left/right edge pixels across the full padded
+        //    height. Step 2 already filled column `region.x` of the top
+        //    and bottom rows, so the four corners come out correctly.
+        for row in paddedY..<paddedBottom {
+            let rowBase = row * atlasStride
+            let leftSrc = rowBase + (region.x * bytesPerPixel)
+            let rightSrc = rowBase + ((region.x + width - 1) * bytesPerPixel)
+            for col in paddedX..<region.x {
+                let dst = rowBase + (col * bytesPerPixel)
+                for b in 0..<bytesPerPixel {
+                    data[dst + b] = data[leftSrc + b]
+                }
+            }
+            for col in (region.x + width)..<paddedRight {
+                let dst = rowBase + (col * bytesPerPixel)
+                for b in 0..<bytesPerPixel {
+                    data[dst + b] = data[rightSrc + b]
+                }
+            }
+        }
+
+        let regionMTL = MTLRegionMake2D(paddedX, paddedY, paddedWidth, paddedHeight)
+        let offset = (paddedY * atlasStride) + (paddedX * bytesPerPixel)
         data.withUnsafeBytes { raw in
             let base = raw.baseAddress!.advanced(by: offset)
             texture.replace(region: regionMTL, mipmapLevel: 0, withBytes: base, bytesPerRow: atlasStride)
         }
+    }
+
+    private func contentRegion(in paddedRegion: AtlasRegion, width: Int, height: Int) -> AtlasRegion {
+        AtlasRegion(
+            x: paddedRegion.x + Self.glyphPadding,
+            y: paddedRegion.y + Self.glyphPadding,
+            width: width,
+            height: height
+        )
     }
 
     private func reserve(width: Int, height: Int) -> AtlasRegion? {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/Metal/MetalTerminalRenderer.swift
@@ -94,6 +94,8 @@ struct RowDrawBuffers {
 }
 
 struct RowCacheEntry {
+    var lineRef: BufferLine
+    var generation: UInt64
     var data: RowDrawData?
     var buffers: RowDrawBuffers?
 }
@@ -321,7 +323,15 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             frameSemaphore.signal()
             return
         }
+#if os(macOS)
+        rasterizer.fontSmoothing = terminalView.fontSmoothing
+        let scale = terminalView.metalRenderingScaleFactor()
+        if let layer = view.layer, layer.contentsScale != scale {
+            layer.contentsScale = scale
+        }
+#else
         let scale = terminalView.backingScaleFactor()
+#endif
         view.drawableSize = CGSize(width: view.bounds.width * scale, height: view.bounds.height * scale)
         let cursorStyle = terminalView.terminal.options.cursorStyle
         let shouldBlink = isBlinkStyle(cursorStyle) && !terminalView.terminal.cursorHidden
@@ -644,10 +654,16 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         var rebuiltRows = 0
         var cachedRows = 0
         for row in visibleRange {
+            let line = buffer.lines[row]
+            let lineGeneration = line.generation
             var entry = rowCache[row]
+            // Cache is valid only when the absolute row still maps to the same
+            // BufferLine instance (scrolls rotate refs in the CircularList) and
+            // that line has not been mutated since we cached its draw data.
+            let cacheValid = entry?.lineRef === line && entry?.generation == lineGeneration
             let needsRebuild = needsFullRebuild ||
                 (rebuildRange?.contains(row) ?? false) ||
-                entry == nil ||
+                !cacheValid ||
                 (bufferingMode == .perFrameAggregated && entry?.data == nil)
             let rowBuffers: RowDrawBuffers?
             let rowData: RowDrawData
@@ -662,7 +678,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
-                entry = RowCacheEntry(data: rowData, buffers: buffers)
+                entry = RowCacheEntry(lineRef: line, generation: lineGeneration, data: rowData, buffers: buffers)
                 rowCache[row] = entry
                 rowBuffers = buffers
                 rebuiltRows += 1
@@ -677,7 +693,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                                           scale: scale,
                                                           virtualPlacementsByImageId: virtualPlacementsByImageId)
                 if cached.data == nil {
-                    entry = RowCacheEntry(data: rowData, buffers: cached.buffers)
+                    entry = RowCacheEntry(lineRef: line, generation: lineGeneration, data: rowData, buffers: cached.buffers)
                     rowCache[row] = entry
                 }
                 if bufferingMode == .perRowPersistent {
@@ -704,7 +720,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                                            scale: scale,
                                            virtualPlacementsByImageId: virtualPlacementsByImageId)
                 let buffers = bufferingMode == .perRowPersistent ? makeRowBuffers(from: rowData) : nil
-                entry = RowCacheEntry(data: rowData, buffers: buffers)
+                entry = RowCacheEntry(lineRef: line, generation: lineGeneration, data: rowData, buffers: buffers)
                 rowCache[row] = entry
                 rowBuffers = buffers
                 rebuiltRows += 1
@@ -1013,7 +1029,19 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                             let y0 = lineOriginPx.y
                             var x1 = lineOriginPx.x + (CGFloat(startColumn + columnSpan) * cellWidthPx)
                             if endColumn >= buffer.cols {
-                                x1 = lineOriginPx.x + viewWidthPx
+                                if backgroundColor == terminalView.nativeBackgroundColor {
+                                    x1 = lineOriginPx.x + viewWidthPx
+                                } else {
+                                    let marginX0 = x1
+                                    let marginX1 = lineOriginPx.x + viewWidthPx
+                                    if marginX1 > marginX0 {
+                                        let (mx0, my0, mx1, my1) = transformRect(x0: marginX0, y0: y0, x1: marginX1, y1: lineOriginPx.y + cellHeightPx)
+                                        if let mClipped = self.clipRect(mx0, my0, mx1, my1, clipRect) {
+                                            let defaultBg = colorToSIMD(terminalView.nativeBackgroundColor)
+                                            backgroundCells.append(makeColorCell(x0: mClipped.0, y0: mClipped.1, x1: mClipped.2, y1: mClipped.3, color: defaultBg))
+                                        }
+                                    }
+                                }
                             }
                             let y1 = lineOriginPx.y + cellHeightPx
                             let (tx0, ty0, tx1, ty1) = transformRect(x0: x0, y0: y0, x1: x1, y1: y1)
@@ -1134,12 +1162,11 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 let runFont = runAttributes[.font] as? TTFont ?? terminalView.fontSet.normal
                 let ctFont = runFont as CTFont
                 let startColumn = shaped.segment.column + (processedGlyphs * shaped.segment.columnWidth)
-                let baseX = lineOrigin.x + (cellWidth * CGFloat(startColumn))
-                let xOffset = baseX - run.shaperRun.firstX
 
                 let textColor = runAttributes[.foregroundColor] as? TTColor ?? terminalView.nativeForegroundColor
                 let textColorSIMD = colorToSIMD(textColor)
 
+                var drawnGlyphsInRun = 0
                 for glyphRun in run.shaperRun.glyphRuns {
                     let scaledFont = scaledFontFor(font: glyphRun.font, scale: scale)
                     for i in 0..<glyphRun.glyphs.count {
@@ -1151,15 +1178,26 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                             continue
                         }
                         let ctPos = glyphRun.positions[i]
-                        let basePos = CGPoint(x: ctPos.x + xOffset,
-                                              y: lineOrigin.y + yOffset + ctPos.y)
-                        let pxX = basePos.x * scale + entry.bearing.x
-                        let pxY = basePos.y * scale + entry.bearing.y
+                        let glyphColumn = startColumn + ((drawnGlyphsInRun + i) * shaped.segment.columnWidth)
+                        // Center full-width (CJK) and substituted glyphs within
+                        // their multi-cell slot instead of pinning them to the
+                        // cell's left edge, mirroring the CoreGraphics path. The
+                        // decoration loops below keep using the grid column, so
+                        // underlines/strikethroughs stay cell-aligned.
+                        let fit = shaped.segment.columnWidth >= 2
+                            ? terminalView.glyphSlotFit(font: glyphRun.font,
+                                                        glyph: glyph,
+                                                        columnWidth: shaped.segment.columnWidth)
+                            : GlyphSlotFit.identity
+                        let basePos = CGPoint(x: lineOrigin.x + (cellWidth * CGFloat(glyphColumn)) + fit.dx,
+                                              y: lineOrigin.y + yOffset + ctPos.y + fit.dy)
+                        let pxX = basePos.x * scale + entry.bearing.x * fit.scale
+                        let pxY = basePos.y * scale + entry.bearing.y * fit.scale
 
                         let x0 = pxX
                         let y0 = pxY
-                        let x1 = pxX + entry.size.width
-                        let y1 = pxY + entry.size.height
+                        let x1 = pxX + entry.size.width * fit.scale
+                        let y1 = pxY + entry.size.height * fit.scale
                         let (tx0, ty0, tx1, ty1) = transformRect(x0: x0, y0: y0, x1: x1, y1: y1)
 
                         let atlasSize = entry.atlasKind == .color ? colorAtlas.size : grayscaleAtlas.size
@@ -1187,6 +1225,7 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                             }
                         }
                     }
+                    drawnGlyphsInRun += glyphRun.glyphs.count
                 }
 
                 if let rawStyle = runAttributes[.underlineStyle] as? Int,
@@ -1197,8 +1236,9 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     let thickness = underlineThickness * scale
                     let segmentStyle: UnderlineStyle = underlineStyle == .double ? .single : underlineStyle
 
-                    for ctPos in run.shaperRun.positions {
-                        let basePos = CGPoint(x: ctPos.x + xOffset,
+                    for (glyphIndex, ctPos) in run.shaperRun.positions.enumerated() {
+                        let glyphColumn = startColumn + (glyphIndex * shaped.segment.columnWidth)
+                        let basePos = CGPoint(x: lineOrigin.x + (cellWidth * CGFloat(glyphColumn)),
                                               y: lineOrigin.y + yOffset + ctPos.y)
                         let x0 = basePos.x * scale
                         let x1 = (basePos.x + decorationCellWidth) * scale
@@ -1248,8 +1288,9 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     let strikeThickness = max(round(scale * CTFontGetUnderlineThickness(ctFont)) / scale, 0.5)
                     let strikePosition = (CTFontGetXHeight(ctFont) + strikeThickness) * 0.5
 
-                    for ctPos in run.shaperRun.positions {
-                        let basePos = CGPoint(x: ctPos.x + xOffset,
+                    for (glyphIndex, ctPos) in run.shaperRun.positions.enumerated() {
+                        let glyphColumn = startColumn + (glyphIndex * shaped.segment.columnWidth)
+                        let basePos = CGPoint(x: lineOrigin.x + (cellWidth * CGFloat(glyphColumn)),
                                               y: lineOrigin.y + yOffset + ctPos.y)
                         let x0 = basePos.x * scale
                         let x1 = (basePos.x + decorationCellWidth) * scale
@@ -1722,7 +1763,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let glyphRuns: [ShaperGlyphRun]
         let positions: [CGPoint]
         let glyphCount: Int
-        let firstX: CGFloat
     }
 
     private struct ShapedRun {
@@ -1763,9 +1803,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
 
             var glyphRuns: [ShaperGlyphRun] = []
             var positions: [CGPoint] = []
-            var firstX: CGFloat = 0
-            var hasFirstX = false
-
             for run in runs {
                 let count = CTRunGetGlyphCount(run)
                 if count == 0 {
@@ -1784,18 +1821,13 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                 }
                 var runPositions = [CGPoint](repeating: .zero, count: count)
                 CTRunGetPositions(run, CFRange(), &runPositions)
-                if let first = runPositions.first, !hasFirstX {
-                    firstX = first.x
-                    hasFirstX = true
-                }
                 glyphRuns.append(ShaperGlyphRun(font: runFont, glyphs: glyphs, positions: runPositions))
                 positions.append(contentsOf: runPositions)
             }
 
             let result = ShaperRun(glyphRuns: glyphRuns,
                                    positions: positions,
-                                   glyphCount: positions.count,
-                                   firstX: firstX)
+                                   glyphCount: positions.count)
             insert(key: key, run: result)
             return result
         }
@@ -2068,10 +2100,14 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let cellWidthPx = cellWidth * scale
         let cellHeightPx = cellHeight * scale
         let doublePosition: CGFloat = buffer.lines[cursorRow].renderMode == .single ? 1.0 : 2.0
+        // Span the cursor across the full character so a block/underline cursor
+        // covers a full-width (CJK) glyph instead of only its left half, matching
+        // the CoreGraphics caret.
+        let cursorColumnWidth = CGFloat(max(1, Int(buffer.lines[cursorRow][buffer.x].width)))
 
         let x0 = lineOriginPx.x + CGFloat(buffer.x) * cellWidthPx * doublePosition
         let y0 = lineOriginPx.y
-        let x1 = x0 + cellWidthPx
+        let x1 = x0 + cellWidthPx * doublePosition * cursorColumnWidth
         let y1 = y0 + cellHeightPx
 
         #if os(macOS)
@@ -2140,14 +2176,13 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
         let attributes = terminalView.getAttributedValue(charData.attribute,
                                                          usingFg: terminalView.caretColor,
                                                          andBg: caretTextColor) ?? [.font: terminalView.fontSet.normal]
-        let attributedString = NSAttributedString(string: String(charData.getCharacter()), attributes: attributes)
+        let attributedString = NSAttributedString(string: UnicodeUtil.textPresentationAdjusted(charData.getCharacter()), attributes: attributes)
         let ctline = CTLineCreateWithAttributedString(attributedString)
         guard let runs = CTLineGetGlyphRuns(ctline) as? [CTRun] else {
             return (colorVertices, [], [])
         }
         let yOffset = ceil(lineDescent + lineLeading)
         let textColorSIMD = colorToSIMD(caretTextColor)
-        let baseX = lineOrigin.x + cellWidth * doublePosition * CGFloat(buffer.x)
 
         for run in runs {
             let runGlyphsCount = CTRunGetGlyphCount(run)
@@ -2166,9 +2201,6 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
             var coreTextPositions = [CGPoint](repeating: .zero, count: runGlyphsCount)
             CTRunGetPositions(run, CFRange(), &coreTextPositions)
 
-            let firstCoreTextX = coreTextPositions.first?.x ?? 0
-            let xOffset = baseX - firstCoreTextX
-
             for i in 0..<runGlyphsCount {
                 let glyph = runGlyphs[i]
                 guard let entry = glyphEntry(for: scaledFont, glyph: glyph) else {
@@ -2178,14 +2210,17 @@ final class MetalTerminalRenderer: NSObject, MTKViewDelegate {
                     continue
                 }
                 let ctPos = coreTextPositions[i]
-                let basePos = CGPoint(x: ctPos.x + xOffset,
-                                      y: lineOrigin.y + yOffset + ctPos.y)
-                let pxX = basePos.x * scale + entry.bearing.x
-                let pxY = basePos.y * scale + entry.bearing.y
+                // Center the glyph under the cursor the same way as normal text so
+                // a full-width (CJK) character doesn't shift when the caret lands on it.
+                let fit = terminalView.glyphSlotFit(font: ctFont, glyph: glyph, columnWidth: max(1, Int(charData.width)))
+                let basePos = CGPoint(x: lineOrigin.x + cellWidth * doublePosition * CGFloat(buffer.x) + fit.dx * doublePosition,
+                                      y: lineOrigin.y + yOffset + ctPos.y + fit.dy)
+                let pxX = basePos.x * scale + entry.bearing.x * fit.scale
+                let pxY = basePos.y * scale + entry.bearing.y * fit.scale
                 let x0 = Float(pxX)
                 let y0 = Float(pxY)
-                let x1 = x0 + Float(entry.size.width)
-                let y1 = y0 + Float(entry.size.height)
+                let x1 = x0 + Float(entry.size.width * fit.scale)
+                let y1 = y0 + Float(entry.size.height * fit.scale)
 
                 let atlasSize = entry.atlasKind == .color ? colorAtlas.size : grayscaleAtlas.size
                 let u0 = Float(entry.region.x) / Float(atlasSize)

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/TerminalViewDelegate.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/TerminalViewDelegate.swift
@@ -75,6 +75,21 @@ public protocol TerminalViewDelegate: AnyObject {
     func clipboardCopy(source: TerminalView, content: Data)
     
     /**
+     * This method is invoked when the client application has issued an OSC 52
+     * query to read the clipboard contents.
+     *
+     * Returning the clipboard data allows the terminal application to read it;
+     * returning `nil` denies the request.  The host may use this callback to
+     * prompt the user for confirmation before providing clipboard data.
+     *
+     * The default implementation returns `nil` (denying the request for security).
+     *
+     * - Parameter source: identifies the instance of the terminal that sent this request
+     * - Returns: the current clipboard contents, or `nil` to deny the request
+     */
+    func clipboardRead(source: TerminalView) -> Data?
+    
+    /**
      * This method is invoked when the client application (iTerm2) has issued a OSC 1337 and
      * SwiftTerm did not handle a handler for it.
      *

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Buffer.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Buffer.swift
@@ -24,8 +24,19 @@ public final class Buffer {
     
     // this keeps incrementing even as we run out of space in _lines and trim out
     // old lines.
-    var linesTop: Int 
-    
+    var linesTop: Int
+
+    /// Monotonic count of lines that have been trimmed off the top of the
+    /// scrollback since this buffer was created or reset. Increments by one
+    /// each time output pushes a line out of a full scrollback buffer
+    /// (`Terminal.scroll`); resets to zero on hard reset (RIS) and buffer
+    /// (re)construction. Embedders can use this to anchor a scrolled-up
+    /// viewport by absolute buffer line rather than pixel offset: at the
+    /// scrollback cap the content height stays constant while rows shift,
+    /// so a pixel-based anchor drifts by one row per trimmed line.
+    public var totalLinesTrimmed: Int { linesTop }
+
+
     /// This is the index into the `lines` array that corresponds to the top row of displayed
     /// content in the terminal when the scroll is zero.   So the terminal contents that the application
     /// has access to are `lines [yBase..(yBase+rows)]`
@@ -281,6 +292,8 @@ public final class Buffer {
         xBase = 0
         _scrollTop = 0
         _scrollBottom = rows - 1
+        _marginLeft = 0
+        _marginRight = cols - 1
         linesTop = 0
         _x = 0
         _y = 0
@@ -362,6 +375,8 @@ public final class Buffer {
         _linesWithImagesCount = 0
         scrollTop = 0
         scrollBottom = rows - 1
+        marginLeft = 0
+        marginRight = cols - 1
 
         // Figure out how to do this elegantly
         // SetupTabStops ()
@@ -421,7 +436,12 @@ public final class Buffer {
             // Deal with columns increasing (reducing needs to happen after reflow)
             
             if cols < newCols {
-                for i in 0..<lines.maxLength {
+                // Iterate only the lines that exist: touching every capacity slot
+                // materializes a BufferLine per empty slot (the CircularList subscript
+                // calls makeEmpty), making resize O(scrollback capacity). Empty slots
+                // are created on demand at the buffer's current cols, so they never
+                // need resizing here.
+                for i in 0..<lines.count {
                     lines [i].resize (cols: newCols, fillData: CharData.Null)
                 }
 
@@ -503,7 +523,8 @@ public final class Buffer {
             reflow (newCols, newRows)
             // Trim the end of the line off if cols shrunk
             if cols > newCols {
-                for i in 0..<lines.maxLength {
+                // lines.count, not lines.maxLength (see the widen loop above).
+                for i in 0..<lines.count {
                     lines [i].resize (cols: newCols, fillData: CharData.Null)
                 }
             }
@@ -511,7 +532,11 @@ public final class Buffer {
         
         // DEBUG: Post-condition
         if lines.count > 0 {
-            for i in 0..<lines.maxLength {
+            // lines.count, not lines.maxLength: checking every capacity slot would
+            // materialize blank lines for the whole scrollback on every resize and,
+            // worse, they would be created at the old `cols` (updated below) and
+            // trip the abort() when widening.
+            for i in 0..<lines.count {
                 let line = lines [i]
                 if line.count < newCols {
                     print ("stop here newCols=\(newCols) but the element has: \(line.count)")

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/BufferLine.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/BufferLine.swift
@@ -21,14 +21,23 @@ public final class BufferLine: CustomDebugStringConvertible {
         /// Renders the bottom of a character, using two cells
         case doubledDown
     }
-    var isWrapped: Bool
-    var renderMode: RenderLineMode = .single
+    var isWrapped: Bool { didSet { bump() } }
+    var renderMode: RenderLineMode = .single { didSet { bump() } }
     private var data: UnsafeMutableBufferPointer<CharData>
     private var dataSize: Int
 
     private var fillCharacter: CharData //used to initialise data
 
-    var images: [TerminalImage]?
+    var images: [TerminalImage]? { didSet { bump() } }
+
+    /// Monotonically increasing counter incremented on every mutation of this line's
+    /// contents (cells, isWrapped, renderMode, images). Renderers that cache per-line
+    /// draw state can compare this counter against a cached value to detect in-place
+    /// changes without diffing individual cells.
+    public private(set) var generation: UInt64 = 0
+
+    @inline(__always)
+    private func bump() { generation &+= 1 }
 
     public init (cols: Int, fillData: CharData? = nil, isWrapped: Bool = false)
     {
@@ -97,6 +106,7 @@ public final class BufferLine: CustomDebugStringConvertible {
             } else {
                 data[index] = value
             }
+            bump()
         }
     }
 
@@ -109,6 +119,7 @@ public final class BufferLine: CustomDebugStringConvertible {
         let empty = CharData(attribute: attribute)
         data.update(repeating: empty)
         images = nil
+        bump()
     }
     /// Test whether contains any chars.
     public func hasContent (index: Int) -> Bool {
@@ -146,6 +157,7 @@ public final class BufferLine: CustomDebugStringConvertible {
                 data [i] = fillData
             }
         }
+        bump()
     }
 
     /// Removes the cells at the specified position, shifting data leftwards
@@ -165,6 +177,7 @@ public final class BufferLine: CustomDebugStringConvertible {
                 data [i] = fillData
             }
         }
+        bump()
     }
 
     /// Replaces the cells in the start to end range with the specified fill data
@@ -176,6 +189,7 @@ public final class BufferLine: CustomDebugStringConvertible {
             data [idx] = fillData
             idx += 1
         }
+        bump()
     }
 
     /// Resizes the buffer line, if the new size is larger, the empty region is filled with
@@ -186,6 +200,7 @@ public final class BufferLine: CustomDebugStringConvertible {
         if len == cols {
             return
         }
+        defer { bump() }
 
         if cols > len {
             let newBuf = UnsafeMutableBufferPointer<CharData>.allocate(capacity: cols)
@@ -237,6 +252,7 @@ public final class BufferLine: CustomDebugStringConvertible {
     public func fill (with: CharData)
     {
         data.update(repeating: with)
+        bump()
     }
 
     /// Fills the specified region of the bufferline with the specified ``CharData``
@@ -249,6 +265,7 @@ public final class BufferLine: CustomDebugStringConvertible {
         for i in 0..<len {
             data [i+atCol] = with
         }
+        bump()
     }
 
     /// Fills the current BufferLine with the contents of another BufferLine.
@@ -274,6 +291,7 @@ public final class BufferLine: CustomDebugStringConvertible {
         }
         dataSize = srcSize
         isWrapped = line.isWrapped
+        bump()
     }
 
     /// Returns the trimmed length in terms of cells used from the BufferLine
@@ -311,6 +329,7 @@ public final class BufferLine: CustomDebugStringConvertible {
                 data[dstCol + i] = src.data[srcCol + i]
             }
         }
+        bump()
     }
 
     /// Returns the contents of the line as a string in the specified range

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Colors.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Colors.swift
@@ -13,7 +13,12 @@ public enum Ansi256PaletteStrategy: Sendable {
     /// Keep the historical xterm 6x6x6 cube + grayscale ramp.
     case xterm
     /// Generate colors from base16 + terminal background/foreground using LAB interpolation.
+    /// The cube and grayscale ramp always run dark → light, swapping the anchors on light themes.
     case base16Lab
+    /// Like ``base16Lab`` but preserves the original bg → fg direction on light themes
+    /// instead of swapping to dark → light. This produces a "harmonious" palette where
+    /// the extended colors follow the theme's natural luminance ordering.
+    case base16LabHarmonious
 }
 
 /**
@@ -151,7 +156,13 @@ public class Color: Hashable {
         case .base16Lab:
             return generateBase16LabPalette(initialColors: initialColors,
                                             backgroundColor: backgroundColor,
-                                            foregroundColor: foregroundColor)
+                                            foregroundColor: foregroundColor,
+                                            harmonious: false)
+        case .base16LabHarmonious:
+            return generateBase16LabPalette(initialColors: initialColors,
+                                            backgroundColor: backgroundColor,
+                                            foregroundColor: foregroundColor,
+                                            harmonious: true)
         }
     }
 
@@ -180,25 +191,32 @@ public class Color: Hashable {
 
     private static func generateBase16LabPalette(initialColors: [Color],
                                                   backgroundColor: Color?,
-                                                  foregroundColor: Color?) -> [Color] {
+                                                  foregroundColor: Color?,
+                                                  harmonious: Bool) -> [Color] {
         guard initialColors.count >= 8 else {
             return generateXtermPalette(initialColors: initialColors)
         }
 
-        let base8 = initialColors.prefix(8)
-        let base8Lab = base8.map(LabColor.fromColor(_:))
-        let bgLab = LabColor.fromColor(backgroundColor ?? initialColors[0])
-        let fgLab = LabColor.fromColor(foregroundColor ?? initialColors[7])
+        // Anchor array: palette 0-7 with bg/fg overriding indices 0 and 7.
+        var base8Lab = Array(initialColors.prefix(8)).map(LabColor.fromColor(_:))
+        base8Lab[0] = LabColor.fromColor(backgroundColor ?? initialColors[0])
+        base8Lab[7] = LabColor.fromColor(foregroundColor ?? initialColors[7])
+
+        // Swap anchors on light themes so the ramp runs dark → light.
+        let isLightTheme = base8Lab[7].l < base8Lab[0].l
+        if isLightTheme && !harmonious {
+            base8Lab.swapAt(0, 7)
+        }
 
         var palette = initialColors
 
         // 16...231: 6x6x6 color cube via trilinear interpolation in LAB.
         for r in 0..<6 {
             let tr = Double(r) / 5.0
-            let c0 = LabColor.lerp(tr, bgLab, base8Lab[1])
+            let c0 = LabColor.lerp(tr, base8Lab[0], base8Lab[1])
             let c1 = LabColor.lerp(tr, base8Lab[2], base8Lab[3])
             let c2 = LabColor.lerp(tr, base8Lab[4], base8Lab[5])
-            let c3 = LabColor.lerp(tr, base8Lab[6], fgLab)
+            let c3 = LabColor.lerp(tr, base8Lab[6], base8Lab[7])
 
             for g in 0..<6 {
                 let tg = Double(g) / 5.0
@@ -213,10 +231,10 @@ public class Color: Hashable {
             }
         }
 
-        // 232...255: grayscale ramp interpolated from background to foreground.
+        // 232...255: grayscale ramp from dark to light.
         for i in 0..<24 {
             let t = Double(i + 1) / 25.0
-            let c = LabColor.lerp(t, bgLab, fgLab)
+            let c = LabColor.lerp(t, base8Lab[0], base8Lab[7])
             palette.append(c.toColor())
         }
 

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Documentation.docc/Customization.md
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Documentation.docc/Customization.md
@@ -191,8 +191,13 @@ Key options:
 | `kittyImageCacheLimitBytes` | 320 MB | Memory limit for Kitty image cache |
 | `ansi256PaletteStrategy` | `.base16Lab` | 256-color palette generation strategy |
 
-The `.base16Lab` strategy is based on the palette-generation write-up by
+The `.base16Lab` and `.base16LabHarmonious` strategies are based on the
+palette-generation write-up by
 [Jake Stewart](https://gist.github.com/jake-stewart/0a8ea46159a7da2c808e5be2177e1783).
+
+Use `.base16Lab` to keep the generated cube and grayscale ramp ordered dark to
+light even on light themes. Use `.base16LabHarmonious` to preserve the theme's
+native background-to-foreground direction instead.
 
 ## Rendering Options
 

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/EscapeSequenceParser.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/EscapeSequenceParser.swift
@@ -416,15 +416,17 @@ public class EscapeSequenceParser {
         case 0x71: terminal.cmdSetCursorStyle(pars, collect)    // q
         case 0x72: terminal.cmdSetScrollRegion(pars, collect)   // r
         case 0x73:                                              // s
-            // Only plain CSI s is overloaded between save-cursor and DECSLRM.
-            // Sequences with intermediates must not be routed to either handler.
-            if !collect.isEmpty {
-                break
-            }
-            if terminal.marginMode {
-                terminal.cmdSetMargins(pars, collect)
-            } else {
-                terminal.cmdSaveCursor(pars, collect)
+            // Plain CSI s is overloaded between save-cursor and DECSLRM, and
+            // CSI > Ps s is XTSHIFTESCAPE. Sequences with any other intermediate
+            // must not be routed to either save-cursor or DECSLRM.
+            if collect == [UInt8 (ascii: ">")] {
+                terminal.cmdSetShiftEscape(pars)
+            } else if collect.isEmpty {
+                if terminal.marginMode {
+                    terminal.cmdSetMargins(pars, collect)
+                } else {
+                    terminal.cmdSaveCursor(pars, collect)
+                }
             }
         case 0x74: terminal.csit(pars, collect)                 // t
         case 0x75: terminal.cmdCsiU(pars, collect)              // u

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/KittyGraphics.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/KittyGraphics.swift
@@ -1649,8 +1649,16 @@ extension Terminal {
                 maxLine = max(maxLine, idx)
             }
         }
-        if !removedKeys.isEmpty, buffer === self.buffer, minLine <= maxLine {
-            updateRange(startLine: minLine, endLine: maxLine)
+        if minLine <= maxLine, buffer === self.buffer {
+            // Convert absolute buffer line indices to display-relative row indices.
+            // minLine/maxLine are indices into buffer.lines[], while updateRange expects
+            // 0-based display rows (0 = top of viewport). For the alternate screen yBase==0
+            // so they coincide, but for the normal screen with scrollback they differ.
+            let displayMin = minLine - buffer.yBase
+            let displayMax = maxLine - buffer.yBase
+            if displayMax >= 0 && displayMin < rows {
+                updateRange(startLine: max(0, displayMin), endLine: min(rows - 1, displayMax))
+            }
         }
         return removedKeys
     }

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/LocalProcess.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/LocalProcess.swift
@@ -93,6 +93,18 @@ public class LocalProcess {
     private var pendingChunkIndex: Int = 0
     private var pendingScheduled = false
     private let pendingLock = NSLock()
+    // Backpressure for the main-queue delivery path: without it the read loop
+    // re-arms unconditionally, so when the child produces output faster than
+    // the consumer queue drains it, pendingChunks grows without bound (observed
+    // ~280 MB/s with a `yes` flood against a busy main thread — multi-GB
+    // footprints in long sessions). Past the high-water mark we stop re-arming
+    // the PTY read; the kernel PTY buffer fills and the child blocks in
+    // write(), exactly like any other terminal. Reads resume once the backlog
+    // drains below the low-water mark.
+    private let pendingHighWaterBytes = 4 * 1024 * 1024
+    private let pendingLowWaterBytes = 1 * 1024 * 1024
+    private var pendingBytes = 0
+    private var readSuspendedForBackpressure = false
     
     #if false //canImport(Subprocess)
     // Swift Subprocess related properties
@@ -117,9 +129,16 @@ public class LocalProcess {
         self.usesMainQueue = self.dispatchQueue === DispatchQueue.main
     }
 
-    private func enqueueReceivedData(_ bytes: [UInt8]) {
+    // Returns false when the backlog passed the high-water mark; the caller
+    // must then skip re-arming the PTY read (drainReceivedData resumes it).
+    private func enqueueReceivedData(_ bytes: [UInt8]) -> Bool {
         pendingLock.lock()
         pendingChunks.append(bytes)
+        pendingBytes += bytes.count
+        let keepReading = pendingBytes < pendingHighWaterBytes
+        if !keepReading {
+            readSuspendedForBackpressure = true
+        }
         let shouldSchedule = !pendingScheduled
         if shouldSchedule {
             pendingScheduled = true
@@ -130,12 +149,22 @@ public class LocalProcess {
                 self?.drainReceivedData()
             }
         }
+        return keepReading
+    }
+
+    // Re-arm the PTY read loop after a backpressure pause.
+    private func resumePtyRead() {
+        guard running, let io else { return }
+        io.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+            self?.childProcessRead(done: done, data: data, errno: errno)
+        }
     }
 
     private func drainReceivedData() {
         let start = DispatchTime.now().uptimeNanoseconds
         while true {
             var chunk: [UInt8]?
+            var resumeRead = false
             pendingLock.lock()
             if pendingChunkIndex < pendingChunks.count {
                 chunk = pendingChunks[pendingChunkIndex]
@@ -144,15 +173,28 @@ public class LocalProcess {
                     pendingChunks.removeFirst(pendingChunkIndex)
                     pendingChunkIndex = 0
                 }
+                // Track backlog size; resume the paused PTY read once it
+                // drains below the low-water mark.
+                if let chunk {
+                    pendingBytes -= chunk.count
+                    if readSuspendedForBackpressure && pendingBytes <= pendingLowWaterBytes {
+                        readSuspendedForBackpressure = false
+                        resumeRead = true
+                    }
+                }
             } else {
                 pendingChunks.removeAll(keepingCapacity: true)
                 pendingChunkIndex = 0
+                pendingBytes = 0
                 pendingScheduled = false
                 pendingLock.unlock()
                 return
             }
             pendingLock.unlock()
 
+            if resumeRead {
+                resumePtyRead()
+            }
             if let chunk {
                 delegate?.dataReceived(slice: chunk[...])
             }
@@ -184,7 +226,8 @@ public class LocalProcess {
                 print ("[SEND-\(copy)] Queuing data to client: \(data) ")
             }
 
-            DispatchIO.write(toFileDescriptor: childfd, data: ddata, runningHandlerOn: DispatchQueue.global(qos: .userInitiated), handler:  { dd, errno in
+            DispatchIO.write(toFileDescriptor: childfd, data: ddata, runningHandlerOn: DispatchQueue.global(qos: .userInitiated), handler:  { [weak self] dd, errno in
+                guard let self else { return }
                 self.total += copyCount
                 if self.debugIO {
                     print ("[SEND-\(copy)] completed bytes=\(self.total)")
@@ -239,7 +282,9 @@ public class LocalProcess {
         guard let data else {
             // Re-schedule the read on transient errors to keep the chain alive
             if !done, running {
-                io?.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
+                io?.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+                    self?.childProcessRead(done: done, data: data, errno: errno)
+                }
             }
             return
         }
@@ -273,14 +318,28 @@ public class LocalProcess {
                 }
             }
         })
+        // Two gates on re-arming the next read.
+        // 1. `done`: DispatchIO invokes this handler several times per read op
+        //    (partial deliveries with done=false, then a final done=true).
+        //    Re-arming on every invocation spawns an extra concurrent read
+        //    chain per partial delivery — under a fast producer the chains
+        //    multiply and hundreds of MB of in-flight reads pile up. One op
+        //    must spawn exactly one successor.
+        // 2. backlog under the high-water mark; drainReceivedData re-arms
+        //    otherwise.
+        var keepReading = true
         if usesMainQueue {
-            enqueueReceivedData(b)
+            keepReading = enqueueReceivedData(b)
         } else {
             dispatchQueue.sync {
                 self.delegate?.dataReceived(slice: b[...])
             }
         }
-        io?.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
+        if done && keepReading {
+            io?.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+                self?.childProcessRead(done: done, data: data, errno: errno)
+            }
+        }
     }
 
 #if os(macOS)
@@ -292,6 +351,15 @@ public class LocalProcess {
         childMonitor?.cancel()
         childMonitor = nil
 #endif
+        // With [weak self] in the read/write handlers, deinit can fire even
+        // when the consumer never called terminate() explicitly. Close the
+        // DispatchIO so its cleanup handler releases the file descriptor —
+        // otherwise the FD (and the DispatchIO itself) would leak. We
+        // intentionally don't send SIGTERM here; terminate() remains the
+        // explicit API for killing the shell. deinit only guarantees that
+        // our own I/O resources don't outlive us.
+        io?.close()
+        io = nil
     }
 
     func processTerminated ()
@@ -368,8 +436,10 @@ public class LocalProcess {
             }
             io.setLimit(lowWater: 1)
             io.setLimit(highWater: readSize)
-            io.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
-            
+            io.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+                self?.childProcessRead(done: done, data: data, errno: errno)
+            }
+
             // Start subprocess with swift-subprocess asynchronously
             Task {
                 do {
@@ -467,7 +537,9 @@ public class LocalProcess {
             }
             io.setLimit(lowWater: 1)
             io.setLimit(highWater: readSize)
-            io.read(offset: 0, length: readSize, queue: readQueue, ioHandler: childProcessRead)
+            io.read(offset: 0, length: readSize, queue: readQueue) { [weak self] done, data, errno in
+                self?.childProcessRead(done: done, data: data, errno: errno)
+            }
         }
     }
 

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacCaretView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacCaretView.swift
@@ -18,6 +18,9 @@ import CoreText
 class CaretView: NSView, CALayerDelegate {
     weak var terminal: TerminalView?
     var ctline: CTLine?
+    /// Cell width of the character currently under the caret (2 for full-width
+    /// CJK). Used to center its glyph within the caret, matching the text.
+    var glyphColumnWidth: Int = 1
     var bgColor: CGColor
     var tracksFocus = true
     
@@ -45,9 +48,10 @@ class CaretView: NSView, CALayerDelegate {
     }
     
     func setText (ch: CharData) {
+        glyphColumnWidth = max(1, Int(ch.width))
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
-            string: String (character),
+            string: UnicodeUtil.textPresentationAdjusted (character),
             attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor ?? terminal?.nativeForegroundColor ?? NSColor.black))
         ctline = CTLineCreateWithAttributedString(res)
 

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacExtensions.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacExtensions.swift
@@ -1,6 +1,6 @@
 //
 //  MacExtensions.swift
-//  
+//
 //
 //  Created by Miguel de Icaza on 6/29/21.
 //
@@ -10,48 +10,51 @@ import Foundation
 import AppKit
 
 extension NSColor {
+    private static let srgbColorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+
     func getTerminalColor () -> Color {
-        guard let color = self.usingColorSpace(.deviceRGB) else {
+        guard let color = self.usingColorSpace(.sRGB) else {
             return Color.defaultForeground
         }
-        
+
         var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
         color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         return Color(red: UInt16(red*65535), green: UInt16(green*65535), blue: UInt16(blue*65535))
     }
     func inverseColor() -> NSColor {
-        guard let color = self.usingColorSpace(.deviceRGB) else {
+        guard let color = self.usingColorSpace(.sRGB) else {
             return self
         }
 
         var red: CGFloat = 0.0, green: CGFloat = 0.0, blue: CGFloat = 0.0, alpha: CGFloat = 1.0
         color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        return NSColor(calibratedRed: 1.0 - red, green: 1.0 - green, blue: 1.0 - blue, alpha: alpha)
+        let cg = CGColor(colorSpace: Self.srgbColorSpace, components: [1.0 - red, 1.0 - green, 1.0 - blue, alpha])!
+        return NSColor(cgColor: cg)!
     }
 
     /// Returns a dimmed version of the color (SGR 2 faint/dim attribute) by
     /// blending 50 % toward `background`. The result is fully opaque so that
     /// adjacent box-drawing characters tile without visible seams.
     func dimmedColor (towards background: NSColor) -> NSColor {
-        guard let fg = self.usingColorSpace(.deviceRGB),
-              let bg = background.usingColorSpace(.deviceRGB) else {
+        guard let fg = self.usingColorSpace(.sRGB),
+              let bg = background.usingColorSpace(.sRGB) else {
             return self
         }
         var fRed: CGFloat = 0.0, fGreen: CGFloat = 0.0, fBlue: CGFloat = 0.0, fAlpha: CGFloat = 1.0
         fg.getRed(&fRed, green: &fGreen, blue: &fBlue, alpha: &fAlpha)
         var bRed: CGFloat = 0.0, bGreen: CGFloat = 0.0, bBlue: CGFloat = 0.0, bAlpha: CGFloat = 1.0
         bg.getRed(&bRed, green: &bGreen, blue: &bBlue, alpha: &bAlpha)
-        return NSColor (deviceRed: (fRed + bRed) * 0.5,
-                        green: (fGreen + bGreen) * 0.5,
-                        blue: (fBlue + bBlue) * 0.5,
-                        alpha: fAlpha)
+        let cg = CGColor(colorSpace: Self.srgbColorSpace,
+                         components: [(fRed + bRed) * 0.5, (fGreen + bGreen) * 0.5, (fBlue + bBlue) * 0.5, fAlpha])!
+        return NSColor(cgColor: cg)!
     }
 
     static func make (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> NSColor
     {
-        return NSColor (deviceRed: red, green: green, blue: blue, alpha: alpha)
+        let cg = CGColor(colorSpace: srgbColorSpace, components: [red, green, blue, alpha])!
+        return NSColor(cgColor: cg)!
     }
-    
+
     static func make (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) -> TTColor
     {
         return NSColor (
@@ -63,12 +66,13 @@ extension NSColor {
 
     static func make (color: Color) -> NSColor
     {
-        return NSColor (deviceRed: CGFloat (color.red) / 65535.0,
-                        green: CGFloat (color.green) / 65535.0,
-                        blue: CGFloat (color.blue) / 65535.0,
-                        alpha: 1.0)
+        let r = CGFloat(color.red) / 65535.0
+        let g = CGFloat(color.green) / 65535.0
+        let b = CGFloat(color.blue) / 65535.0
+        let cg = CGColor(colorSpace: srgbColorSpace, components: [r, g, b, 1.0])!
+        return NSColor(cgColor: cg)!
     }
-    
+
     static func transparent () -> NSColor {
         return NSColor (calibratedWhite: 0, alpha: 0)
     }
@@ -89,7 +93,7 @@ extension NSView {
 
        return Array(UnsafeBufferPointer(start: rectsPtr, count: count))
      }
-    
+
     public func pending(_ msg: String = "PENDING RECTS") {
         print (msg)
         for x in rectsBeingDrawn() {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacLocalTerminalView.swift
@@ -112,6 +112,13 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalPr
         }
     }
     
+    public func clipboardRead(source: TerminalView) -> Data? {
+        guard let str = NSPasteboard.general.string(forType: .string) else {
+            return nil
+        }
+        return str.data(using: .utf8)
+    }
+    
     /**
      * Invoke this method to notify the processDelegate of the new title for the terminal window
      */
@@ -189,8 +196,10 @@ open class LocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalPr
      */
     open func getWindowSize () -> winsize
     {
-        let f: CGRect = self.frame
-        return winsize(ws_row: UInt16(terminal.rows), ws_col: UInt16(terminal.cols), ws_xpixel: UInt16 (f.width), ws_ypixel: UInt16 (f.height))
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1
+        let pxW = Int((cellDimension?.width ?? 0) * CGFloat(terminal.cols) * scale)
+        let pxH = Int((cellDimension?.height ?? 0) * CGFloat(terminal.rows) * scale)
+        return winsize(ws_row: UInt16(terminal.rows), ws_col: UInt16(terminal.cols), ws_xpixel: UInt16(pxW), ws_ypixel: UInt16(pxH))
     }
 }
 

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -17,6 +17,9 @@ import Carbon.HIToolbox
 #if canImport(MetalKit)
 import MetalKit
 #endif
+#if canImport(os)
+import os.log
+#endif
 
 /**
  * TerminalView provides an AppKit front-end to the `Terminal` termininal emulator.
@@ -55,6 +58,94 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         UInt16(kVK_DownArrow),
         UInt16(kVK_UpArrow)
     ]
+
+    // Per-window state for the macOS 26 mouse-moved fallback. `acceptsMouseMovedEvents`
+    // is an NSWindow-wide setting and a single `.mouseMoved` local monitor is enough
+    // to service every terminal view in the window, so this state is shared per window
+    // rather than per view (multiple terminal views can share a window, e.g. a
+    // split-pane host). It is a reference type so the monitor and the weak view set
+    // can be mutated in place while held in the registry.
+    private final class MouseMovedFallbackWindowState {
+        // The window's `acceptsMouseMovedEvents` value before we turned it on, so we
+        // can put it back when the last interested terminal view stops tracking.
+        let originalAcceptsMouseMovedEvents: Bool
+        // The single local monitor servicing this window (removed with the last view).
+        var monitor: Any?
+        // The terminal views in this window that currently want move tracking.
+        let views = NSHashTable<TerminalView>.weakObjects()
+
+        init(originalAcceptsMouseMovedEvents: Bool) {
+            self.originalAcceptsMouseMovedEvents = originalAcceptsMouseMovedEvents
+        }
+    }
+
+    // Guards `mouseMovedFallbackWindowStates` and the per-window state it holds. NSView
+    // deinit is expected on the main thread, but a stray off-main last release would
+    // otherwise race begin/end and corrupt the registry, so serialize all access.
+    private static let mouseMovedFallbackLock = NSLock()
+    private static var mouseMovedFallbackWindowStates: [ObjectIdentifier: MouseMovedFallbackWindowState] = [:]
+
+    private static func beginWindowMouseMovedFallback(view: TerminalView, window: NSWindow) {
+        mouseMovedFallbackLock.lock()
+        defer { mouseMovedFallbackLock.unlock() }
+
+        let identifier = ObjectIdentifier(window)
+        let state: MouseMovedFallbackWindowState
+        if let existing = mouseMovedFallbackWindowStates[identifier] {
+            state = existing
+        } else {
+            state = MouseMovedFallbackWindowState(originalAcceptsMouseMovedEvents: window.acceptsMouseMovedEvents)
+            mouseMovedFallbackWindowStates[identifier] = state
+            window.acceptsMouseMovedEvents = true
+            // A single window-scoped monitor dispatches to whichever view the pointer is
+            // over. It captures only the window identifier (a value), never the window or
+            // the state, so nothing is retained. Note: local monitors do not fire while
+            // the application is inactive, so background mouse-move reporting that the old
+            // `.activeAlways` tracking area provided is not available on macOS 26.
+            state.monitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { event in
+                TerminalView.dispatchWindowMouseMoved(event, windowIdentifier: identifier)
+                // Never consume the event: sibling/overlay `.mouseMoved` tracking areas and
+                // AppKit's normal first-responder delivery must still see it.
+                return event
+            }
+        }
+        state.views.add(view)
+    }
+
+    // `window` may be nil if it was deallocated before the view's deinit ran (ARC zeroes
+    // the weak reference first). The identifier still lets us drop the registry entry so a
+    // later NSWindow reusing the same address does not inherit stale state.
+    private static func endWindowMouseMovedFallback(view: TerminalView, identifier: ObjectIdentifier, window: NSWindow?) {
+        mouseMovedFallbackLock.lock()
+        defer { mouseMovedFallbackLock.unlock() }
+
+        guard let state = mouseMovedFallbackWindowStates[identifier] else { return }
+        state.views.remove(view)
+        guard state.views.allObjects.isEmpty else { return }
+
+        mouseMovedFallbackWindowStates.removeValue(forKey: identifier)
+        if let monitor = state.monitor {
+            NSEvent.removeMonitor(monitor)
+            state.monitor = nil
+        }
+        // Restore the original setting only if it is still the `true` we wrote. If the host
+        // changed it out from under us we leave its choice in place rather than clobber it.
+        if let window, window.acceptsMouseMovedEvents {
+            window.acceptsMouseMovedEvents = state.originalAcceptsMouseMovedEvents
+        }
+    }
+
+    // Called on the main thread from the per-window monitor. Delivers the move to every
+    // terminal view in the window; each view decides whether the pointer is over it.
+    private static func dispatchWindowMouseMoved(_ event: NSEvent, windowIdentifier: ObjectIdentifier) {
+        mouseMovedFallbackLock.lock()
+        let views = mouseMovedFallbackWindowStates[windowIdentifier]?.views.allObjects ?? []
+        mouseMovedFallbackLock.unlock()
+
+        for view in views {
+            view.handleWindowMouseMoved(event)
+        }
+    }
 
     struct FontSet {
         public let normal: NSFont
@@ -113,14 +204,34 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     private var findBarOptions: SearchOptions = SearchOptions()
     var debug: TerminalDebugView?
     var pendingDisplay: Bool = false
+    /// Output received shortly after local input is likely echo or prompt redraw;
+    /// render it without the 16.67ms frame-rate throttle so typing feels responsive.
+    var lastUserInputUptimeNs: UInt64 = 0
+    /// Guards lastUserInputUptimeNs, which is written on the main thread and
+    /// read from the (possibly background) feed thread.
+    let userInputLock = NSLock()
+    let interactiveInputDisplayWindowNs: UInt64 = 150_000_000
 #if canImport(MetalKit)
     var metalView: MTKView?
     var metalRenderer: MetalTerminalRenderer?
     /// Experimental GPU path: CoreText glyph atlas + Metal quads.
     /// Limitations: image caching is basic; GPU path is still evolving.
     private var useMetalRenderer = false
+    /// The NSWindow that the current `metalView`'s CAMetalLayer is bound to.
+    /// CAMetalLayer's binding to a window's WindowServer surface doesn't
+    /// survive being reparented across NSWindow instances — `present(_:)`
+    /// silently no-ops on the new window, leaving the terminal frozen on its
+    /// last frame. When `viewDidMoveToWindow` fires with a different window,
+    /// we rebuild the MTKView so a fresh CAMetalLayer binds to it.
+    private weak var metalBoundWindow: NSWindow?
     var metalDirtyRange: ClosedRange<Int>?
     var pendingMetalDisplay: Bool = false
+    /// The cursor position last submitted to the Metal renderer. Used to
+    /// detect pure cursor-only moves (no rows dirty) such as the
+    /// CSI Ps C / CSI Ps D sequences shells emit in response to Option+Arrow
+    /// word jumps, which would otherwise leave the cursor visually stuck
+    /// because `MTKView` is paused and only redraws on demand.
+    var lastRenderedCursor: (x: Int, y: Int, hidden: Bool)?
     /// Controls how the Metal renderer builds GPU buffers each frame.
     ///
     /// The default is ``MetalBufferingMode/perRowPersistent``, which caches
@@ -131,6 +242,19 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     /// You can change this property at any time; the renderer picks up the
     /// new mode on the next frame.
     public var metalBufferingMode: MetalBufferingMode = .perRowPersistent
+
+    /// Overrides the backing scale used by the Metal renderer.
+    ///
+    /// Client applications that apply their own view transforms can set this
+    /// to the effective on-screen pixels-per-point value so Metal rasterizes
+    /// glyphs at the same scale the transformed view is displayed at.
+    public var metalScaleFactorOverride: CGFloat? {
+        didSet {
+            guard oldValue != metalScaleFactorOverride else { return }
+            guard useMetalRenderer else { return }
+            requestMetalDisplay()
+        }
+    }
 
     /// Whether the terminal view is currently using the Metal GPU renderer.
     ///
@@ -143,7 +267,14 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
 
     var cellDimension: CellDimension!
     var caretView: CaretView!
+    var _fontSmoothing: Bool = true
+    var _lineSpacing: CGFloat = 1.0
     public var terminal: Terminal!
+
+    /// Marked (uncommitted) text from an input source (IME, dictation, etc.).
+    private var markedTextStorage: NSAttributedString?
+    private var markedSelectedRange: NSRange = NSRange(location: NSNotFound, length: 0)
+    private var markedTextOverlay: NSTextField?
     private var progressBarView: TerminalProgressBarView?
     private var progressReportTimer: Timer?
     private var lastProgressValue: UInt8?
@@ -265,29 +396,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             guard let device = MTLCreateSystemDefaultDevice() else {
                 throw MetalError.deviceUnavailable
             }
-            let mtkView = MTKView(frame: bounds, device: device)
-            mtkView.autoresizingMask = [.width, .height]
-            mtkView.isPaused = true
-            mtkView.enableSetNeedsDisplay = true
-            mtkView.framebufferOnly = true
-            mtkView.colorPixelFormat = .bgra8Unorm
+            let mtkView = makeMetalView(frame: bounds, device: device)
             let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: self)
             mtkView.delegate = renderer
-            if let caretView = caretView {
-                addSubview(mtkView, positioned: .below, relativeTo: caretView)
-                caretView.disableAnimations()
-                caretView.isHidden = true
-            } else {
-                addSubview(mtkView, positioned: .below, relativeTo: nil)
-            }
+            insertMetalView(mtkView, replacing: nil)
             metalView = mtkView
             metalRenderer = renderer
+            metalBoundWindow = window
             needsDisplay = false
             mtkView.setNeedsDisplay(mtkView.bounds)
         } else {
+            metalView?.delegate = nil
             metalView?.removeFromSuperview()
             metalView = nil
             metalRenderer = nil
+            metalBoundWindow = nil
             if let caretView = caretView {
                 caretView.isHidden = false
                 caretView.updateCursorStyle()
@@ -295,7 +418,145 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             needsDisplay = true
         }
     }
+
+    func metalRenderingScaleFactor() -> CGFloat {
+        max(1, metalScaleFactorOverride ?? backingScaleFactor())
+    }
+
+    /// Builds an MTKView configured for terminal rendering. Used by both
+    /// initial Metal enablement and `rebindMetalRendererToWindow` so the two
+    /// paths can never drift out of sync on MTKView configuration.
+    private func makeMetalView(frame: CGRect, device: MTLDevice) -> MTKView {
+        let mtkView = MTKView(frame: frame, device: device)
+        mtkView.autoresizingMask = [.width, .height]
+        mtkView.isPaused = true
+        mtkView.enableSetNeedsDisplay = true
+        mtkView.autoResizeDrawable = false
+        mtkView.framebufferOnly = true
+        mtkView.colorPixelFormat = .bgra8Unorm
+        // Tag the metal layer with sRGB so the compositor color-manages our
+        // pixels the same way it color-manages the layer-backed NSView
+        // (whose backing store is in the display colorspace). Without this,
+        // CAMetalLayer is untagged and our raw bytes are treated as
+        // already-in-display-gamut, producing oversaturated colors on
+        // wide-gamut displays — most visible on selection highlights and
+        // any non-default cell backgrounds. NSColor components resolved via
+        // `usingColorSpace(.deviceRGB)` are sRGB-encoded on modern macOS,
+        // so this is the colorspace they actually live in.
+        if let metalLayer = mtkView.layer as? CAMetalLayer {
+            metalLayer.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
+        }
+        return mtkView
+    }
+
+    /// Inserts the Metal view into the view hierarchy with the correct
+    /// z-order: below the caret (which is hidden while Metal owns the
+    /// cursor), with the scroller above it. When there is no caret view
+    /// and `replacing` is non-nil, the new view takes the old one's
+    /// z-position instead. Actually removing the old view is the caller's
+    /// responsibility — the rebind path defers removal until after the new
+    /// view has drawn its first frame so the hierarchy is never empty.
+    private func insertMetalView(_ newView: MTKView, replacing oldView: MTKView?) {
+        if let caretView = caretView {
+            addSubview(newView, positioned: .below, relativeTo: caretView)
+            caretView.disableAnimations()
+            caretView.isHidden = true
+        } else if let oldView = oldView {
+            addSubview(newView, positioned: .above, relativeTo: oldView)
+        } else {
+            addSubview(newView, positioned: .below, relativeTo: nil)
+        }
+        if let scroller = scroller {
+            addSubview(scroller, positioned: .above, relativeTo: newView)
+        }
+    }
+
+    /// Swaps in a fresh MTKView (and therefore a fresh CAMetalLayer) bound
+    /// to the current window's CAContext.
+    ///
+    /// CAMetalLayer's WindowServer binding does not survive being reparented
+    /// across NSWindow instances. After the reparent, `present(_:)` silently
+    /// no-ops on the new window and the terminal stays frozen on its last
+    /// frame. Apple exposes no public API to rebind an existing layer to a
+    /// new context, so the only reliable fix is to recreate the MTKView.
+    ///
+    /// To avoid the visible CoreGraphics-fallback flash that a naive
+    /// disable/enable toggle produces, the new view is built and inserted
+    /// before the old one is removed, and we force a synchronous draw plus a
+    /// belt-and-braces `setNeedsDisplay` so the new layer has content the
+    /// moment it is in the hierarchy.
+    ///
+    /// On failure (renderer init throws), we fall back to CoreGraphics
+    /// rendering rather than leaving a frozen Metal view in place — a
+    /// degraded but responsive terminal beats a dead one.
+    private func rebindMetalRendererToWindow(_ targetWindow: NSWindow) {
+        guard useMetalRenderer, let oldView = metalView else { return }
+        // Reuse the old view's MTLDevice when possible so we don't churn
+        // GPUs unnecessarily on multi-GPU or eGPU setups.
+        guard let device = oldView.device ?? MTLCreateSystemDefaultDevice() else {
+            disableMetalRendererAfterRebindFailure(error: MetalError.deviceUnavailable)
+            return
+        }
+
+        let newView = makeMetalView(frame: oldView.frame, device: device)
+
+        let newRenderer: MetalTerminalRenderer
+        do {
+            newRenderer = try MetalTerminalRenderer(view: newView, terminalView: self)
+        } catch {
+            disableMetalRendererAfterRebindFailure(error: error)
+            return
+        }
+        newView.delegate = newRenderer
+
+        // Critical sequence: the new layer must have visible content before
+        // the old view is removed. Force a synchronous draw, plus a
+        // `setNeedsDisplay` belt-and-braces in case the synchronous draw bails
+        // out (e.g. the new layer hasn't acquired its first drawable yet).
+        insertMetalView(newView, replacing: oldView)
+        newView.draw()
+        newView.setNeedsDisplay(newView.bounds)
+
+        oldView.delegate = nil
+        oldView.removeFromSuperview()
+
+        metalView = newView
+        metalRenderer = newRenderer
+        metalBoundWindow = targetWindow
+    }
+
+    /// Tears down the Metal renderer and reverts to CoreGraphics rendering
+    /// after an unrecoverable rebind failure. Keeps the terminal usable when
+    /// the GPU path can't be restored.
+    private func disableMetalRendererAfterRebindFailure(error: Error) {
+#if canImport(os)
+        os_log("SwiftTerm: Metal renderer rebind failed; falling back to CoreGraphics: %{public}@",
+               type: .error, String(describing: error))
 #endif
+        metalView?.delegate = nil
+        metalView?.removeFromSuperview()
+        metalView = nil
+        metalRenderer = nil
+        metalBoundWindow = nil
+        useMetalRenderer = false
+        if let caretView = caretView {
+            caretView.isHidden = false
+            caretView.updateCursorStyle()
+        }
+        needsDisplay = true
+    }
+#endif
+
+    open override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        startWindowMouseMovedFallback()
+#if canImport(MetalKit)
+        guard useMetalRenderer, let currentWindow = window else { return }
+        if currentWindow !== metalBoundWindow {
+            rebindMetalRendererToWindow(currentWindow)
+        }
+#endif
+    }
     
     func startDisplayUpdates ()
     {
@@ -310,6 +571,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     var becomeMainObserver, resignMainObserver: NSObjectProtocol?
     
     deinit {
+        stopWindowMouseMovedFallback()
         if let becomeMainObserver {
             NotificationCenter.default.removeObserver (becomeMainObserver)
         }
@@ -506,11 +768,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         }
     }
 
-    let scrollerStyle: NSScroller.Style = .legacy
+    /// Style for the terminal's scroll indicator. Defaults to `.overlay` which auto-hides.
+    /// Set to `.legacy` for an always-visible scrollbar.
+    public var scrollerStyle: NSScroller.Style = .overlay {
+        didSet {
+            scroller?.scrollerStyle = scrollerStyle
+            if let scroller {
+                let width = NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollerStyle)
+                scroller.constraints.first(where: { $0.firstAttribute == .width })?.constant = width
+            }
+        }
+    }
 
     func getScrollerFrame() -> CGRect {
-        let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollerStyle)
-        return NSRect(x: bounds.maxX - scrollerWidth, y: 0, width: scrollerWidth, height: bounds.height)
+        let width = reservedScrollerWidth
+        return NSRect(x: bounds.maxX - width, y: 0, width: width, height: bounds.height)
     }
 
     func setupScroller()
@@ -563,17 +835,21 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollerStyle)
     }
 
+    private var reservedScrollerWidth: CGFloat {
+        scroller?.isHidden == true ? 0 : scrollerWidth
+    }
+
     /**
      * Given the current set of columns and rows returns a frame that would host this control.
      */
     open func getOptimalFrameSize () -> NSRect
     {
-        return NSRect (x: 0, y: 0, width: cellDimension.width * CGFloat(terminal.cols) + scrollerWidth, height: cellDimension.height * CGFloat(terminal.rows))
+        return NSRect (x: 0, y: 0, width: cellDimension.width * CGFloat(terminal.cols) + reservedScrollerWidth, height: cellDimension.height * CGFloat(terminal.rows))
     }
 
     func getEffectiveWidth (size: CGSize) -> CGFloat
     {
-        return (size.width - scrollerWidth)
+        max(0, size.width - reservedScrollerWidth)
     }
     
     open func scrolled(source terminal: Terminal, yDisp: Int) {
@@ -744,6 +1020,15 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // Tracking object, maintained by `startTracking` and `deregisterTrackingInterest`
     var tracking: NSTrackingArea? = nil
+
+    // macOS 26 can synthesize left-mouse-down events while a tracking area asks
+    // for `.mouseMoved`.  Keep using the area for enter/exit notifications, and
+    // receive movement through a shared per-window monitor instead (see
+    // `MouseMovedFallbackWindowState`).  We remember the window we registered
+    // with so we can unregister; the identifier is stored separately as a value
+    // so cleanup still works if the window has already been deallocated.
+    private weak var mouseMovedFallbackWindow: NSWindow?
+    private var mouseMovedFallbackWindowIdentifier: ObjectIdentifier?
     
     // Turns on AppKit mouse event tracking - used both by the url highlighter and the mouse move,
     // when the client application has set MouseMove.anyEvent
@@ -754,9 +1039,62 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     func startTracking ()
     {
         if tracking == nil {
-            tracking = NSTrackingArea (rect: frame, options: [.activeAlways, .mouseMoved, .mouseEnteredAndExited], owner: self, userInfo: [:])
+            var options: NSTrackingArea.Options = [.activeAlways, .mouseEnteredAndExited]
+            if #available(macOS 26, *) {
+                // See the Tahoe WindowServer workaround above.
+            } else {
+                options.insert(.mouseMoved)
+            }
+            tracking = NSTrackingArea (rect: frame, options: options, owner: self, userInfo: [:])
             addTrackingArea(tracking!)
         }
+        startWindowMouseMovedFallback()
+    }
+
+    private func startWindowMouseMovedFallback() {
+        guard #available(macOS 26, *) else { return }
+        guard tracking != nil, let window else {
+            stopWindowMouseMovedFallback()
+            return
+        }
+
+        guard mouseMovedFallbackWindow !== window else { return }
+        stopWindowMouseMovedFallback()
+        mouseMovedFallbackWindow = window
+        mouseMovedFallbackWindowIdentifier = ObjectIdentifier(window)
+        TerminalView.beginWindowMouseMovedFallback(view: self, window: window)
+    }
+
+    private func stopWindowMouseMovedFallback() {
+        guard #available(macOS 26, *) else { return }
+
+        if let identifier = mouseMovedFallbackWindowIdentifier {
+            TerminalView.endWindowMouseMovedFallback(view: self, identifier: identifier, window: mouseMovedFallbackWindow)
+        }
+        mouseMovedFallbackWindow = nil
+        mouseMovedFallbackWindowIdentifier = nil
+    }
+
+    // Invoked by the shared per-window monitor for every terminal view in the window.
+    fileprivate func handleWindowMouseMoved(_ event: NSEvent) {
+        guard shouldHandleWindowMouseMoved(event) else { return }
+        // The first responder already receives `mouseMoved` through AppKit's normal
+        // dispatch (because `acceptsMouseMovedEvents` is on), so only synthesize
+        // delivery for a hovered view that is *not* the first responder; otherwise we
+        // would report the same move twice.
+        if window?.firstResponder === self { return }
+        mouseMoved(with: event)
+    }
+
+    private func shouldHandleWindowMouseMoved(_ event: NSEvent) -> Bool {
+        guard tracking != nil,
+              shouldTrackMouse(),
+              let window,
+              event.window === window else {
+            return false
+        }
+        let point = convert(event.locationInWindow, from: nil)
+        return bounds.contains(point)
     }
     
     func shouldTrackMouse () -> Bool
@@ -785,6 +1123,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
                 removeTrackingArea(tracking!)
                 tracking = nil
             }
+            stopWindowMouseMovedFallback()
         }
     }
 
@@ -800,9 +1139,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     func turnOffUrlPreview ()
     {
         if commandActive {
+            commandActive = false
             deregisterTrackingInterest()
             removePreviewUrl()
-            commandActive = false
             lastReportedLink = nil
             if linkHighlightMode == .hoverWithModifier {
                 let oldRange = linkHighlightRange
@@ -1061,38 +1400,44 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     public override func doCommand(by selector: Selector) {
         if !terminal.keyboardEnhancementFlags.isEmpty {
+            let mods: KittyKeyboardModifiers
+            if let pending = pendingKittyKeyEvent {
+                mods = kittyModifiers(from: pending.event, includeOption: optionAsMetaKey)
+            } else {
+                mods = []
+            }
             switch selector {
             case #selector(insertNewline(_:)):
-                if sendKittyFunctionalKey(.enter) { return }
+                if sendKittyFunctionalKey(.enter, modifiers: mods) { return }
             case #selector(cancelOperation(_:)):
-                if sendKittyFunctionalKey(.escape) { return }
+                if sendKittyFunctionalKey(.escape, modifiers: mods) { return }
             case #selector(deleteBackward(_:)):
-                if sendKittyFunctionalKey(.backspace) { return }
+                if sendKittyFunctionalKey(.backspace, modifiers: mods) { return }
             case #selector(moveUp(_:)):
-                if sendKittyFunctionalKey(.up) { return }
+                if sendKittyFunctionalKey(.up, modifiers: mods) { return }
             case #selector(moveDown(_:)):
-                if sendKittyFunctionalKey(.down) { return }
+                if sendKittyFunctionalKey(.down, modifiers: mods) { return }
             case #selector(moveLeft(_:)):
-                if sendKittyFunctionalKey(.left) { return }
+                if sendKittyFunctionalKey(.left, modifiers: mods) { return }
             case #selector(moveRight(_:)):
-                if sendKittyFunctionalKey(.right) { return }
+                if sendKittyFunctionalKey(.right, modifiers: mods) { return }
             case #selector(insertTab(_:)):
-                if sendKittyFunctionalKey(.tab) { return }
+                if sendKittyFunctionalKey(.tab, modifiers: mods) { return }
             case #selector(insertBacktab(_:)):
-                if sendKittyFunctionalKey(.tab, modifiers: [.shift]) { return }
+                if sendKittyFunctionalKey(.tab, modifiers: mods.union([.shift])) { return }
             case #selector(moveToBeginningOfLine(_:)):
-                if sendKittyFunctionalKey(.home) { return }
+                if sendKittyFunctionalKey(.home, modifiers: mods) { return }
             case #selector(scrollToBeginningOfDocument(_:)):
-                if sendKittyFunctionalKey(.home) { return }
+                if sendKittyFunctionalKey(.home, modifiers: mods) { return }
             case #selector(moveToEndOfLine(_:)):
-                if sendKittyFunctionalKey(.end) { return }
+                if sendKittyFunctionalKey(.end, modifiers: mods) { return }
             case #selector(scrollToEndOfDocument(_:)):
-                if sendKittyFunctionalKey(.end) { return }
+                if sendKittyFunctionalKey(.end, modifiers: mods) { return }
             case #selector(scrollPageUp(_:)):
                 fallthrough
             case #selector(pageUp(_:)):
                 if terminal.applicationCursor {
-                    if sendKittyFunctionalKey(.pageUp) { return }
+                    if sendKittyFunctionalKey(.pageUp, modifiers: mods) { return }
                 } else {
                     pageUp()
                     return
@@ -1101,7 +1446,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
                 fallthrough
             case #selector(pageDown(_:)):
                 if terminal.applicationCursor {
-                    if sendKittyFunctionalKey(.pageDown) { return }
+                    if sendKittyFunctionalKey(.pageDown, modifiers: mods) { return }
                 } else {
                     pageDown()
                     return
@@ -1175,6 +1520,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
     
     func insertText(_ string: Any, replacementRange: NSRange, isPaste: Bool) {
+        markedTextStorage = nil
+        markedSelectedRange = NSRange(location: NSNotFound, length: 0)
+        updateMarkedTextOverlay()
         if let str = string as? NSString {
             if !terminal.keyboardEnhancementFlags.isEmpty {
                 if isPaste, terminal.bracketedPasteMode {
@@ -1188,6 +1536,28 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
                 pendingKittyKeyEvent = nil
                 kittyIsComposing = false
                 let text = str as String
+
+                // Option acting as a compose/AltGr layer (e.g. on the Czech
+                // layout Option+2 produces "@" while the bare key is "ě"). When
+                // optionAsMetaKey is off, Option is not Meta, so the keypress
+                // simply produced a normal character. Encoding it as a kitty
+                // CSI-u event keys off charactersIgnoringModifiers (the
+                // base-layout glyph, "ě") and only carries the composed "@" as
+                // associated text, so apps that negotiate reportAlternates or
+                // reportAllKeys without reportText (e.g. OpenCode) receive the
+                // base key and the composed glyph is lost. Send the composed
+                // text directly instead, matching how kitty/Ghostty handle
+                // AltGr layers.
+                if let pendingEvent,
+                   !optionAsMetaKey,
+                   pendingEvent.event.modifierFlags.contains(.option),
+                   !pendingEvent.event.modifierFlags.contains(.control),
+                   !pendingEvent.event.modifierFlags.contains(.command),
+                   isPlainPrintableText(text) {
+                    send(txt: text)
+                    return
+                }
+
                 let kittyEvent: KittyKeyEvent
                 if text.unicodeScalars.count == 1,
                    let pendingEvent,
@@ -1211,9 +1581,76 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         // needsDisplay = true
     }
     
+    /// Whether `text` is a non-empty run of printable scalars (no C0/C1 control
+    /// characters). Used to decide when Option-composed input can be sent as
+    /// literal UTF-8 rather than encoded as a kitty key event.
+    private func isPlainPrintableText(_ text: String) -> Bool {
+        guard !text.isEmpty else { return false }
+        for scalar in text.unicodeScalars {
+            if scalar.value < 0x20 || (scalar.value >= 0x7f && scalar.value <= 0x9f) {
+                return false
+            }
+        }
+        return true
+    }
+
     // NSTextInputClient protocol implementation
     open func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        switch string {
+        case let attributed as NSAttributedString:
+            markedTextStorage = attributed.length > 0 ? attributed : nil
+        case let plain as String:
+            markedTextStorage = plain.isEmpty ? nil : NSAttributedString(string: plain)
+        default:
+            markedTextStorage = nil
+        }
+        markedSelectedRange = selectedRange
         kittyIsComposing = true
+        updateMarkedTextOverlay()
+    }
+
+    /// Shows or hides a floating overlay that previews in-progress marked text
+    /// (e.g. dictation hypotheses or IME composition) at the current cursor position.
+    private func updateMarkedTextOverlay() {
+        guard let markedTextStorage, markedTextStorage.length > 0 else {
+            markedTextOverlay?.removeFromSuperview()
+            markedTextOverlay = nil
+            return
+        }
+
+        let overlay: NSTextField
+        if let existing = markedTextOverlay {
+            overlay = existing
+        } else {
+            overlay = NSTextField(labelWithString: "")
+            overlay.isBezeled = false
+            overlay.isEditable = false
+            overlay.drawsBackground = true
+            overlay.backgroundColor = nativeBackgroundColor.withAlphaComponent(0.9)
+            overlay.wantsLayer = true
+            overlay.layer?.cornerRadius = 3
+            addSubview(overlay, positioned: .above, relativeTo: nil)
+            markedTextOverlay = overlay
+        }
+
+        // Style the text to match the terminal font/colors with an underline.
+        let displayString = NSMutableAttributedString(attributedString: markedTextStorage)
+        let fullRange = NSRange(location: 0, length: displayString.length)
+        displayString.addAttributes([
+            .font: font,
+            .foregroundColor: nativeForegroundColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ], range: fullRange)
+        overlay.attributedStringValue = displayString
+
+        // Position at the caret.
+        overlay.sizeToFit()
+        overlay.frame.origin = caretView.frame.origin
+
+        // Clamp to view bounds so the overlay doesn't extend off-screen.
+        if overlay.frame.maxX > bounds.maxX {
+            overlay.frame.origin.x = max(0, bounds.maxX - overlay.frame.width)
+        }
     }
 
     private func kittyEncoder() -> KittyKeyboardEncoder {
@@ -1587,54 +2024,62 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // NSTextInputClient protocol implementation
     open func unmarkText() {
+        markedTextStorage = nil
+        markedSelectedRange = NSRange(location: NSNotFound, length: 0)
         kittyIsComposing = false
+        updateMarkedTextOverlay()
     }
     
     // NSTextInputClient protocol implementation
     open func selectedRange() -> NSRange {
-        guard let selection = self.selection, selection.active else {
-            // This means "no selection":
-            return NSRange.empty
+        if let selection = self.selection, selection.active {
+            let displayBuffer = terminal.displayBuffer
+            var startLocation = (selection.start.row * displayBuffer.rows) + selection.start.col
+            var endLocation = (selection.end.row * displayBuffer.rows) + selection.end.col
+            if startLocation > endLocation {
+                swap(&startLocation, &endLocation)
+            }
+            let length = endLocation - startLocation
+            if length > 0 {
+                return NSRange(location: startLocation, length: length)
+            }
         }
-        
-        let displayBuffer = terminal.displayBuffer
-        var startLocation = (selection.start.row * displayBuffer.rows) + selection.start.col
-        var endLocation = (selection.end.row * displayBuffer.rows) + selection.end.col
-        if startLocation > endLocation {
-            swap(&startLocation, &endLocation)
-        }
-        let length = endLocation - startLocation
-        if length == 0 {
-            return NSRange.empty
-        }
-        return NSRange(location: startLocation, length: endLocation - startLocation)
+        // Return the cursor position as a zero-length selection (insertion point).
+        // The input system needs a valid location to anchor dictation and IME input.
+        let cursorLocation = terminal.buffer.y * terminal.cols + terminal.buffer.x
+        return NSRange(location: cursorLocation, length: 0)
     }
     
     // NSTextInputClient protocol implementation
     open func markedRange() -> NSRange {
-        print ("markedRange: This should return the actual range from the selection")
-        
-        // This means "no marked" - when we fix, we should address
-        return NSRange.empty
+        guard let marked = markedTextStorage else {
+            return NSRange.empty
+        }
+        return NSRange(location: 0, length: marked.length)
     }
     
     // NSTextInputClient protocol implementation
     open func hasMarkedText() -> Bool {
-        // print ("hasMarkedText: This should return the actual range from the selection")
-        // TODO
-        return false
+        markedTextStorage != nil
     }
     
     // NSTextInputClient protocol implementation
     open func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
-        print ("Attribuetd string")
+        // Return the marked text when the requested range overlaps it.
+        if let marked = markedTextStorage, range.location != NSNotFound, range.location < marked.length {
+            let clampedLength = min(range.length, marked.length - range.location)
+            if clampedLength > 0 {
+                let clampedRange = NSRange(location: range.location, length: clampedLength)
+                actualRange?.pointee = clampedRange
+                return marked.attributedSubstring(from: clampedRange)
+            }
+        }
         return nil
     }
-    
+
     // NSTextInputClient Protocol implementation
     open func validAttributesForMarkedText() -> [NSAttributedString.Key] {
-        // TODO print ("validAttributesForMarkedText: This should return the actual range from the selection")
-        return []
+        [.underlineStyle, .markedClauseSegment, .glyphInfo]
     }
     
     // NSTextInputClient protocol implementation
@@ -1650,8 +2095,10 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // NSTextInputClient protocol implementation
     open func characterIndex(for point: NSPoint) -> Int {
-        print ("characterIndex:for point: This should return the actual range from the selection")
-        return NSNotFound
+        let local = convert(point, from: nil)
+        let col = Int(local.x / cellDimension.width)
+        let row = Int((bounds.height - local.y) / cellDimension.height)
+        return row * terminal.cols + col
     }
     
     open func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
@@ -1946,7 +2393,34 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
     
     private var autoScrollDelta = 0
-    // Callback from when the mouseDown autoscrolling timer goes off
+    private var selectionAutoScrollTimer: Timer?
+    // Last mouse location (view coordinates) seen during a selection drag, used
+    // to re-extend the selection as the auto-scroll timer advances the viewport
+    // while the pointer is held still past the top or bottom edge.
+    private var lastSelectionDragPoint: CGPoint?
+
+    private func startSelectionAutoScrollTimer() {
+        if selectionAutoScrollTimer != nil {
+            return
+        }
+        // The timer has to fire while the mouse is being tracked: during a drag
+        // the run loop is in .eventTracking mode, in which timers scheduled in
+        // the default mode are suspended. Add it in .common modes so it keeps
+        // ticking while the button is held down at the edge.
+        let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] t in
+            self?.scrollingTimerElapsed(source: t)
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        selectionAutoScrollTimer = timer
+    }
+
+    private func stopSelectionAutoScrollTimer() {
+        selectionAutoScrollTimer?.invalidate()
+        selectionAutoScrollTimer = nil
+    }
+
+    // Callback from the selection auto-scroll timer: advance the viewport while
+    // the pointer is held past an edge, and grow the selection to match.
     private func scrollingTimerElapsed (source: Timer)
     {
         if autoScrollDelta == 0 {
@@ -1955,12 +2429,22 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         if autoScrollDelta < 0 {
             scrollUp(lines: autoScrollDelta * -1)
         } else {
-            scrollUp(lines: autoScrollDelta)
+            scrollDown(lines: autoScrollDelta)
         }
+        // Extend the selection to the pointer's position under the new viewport.
+        if selection.active, let point = lastSelectionDragPoint {
+            let hit = calculateMouseHit(at: point).grid
+            selection.dragExtend(bufferPosition: Position(col: hit.col, row: hit.row))
+        }
+        setNeedsDisplay(bounds)
     }
     
-    public override func mouseDown(with event: NSEvent) {
-        if allowMouseReporting && terminal.mouseMode.sendButtonPress() {
+    private func shiftBypassesMouseReporting(for event: NSEvent) -> Bool {
+        event.modifierFlags.contains(.shift) && !terminal.mouseShiftCapture
+    }
+
+    open override func mouseDown(with event: NSEvent) {
+        if allowMouseReporting && !shiftBypassesMouseReporting(for: event) && terminal.mouseMode.sendButtonPress() {
             sharedMouseEvent(with: event)
             return
         }
@@ -1998,14 +2482,17 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     var didSelectionDrag: Bool = false
     
-    public override func mouseUp(with event: NSEvent) {
+    open override func mouseUp(with event: NSEvent) {
+        stopSelectionAutoScrollTimer()
+        autoScrollDelta = 0
+        lastSelectionDragPoint = nil
         let hit = calculateMouseHit(with: event).grid
         updateHoverLink(at: hit, commandOverride: commandActive || event.modifierFlags.contains(.command))
         if let result = linkForClick(at: hit, hasCommandModifier: event.modifierFlags.contains(.command)) {
             terminalDelegate?.requestOpenLink(source: self, link: result.link, params: result.params)
             return
         }
-        if allowMouseReporting && terminal.mouseMode.sendButtonRelease() {
+        if allowMouseReporting && !shiftBypassesMouseReporting(for: event) && terminal.mouseMode.sendButtonRelease() {
             sharedMouseEvent(with: event)
             return
         }
@@ -2018,16 +2505,16 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         didSelectionDrag = false
     }
     
-    public override func mouseDragged(with event: NSEvent) {
+    open override func mouseDragged(with event: NSEvent) {
         let displayBuffer = terminal.displayBuffer
         let mouseHit = calculateMouseHit(with: event)
         let hit = mouseHit.grid
-        if allowMouseReporting {
-            if terminal.mouseMode.sendMotionEvent() {
+        if allowMouseReporting && !shiftBypassesMouseReporting(for: event) {
+            if terminal.mouseMode.sendButtonTracking() {
                 let flags = encodeMouseEvent(with: event)
                 let screenRow = max (0, min (displayBuffer.rows - 1, hit.row - displayBuffer.yDisp))
                 terminal.sendMotion(buttonFlags: flags, x: hit.col, y: screenRow, pixelX: mouseHit.pixels.col, pixelY: mouseHit.pixels.row)
-            
+
                 return
             }
             if terminal.mouseMode != .off {
@@ -2042,6 +2529,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             selection.startSelection()
         }
         didSelectionDrag = true
+        lastSelectionDragPoint = convert(event.locationInWindow, from: nil)
         autoScrollDelta = 0
         let screenRow = hit.row - displayBuffer.yDisp
         if selection.active {
@@ -2050,6 +2538,13 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             } else if screenRow >= displayBuffer.rows {
                 autoScrollDelta = calcScrollingVelocity(delta: screenRow - displayBuffer.rows)
             }
+        }
+        // Keep auto-scrolling while the pointer is held past an edge; the mouse
+        // stops emitting drag events once it stops moving, so a timer drives it.
+        if autoScrollDelta != 0 {
+            startSelectionAutoScrollTimer()
+        } else {
+            stopSelectionAutoScrollTimer()
         }
         setNeedsDisplay(bounds)
     }
@@ -2154,6 +2649,13 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
     
     public override func mouseMoved(with event: NSEvent) {
+        if #available(macOS 26, *) {
+            // On macOS 26 movement arrives via `acceptsMouseMovedEvents`, which delivers
+            // to the first responder regardless of the pointer's location. Ignore moves
+            // outside our bounds so we do not report cells the pointer is not over.
+            let point = convert(event.locationInWindow, from: nil)
+            if !bounds.contains(point) { return }
+        }
         let hit = calculateMouseHit(with: event)
         if commandActive {
             if let payload = getPayload(for: event) as? String {
@@ -2173,11 +2675,33 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
         if event.deltaY == 0 {
             return
         }
-        let velocity = calcScrollingVelocity(delta: Int (abs (event.deltaY)))
-        if event.deltaY > 0 {
-            scrollUp (lines: velocity)
+        if allowMouseReporting && !shiftBypassesMouseReporting(for: event) && terminal.mouseMode != .off {
+            let hit = calculateMouseHit(with: event)
+            let displayBuffer = terminal.displayBuffer
+            let screenRow = max (0, min (displayBuffer.rows - 1, hit.grid.row - displayBuffer.yDisp))
+            let button = event.deltaY > 0 ? 4 : 5
+            let flags = event.modifierFlags
+            let buttonFlags = terminal.encodeButton(button: button, release: false, shift: flags.contains(.shift), meta: flags.contains(.option), control: flags.contains(.control))
+            let lines = calcScrollingVelocity(delta: Int(abs(event.deltaY)))
+            for _ in 0..<lines {
+                terminal.sendEvent(buttonFlags: buttonFlags, x: hit.grid.col, y: screenRow, pixelX: hit.pixels.col, pixelY: hit.pixels.row)
+            }
+        } else if terminal.isDisplayBufferAlternate {
+            let lines = calcScrollingVelocity(delta: Int(abs(event.deltaY)))
+            for _ in 0..<lines {
+                if event.deltaY > 0 {
+                    sendKeyUp()
+                } else {
+                    sendKeyDown()
+                }
+            }
         } else {
-            scrollDown(lines: velocity)
+            let velocity = calcScrollingVelocity(delta: Int(abs(event.deltaY)))
+            if event.deltaY > 0 {
+                scrollUp(lines: velocity)
+            } else {
+                scrollDown(lines: velocity)
+            }
         }
     }
     
@@ -2322,6 +2846,7 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     func ensureCaretIsVisible ()
     {
+        guard !terminal.synchronizedOutputActive else { return }
         let displayBuffer = terminal.displayBuffer
         let realCaret = displayBuffer.y + displayBuffer.yBase
         let viewportEnd = displayBuffer.yDisp + displayBuffer.rows
@@ -2409,6 +2934,14 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     public func iTermContent (source: Terminal, content: ArraySlice<UInt8>) {
         terminalDelegate?.iTermContent(source: self, content: content)
     }
+    
+    public func clipboardCopy(source: Terminal, content: Data) {
+        terminalDelegate?.clipboardCopy(source: self, content: content)
+    }
+    
+    public func clipboardRead(source: Terminal) -> Data? {
+        return terminalDelegate?.clipboardRead(source: self)
+    }
 }
 
 
@@ -2428,6 +2961,13 @@ extension TerminalViewDelegate {
     }
     
     public func iTermContent (source: TerminalView, content: ArraySlice<UInt8>) {
+    }
+    
+    public func clipboardCopy(source: TerminalView, content: Data) {
+    }
+    
+    public func clipboardRead(source: TerminalView) -> Data? {
+        return nil
     }
 }
 #endif

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/SelectionService.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/SelectionService.swift
@@ -69,7 +69,16 @@ class SelectionService: CustomDebugStringConvertible {
     /**
      * Used to track the pivot point when selection in iOS-style selection
      */
-    public var pivot: Position? 
+    public var pivot: Position?
+
+    /**
+     * When `selectWordOrExpression` seeds a selection (a double-click), the
+     * selected range is recorded here so that a subsequent word-mode drag can
+     * pivot around the whole seed word.  Without this, dragging *backwards*
+     * past the seed word would leave `start` pinned at the seed word's start
+     * and the seed word would be dropped from the selection.
+     */
+    var wordSelectionAnchor: (start: Position, end: Position)?
 
     /**
      * Returns the selection ending point in buffer coordinates
@@ -92,6 +101,7 @@ class SelectionService: CustomDebugStringConvertible {
     {
         setSoftStart(row: row, col: col)
         selectionMode = .character
+        wordSelectionAnchor = nil
         setActiveAndNotify()
     }
         
@@ -121,6 +131,7 @@ class SelectionService: CustomDebugStringConvertible {
         end = start
         selectingRows = false
         selectionMode = .character
+        wordSelectionAnchor = nil
         setActiveAndNotify()
     }
     
@@ -270,14 +281,35 @@ class SelectionService: CustomDebugStringConvertible {
      * The position is in buffer coordinates
      */
     public func dragExtend (bufferPosition: Position) {
+        // When the selection was seeded by a double-click (word mode), pivot the
+        // drag around the whole seed word.  This keeps the seed word in the
+        // selection when the drag goes *backwards* (to the left/up) past it, and
+        // snaps both ends to word boundaries in either direction.
+        if selectionMode == .word, let anchor = wordSelectionAnchor {
+            let buffer = terminal.displayBuffer
+            if Position.compare(bufferPosition, anchor.start) == .before {
+                start = extendToWordBoundary(position: bufferPosition, in: buffer, direction: -1)
+                end = anchor.end
+            } else if Position.compare(bufferPosition, anchor.end) == .after {
+                start = anchor.start
+                end = extendToWordBoundary(position: bufferPosition, in: buffer, direction: 1)
+            } else {
+                // Still inside the seed word: keep the whole word selected.
+                start = anchor.start
+                end = anchor.end
+            }
+            setActiveAndNotify()
+            return
+        }
+
         var adjustedEnd = bufferPosition
-        
+
         // If we're in word selection mode, extend to word boundaries
         if selectionMode == .word {
             let direction = Position.compare(bufferPosition, start) == .before ? -1 : 1
             adjustedEnd = extendToWordBoundary(position: bufferPosition, in: terminal.displayBuffer, direction: direction)
         }
-        
+
         end = adjustedEnd
         setActiveAndNotify()
     }
@@ -312,6 +344,7 @@ class SelectionService: CustomDebugStringConvertible {
         end = Position(col: terminal.cols-1, row: row)
         selectingRows = true
         selectionMode = .row
+        wordSelectionAnchor = nil
         setActiveAndNotify()
     }
 
@@ -519,9 +552,10 @@ class SelectionService: CustomDebugStringConvertible {
             end = position
         }
         selectionMode = .word
+        wordSelectionAnchor = (start, end)
         setActiveAndNotify()
     }
-    
+
     /**
      * Clears the selection
      */
@@ -530,6 +564,7 @@ class SelectionService: CustomDebugStringConvertible {
         if active {
             active = false
             selectionMode = .character
+            wordSelectionAnchor = nil
         }
     }
     

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/SyncDebug.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/SyncDebug.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Opt-in trace for synchronized-output (DEC 2026) flow and display scheduling.
+/// Set `SyncDebug.enabled = true` from the host app to see events on stderr.
+enum SyncDebug {
+    public static let enabled = false
+    private static let start = DispatchTime.now().uptimeNanoseconds
+
+    @inline(__always)
+    @inlinable
+    static func log(_ event: @autoclosure () -> String) {
+        guard enabled else { return }
+        let now = DispatchTime.now().uptimeNanoseconds
+        let ms = Double(now &- start) / 1_000_000
+        let line = String(format: "[sync %9.2fms] %@\n", ms, event())
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+}

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
@@ -202,6 +202,21 @@ public protocol TerminalDelegate: AnyObject {
     func clipboardCopy(source: Terminal, content: Data)
     
     /**
+     * This method is invoked when the client application has issued an OSC 52
+     * query to read the clipboard contents.
+     *
+     * Returning the clipboard data allows the terminal application to read it;
+     * returning `nil` denies the request.  The host may use this callback to
+     * prompt the user for confirmation before providing clipboard data.
+     *
+     * The default implementation returns `nil` (denying the request for security).
+     *
+     * - Parameter source: identifies the instance of the terminal that sent this request
+     * - Returns: the current clipboard contents, or `nil` to deny the request
+     */
+    func clipboardRead(source: Terminal) -> Data?
+    
+    /**
      * Invoked when client application issues OSC 777 to show notification.
      *
      * The default implementation does nothing.
@@ -326,17 +341,15 @@ open class Terminal {
     public private(set) var buffer: Buffer
 
     private let synchronizedOutputTimeoutSeconds: TimeInterval = 1.0
-    private var synchronizedOutputActive: Bool = false
-    private var synchronizedOutputBuffer: Buffer?
-    private var synchronizedOutputBufferIsAlternate: Bool = false
+    public private(set) var synchronizedOutputActive: Bool = false
     private var synchronizedOutputTimeoutItem: DispatchWorkItem?
 
     var displayBuffer: Buffer {
-        synchronizedOutputBuffer ?? buffer
+        buffer
     }
 
     var isDisplayBufferAlternate: Bool {
-        synchronizedOutputBuffer != nil ? synchronizedOutputBufferIsAlternate : isCurrentBufferAlternate
+        isCurrentBufferAlternate
     }
     
     public var isCurrentBufferAlternate: Bool {
@@ -507,7 +520,7 @@ open class Terminal {
             tdel?.setForegroundColor(source: self, color: foregroundColor)
             settingFgColor = false
 
-            if options.ansi256PaletteStrategy == .base16Lab {
+            if options.ansi256PaletteStrategy != .xterm {
                 rebuildAnsiPalette(notifyDelegate: true)
             }
         }
@@ -522,7 +535,7 @@ open class Terminal {
             tdel?.setBackgroundColor(source: self, color: backgroundColor)
             settingBgColor = false
 
-            if options.ansi256PaletteStrategy == .base16Lab {
+            if options.ansi256PaletteStrategy != .xterm {
                 rebuildAnsiPalette(notifyDelegate: true)
             }
         }
@@ -623,6 +636,10 @@ open class Terminal {
             tdel?.mouseModeChanged (source: self)
         }
     }
+
+    /// Whether the running application has requested shift capture via XTSHIFTESCAPE (`CSI > 1 s`).
+    /// When `true`, shift+click is forwarded to the app instead of triggering local text selection.
+    public private(set) var mouseShiftCapture: Bool = false
 
     // The next four variables determine whether setting/querying should be done using utf8 or latin1
     // and whether the values should be set or queried using hex digits, rather than actual byte streams
@@ -762,7 +779,7 @@ open class Terminal {
     
     public func resetNormalBuffer() {
         normalBuffer = Buffer(cols: cols, rows: rows, tabStopWidth: tabStopWidth, scrollback: options.scrollback)
-        normalBuffer.scroll = scroll(isWrapped:)
+        normalBuffer.scroll = { [weak self] wrapped in self?.scroll(isWrapped: wrapped) }
 
         normalBuffer.fillViewportRows()
         normalBuffer.setupTabStops(tabStopWidth: tabStopWidth)
@@ -853,7 +870,8 @@ open class Terminal {
         curAttr = CharData.defaultAttr
         
         mouseMode = .off
-        
+        mouseShiftCapture = false
+
         buffer.scrollTop = 0
         buffer.scrollBottom = rows-1
         buffer.marginLeft = 0
@@ -1270,6 +1288,15 @@ open class Terminal {
                 continue
             }
 
+            // When regionalIndicatorWidth is .narrow, override individual RI width to 1.
+            // The combining logic below will widen the pair to 2 when they form a flag.
+            let narrowRI = options.regionalIndicatorWidth == .narrow
+            if narrowRI, chWidth == 2,
+               let firstScalarForRI = ch.unicodeScalars.first,
+               UnicodeUtil.isRegionalIndicator(firstScalarForRI) {
+                chWidth = 1
+            }
+
             if let firstScalar = ch.unicodeScalars.first {
                 // Check if we should try to combine this character with the previous one.
                 // This applies to:
@@ -1294,12 +1321,37 @@ open class Terminal {
                         if lastChar.unicodeScalars.last?.value == 0x200D {
                             shouldTryCombine = true
                         }
-                        // Regional indicator combining: pair two RIs into a flag emoji
+                        // Regional indicator combining: pair two RIs into a flag emoji.
+                        // In narrow mode, require adjacency (buffer.x == last.x + 1) to
+                        // prevent wrong pairing when a cell is overwritten during partial
+                        // screen repaints from multiplexers.
                         else if UnicodeUtil.isRegionalIndicator(firstScalar),
+                                (!narrowRI || buffer.x == last.x + 1),
                                 lastChar.unicodeScalars.count == 1,
                                 let lastScalar = lastChar.unicodeScalars.first,
                                 UnicodeUtil.isRegionalIndicator(lastScalar) {
                             shouldTryCombine = true
+                        }
+                    }
+                }
+
+                // In narrow RI mode, fallback for combining when lastBufferStorage is
+                // stale (e.g. multiplexer interleaving output across lines).
+                // Check buffer.x - 1 on the current line for a standalone width-1 RI.
+                if narrowRI, !shouldTryCombine, UnicodeUtil.isRegionalIndicator(firstScalar) {
+                    let prevX = buffer.x - 1
+                    if prevX >= 0 {
+                        let currentY = buffer.y + buffer.yBase
+                        let currentLine = buffer.lines [currentY]
+                        let prevCell = currentLine [prevX]
+                        if prevCell.width == 1 {
+                            let prevChar = getCharacter(for: prevCell)
+                            if prevChar.unicodeScalars.count == 1,
+                               let prevScalar = prevChar.unicodeScalars.first,
+                               UnicodeUtil.isRegionalIndicator(prevScalar) {
+                                buffer.lastBufferStorage = (currentY, prevX, cols, rows)
+                                shouldTryCombine = true
+                            }
                         }
                     }
                 }
@@ -1344,6 +1396,12 @@ open class Terminal {
                                     if oldSize == 2 && buffer.x > 0 {
                                         buffer.x -= 1
                                     }
+                                } else if narrowRI && UnicodeUtil.isRegionalIndicator(firstScalar) && oldSize == 1 && lastx + 1 < cols {
+                                    // In narrow mode, two width-1 RIs combine into a width-2 flag.
+                                    updateCharData(&cd, char: newCh, size: 2)
+                                    let empty = makeCharData(attribute: cd.attribute, code: 0, size: 0)
+                                    existingLine [lastx + 1] = empty
+                                    buffer.x += 1
                                 } else {
                                     updateCharData(&cd, char: newCh, size: Int32 (cd.width))
                                     if cd.width != oldSize {
@@ -1523,8 +1581,7 @@ open class Terminal {
         let buffer = self.buffer
         let by = buffer.y
         
-        let canScroll = buffer.x >= buffer.marginLeft && buffer.x <= buffer.marginRight
-        
+        let canScroll = !marginMode || (buffer.x >= buffer.marginLeft && buffer.x <= buffer.marginRight)
         if by == buffer.scrollBottom {
             if canScroll {
                 scroll(isWrapped: false)
@@ -1727,23 +1784,42 @@ open class Terminal {
         }
     }
     
-    // Copy to clipboard with sequence on the form:
-    //    ESC ] 52 ; c ; [base64 data] \a
-    // where c is for copy and the only thing supported.
+    // OSC 52 – clipboard access
+    //    Write:  ESC ] 52 ; <sel> ; <base64-data> ST
+    //    Query:  ESC ] 52 ; <sel> ; ?            ST
+    //
+    // <sel> is one or more characters from {c, p, q, s, 0-7} that identify
+    // the selection/clipboard buffer.  On Apple platforms every selection maps
+    // to the system clipboard, so we accept any value.  An empty <sel> is
+    // treated as "c" (system clipboard).
     func oscClipboard (_ data: ArraySlice<UInt8>) {
-        // we require data to start with c; followed by base64 content
-        guard data.count >= 2,
-              data[data.startIndex] == UInt8(ascii: "c"),
-              data[data.startIndex+1] == UInt8(ascii: ";") else {
+        // Find the semicolon that separates the selection identifier from the payload.
+        guard let sepIdx = data.firstIndex(of: UInt8(ascii: ";")) else {
             return
         }
-        
-        let base64 = Data(data[(data.startIndex+2)...])
-        guard let content = Data(base64Encoded: base64) else {
-            return
+
+        let selectionSlice = data[data.startIndex..<sepIdx]
+        let selectionChars = selectionSlice.isEmpty
+            ? "c"
+            : (String(bytes: selectionSlice, encoding: .ascii) ?? "c")
+
+        let payload = data[(sepIdx + 1)...]
+
+        if payload.count == 1 && payload[payload.startIndex] == UInt8(ascii: "?") {
+            // Read / query – ask the delegate for clipboard contents.
+            guard let content = tdel?.clipboardRead(source: self) else {
+                return
+            }
+            let base64 = content.base64EncodedString()
+            sendResponse(cc.OSC, "52;\(selectionChars);\(base64)", cc.ST)
+        } else {
+            // Write – decode the base64 payload and hand it to the delegate.
+            let base64 = Data(payload)
+            guard let content = Data(base64Encoded: base64) else {
+                return
+            }
+            tdel?.clipboardCopy(source: self, content: content)
         }
-        
-        tdel?.clipboardCopy(source: self, content: content)
     }
     
     // Notifications:
@@ -2447,6 +2523,11 @@ open class Terminal {
         }
         // this.maxRange();
         updateRange (startLine: buffer.y, endLine: buffer.scrollBottom)
+        // A restricted region leaves stale pixels / a bottom-edge ghost outside
+        // [y, scrollBottom] on the CG renderer (as in scroll()); the range above
+        // already covers full-screen, so widen to the whole viewport only when the
+        // region is restricted.
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: true)
     }
     
     //
@@ -4089,17 +4170,18 @@ open class Terminal {
             case 1004: // send focusin/focusout events
                 sendFocus = false
             case 1005: // utf8 ext mode mouse
+                // Resets the coordinate encoding only: 1005/1006/1015/1016 select how mouse
+                // events are encoded, independent of the tracking modes (9/1000-1003). xterm
+                // keeps tracking enabled when an encoding is reset; turning mouseMode off here
+                // broke clients (e.g. mosh re-asserts modes as "CSI ?1003l ?1003h ?1006l ?1006h"
+                // on every resize, which left tracking permanently disabled).
                 mouseProtocol = .x10
-                mouseMode = .off
             case 1006: // sgr ext mode mouse
                 mouseProtocol = .x10
-                mouseMode = .off
             case 1015: // urxvt ext mode mouse
                 mouseProtocol = .x10
-                mouseMode = .off
             case 1016: // sgrPixel mode
                 mouseProtocol = .x10
-                mouseMode = .off
             case 25: // hide cursor
                 hideCursor ()
             case 1048: // alt screen cursor
@@ -4648,22 +4730,32 @@ open class Terminal {
         let p = min (max (pars.count == 0 ? 1 : pars [0], 1), rows)
         let da = CharData.defaultAttr
 
-        let row = buffer.scrollTop + buffer.yBase
+        if marginMode {
+            let row = buffer.scrollTop + buffer.yBase
 
-        let columnCount = buffer.marginRight-buffer.marginLeft+1
-        let rowCount = buffer.scrollBottom-buffer.scrollTop
-        for _ in 0..<p {
-            for i in (0..<rowCount).reversed() {
-                let src = buffer.lines [row+i]
-                let dst = buffer.lines [row+i+1]
-                
-                dst.copyFrom(src, srcCol: buffer.marginLeft, dstCol: buffer.marginLeft, len: columnCount)
+            let columnCount = buffer.marginRight-buffer.marginLeft+1
+            let rowCount = buffer.scrollBottom-buffer.scrollTop
+            for _ in 0..<p {
+                for i in (0..<rowCount).reversed() {
+                    let src = buffer.lines [row+i]
+                    let dst = buffer.lines [row+i+1]
+
+                    dst.copyFrom(src, srcCol: buffer.marginLeft, dstCol: buffer.marginLeft, len: columnCount)
+                }
+                let last = buffer.lines [row]
+                last.fill (with: CharData (attribute: da), atCol: buffer.marginLeft, len: columnCount)
             }
-            let last = buffer.lines [row]
-            last.fill (with: CharData (attribute: da), atCol: buffer.marginLeft, len: columnCount)
+        } else {
+            for _ in 0..<p {
+                buffer.lines.splice (start: buffer.yBase + buffer.scrollBottom, deleteCount: 1,
+                                     items: [], change: { line in updateRange (line)})
+                buffer.lines.splice (start: buffer.yBase + buffer.scrollTop, deleteCount: 0,
+                                     items: [buffer.getBlankLine (attribute: da)],
+                                     change: { line in updateRange (line) })
+            }
         }
         // this.maxRange();
-        updateRange (startLine: buffer.scrollTop, endLine: buffer.scrollBottom)
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
     }
 
     //
@@ -4699,7 +4791,7 @@ open class Terminal {
             }
         }
         // this.maxRange();
-        updateRange (startLine: buffer.scrollTop, endLine: buffer.scrollBottom)
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
     }
 
     //
@@ -4776,6 +4868,11 @@ open class Terminal {
         
         // this.maxRange();
         updateRange (startLine: buffer.y, endLine: buffer.scrollBottom)
+        // A restricted region leaves stale pixels / a bottom-edge ghost outside
+        // [y, scrollBottom] on the CG renderer (as in scroll()); the range above
+        // already covers full-screen, so widen to the whole viewport only when the
+        // region is restricted.
+        refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: true)
     }
 
     //
@@ -5156,7 +5253,7 @@ open class Terminal {
         let newY = buffer.y + 1
 
         // When left/right margins are active, only scroll if cursor is within margins
-        let canScroll = buffer.x >= buffer.marginLeft && buffer.x <= buffer.marginRight
+        let canScroll = !marginMode || (buffer.x >= buffer.marginLeft && buffer.x <= buffer.marginRight)
 
         if newY > buffer.scrollBottom {
             if canScroll {
@@ -5173,6 +5270,16 @@ open class Terminal {
     
     var blankLine: BufferLine = BufferLine(cols: 0)
     
+    /// Flag the scrolled region dirty. The CoreGraphics renderer now clears any
+    /// dirtied region before painting (see AppleTerminalView), so flagging just
+    /// [top, bottom] fixes the stale rows / bottom ghost — no whole-viewport repaint
+    /// needed. Full-screen + scrollback (`canBlit`) keeps the cheap path.
+    private func refreshScrolledRegion(top: Int, bottom: Int, canBlit: Bool) {
+        if top != 0 || bottom != rows - 1 || !canBlit {
+            updateRange(startLine: top, endLine: bottom)
+        }
+    }
+
     public func scroll (isWrapped: Bool = false)
     {
         let buffer = self.buffer
@@ -5239,6 +5346,7 @@ open class Terminal {
             if bottomRow == lines.count - 1 {
                 if willBufferBeTrimmed {
                     lines.recycle (clearAttribute: eraseAttr())
+                     lines[lines.count - 1].isWrapped = isWrapped
                 } else {
                     lines.push (BufferLine (from: newLine))
                 }
@@ -5297,9 +5405,7 @@ open class Terminal {
         updateRange (scrollTop, scrolling: true)
         updateRange (scrollBottom, scrolling: true)
 
-        if !hasScrollback {
-            updateRange(startLine: scrollTop, endLine: scrollBottom)
-        }
+        refreshScrolledRegion(top: scrollTop, bottom: scrollBottom, canBlit: hasScrollback)
 
         if buffer.hasAnyImages {
             updateKittyRelativePlacementsForCurrentBuffer()
@@ -5455,17 +5561,13 @@ open class Terminal {
         // This should call the viewport sync-scroll-area
     }
 
+    // Mirrors ghostty: flip a flag and arm a safety timer. The view layer pauses
+    // rendering while the flag is set (see updateDisplay's early-return). The
+    // live buffer is mutated normally; no snapshot is taken.
     private func beginSynchronizedOutput ()
     {
         let wasActive = synchronizedOutputActive
-        if !synchronizedOutputActive {
-            synchronizedOutputActive = true
-            synchronizedOutputBuffer = snapshotBuffer(buffer)
-            synchronizedOutputBufferIsAlternate = isCurrentBufferAlternate
-        } else if synchronizedOutputBuffer == nil {
-            synchronizedOutputBuffer = snapshotBuffer(buffer)
-            synchronizedOutputBufferIsAlternate = isCurrentBufferAlternate
-        }
+        synchronizedOutputActive = true
         scheduleSynchronizedOutputTimeout()
         if !wasActive {
             tdel?.synchronizedOutputChanged(source: self, active: true)
@@ -5478,8 +5580,6 @@ open class Terminal {
             return
         }
         synchronizedOutputActive = false
-        synchronizedOutputBuffer = nil
-        synchronizedOutputBufferIsAlternate = false
         synchronizedOutputTimeoutItem?.cancel()
         synchronizedOutputTimeoutItem = nil
         refresh (startRow: 0, endRow: rows - 1)
@@ -5499,41 +5599,9 @@ open class Terminal {
         DispatchQueue.main.asyncAfter(deadline: .now() + synchronizedOutputTimeoutSeconds, execute: workItem)
     }
 
-    private func snapshotBuffer (_ source: Buffer) -> Buffer
-    {
-        let copy = Buffer(cols: source.cols, rows: source.rows, tabStopWidth: tabStopWidth, scrollback: source.scrollback)
-        copy.xDisp = source.xDisp
-        copy.yDisp = source.yDisp
-        copy.xBase = source.xBase
-        copy.linesTop = source.linesTop
-        copy.yBase = source.yBase
-        copy.x = source.x
-        copy.y = source.y
-        copy.scrollTop = source.scrollTop
-        copy.scrollBottom = source.scrollBottom
-        copy.tabStops = source.tabStops
-        copy.savedX = source.savedX
-        copy.savedY = source.savedY
-        copy.savedOriginMode = source.savedOriginMode
-        copy.savedMarginMode = source.savedMarginMode
-        copy.savedWraparound = source.savedWraparound
-        copy.savedReverseWraparound = source.savedReverseWraparound
-        copy.marginLeft = source.marginLeft
-        copy.marginRight = source.marginRight
-        copy.savedAttr = source.savedAttr
-        copy.savedCharset = source.savedCharset
-        copy.scrollback = source.scrollback
-
-        for idx in 0..<source.lines.count {
-            copy.lines.push(BufferLine(from: source.lines[idx]))
-        }
-        return copy
-    }
-
     func setViewYDisp (_ newValue: Int)
     {
         buffer.yDisp = newValue
-        synchronizedOutputBuffer?.yDisp = newValue
     }
 
     /**
@@ -5584,6 +5652,19 @@ open class Terminal {
         }
     }
     
+    // XTSHIFTESCAPE (CSI > Ps s)
+    func cmdSetShiftEscape (_ pars: [Int]) {
+        let ps = pars.isEmpty ? 0 : pars[0]
+        switch ps {
+        case 0:
+            mouseShiftCapture = false
+        case 1:
+            mouseShiftCapture = true
+        default:
+            break
+        }
+    }
+
     /**
      * Encodes the button action in the format expected by the client
      * - Parameter button: The button to encode
@@ -5644,14 +5725,16 @@ open class Terminal {
         //print ("got \(mouseProtocol)")
         switch mouseProtocol {
         case .x10:
-            sendResponse(cc.CSI, "M", [UInt8(buttonFlags+32), min (UInt8(255), UInt8(32 + x+1)), min (UInt8(255), UInt8(32+y+1))])
+            sendResponse(cc.CSI, "M", [UInt8(min(buttonFlags+32, 255)), UInt8(min(32 + x+1, 255)), UInt8(min(32+y+1, 255))])
         case .sgr:
-            let bflags : Int = ((buttonFlags & 3) == 3) ? (buttonFlags & ~3) : buttonFlags
-            let m = ((buttonFlags & 3) == 3) ? "m" : "M"
+            let isRelease = (buttonFlags & 3) == 3 && (buttonFlags & 32) == 0
+            let bflags : Int = isRelease ? (buttonFlags & ~3) : buttonFlags
+            let m = isRelease ? "m" : "M"
             sendResponse(cc.CSI, "<\(bflags);\(x+1);\(y+1)\(m)")
         case .sgrPixel:
-            let bflags : Int = ((buttonFlags & 3) == 3) ? (buttonFlags & ~3) : buttonFlags
-            let m = ((buttonFlags & 3) == 3) ? "m" : "M"
+            let isRelease = (buttonFlags & 3) == 3 && (buttonFlags & 32) == 0
+            let bflags : Int = isRelease ? (buttonFlags & ~3) : buttonFlags
+            let m = isRelease ? "m" : "M"
             print ("\(pixelX);\(pixelY)")
             sendResponse(cc.CSI, "<\(bflags);\(pixelX);\(pixelY)\(m)")
             
@@ -5707,7 +5790,8 @@ open class Terminal {
         restrictCursor()
 
         // When left/right margins are active, only scroll if cursor is within margins
-        let canScroll = buffer.x >= buffer.marginLeft && buffer.x <= buffer.marginRight
+        let canScroll = !marginMode || (buffer.x >= buffer.marginLeft && buffer.x <= buffer.marginRight)
+        
 
         if buffer.y == buffer.scrollTop {
             if canScroll {
@@ -5756,7 +5840,7 @@ open class Terminal {
                     }
                     buffer.lines [topRow] = buffer.getBlankLine (attribute: eraseAttr ())
                 }
-                updateRange (startLine: buffer.scrollTop, endLine: buffer.scrollBottom)
+                refreshScrolledRegion(top: buffer.scrollTop, bottom: buffer.scrollBottom, canBlit: false)
             }
         } else if buffer.y > 0 {
             buffer.y -= 1
@@ -6732,6 +6816,10 @@ public extension TerminalDelegate {
     }
     
     func clipboardCopy(source: Terminal, content: Data) {
+    }
+    
+    func clipboardRead(source: Terminal) -> Data? {
+        return nil
     }
     
     func notify(source: Terminal, title: String, body: String) {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/TerminalOptions.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/TerminalOptions.swift
@@ -38,6 +38,18 @@ public enum CursorStyle {
     }
 }
 
+/// Width to assign to individual (unpaired) Regional Indicator symbols (U+1F1E6–U+1F1FF).
+/// Combined flag pairs (e.g. 🇺🇸) are always rendered as width 2 regardless of this setting.
+public enum RegionalIndicatorWidth: Sendable {
+    /// Width 2: matches kitty, Ghostty, iTerm2, and the Python wcwidth >= 0.5.2 library.
+    /// This is the default and preserves SwiftTerm's existing behavior.
+    case wide
+    /// Width 1: matches system wcwidth() on macOS/Linux, Alacritty, WezTerm, Windows Terminal,
+    /// and the Unicode East Asian Width property (Neutral). Use this when running inside tmux
+    /// or other multiplexers that use wcwidth() for cursor positioning.
+    case narrow
+}
+
 /// Configuration options for the terminal at startup, these values are only read at startup
 public struct TerminalOptions {
     /// Desired number of columns at startup (default 80)
@@ -62,7 +74,10 @@ public struct TerminalOptions {
     public var kittyImageCacheLimitBytes: Int
     /// Strategy used to derive the 256-color palette from the base 16 colors.
     public var ansi256PaletteStrategy: Ansi256PaletteStrategy
-    
+    /// Width for individual Regional Indicator symbols. `.wide` (default) preserves existing
+    /// behavior. `.narrow` matches system wcwidth() and avoids cursor divergence with tmux.
+    public var regionalIndicatorWidth: RegionalIndicatorWidth
+
     /// Default options
     public static let `default` = TerminalOptions.init(cols: 80,
                                                        rows: 25,
@@ -74,10 +89,12 @@ public struct TerminalOptions {
                                                        tabStopWidth: 8,
                                                        enableSixelReported: true,
                                                        kittyImageCacheLimitBytes: 320 * 1024 * 1024,
-                                                       ansi256PaletteStrategy: .base16Lab)
+                                                       ansi256PaletteStrategy: .base16Lab,
+                                                       regionalIndicatorWidth: .wide)
 
   public init(cols: Int = Self.default.cols, rows: Int = Self.default.rows, convertEol: Bool = Self.default.convertEol, termName: String = Self.default.termName, cursorStyle: CursorStyle = Self.default.cursorStyle, screenReaderMode: Bool = Self.default.screenReaderMode, scrollback: Int = Self.default.scrollback, tabStopWidth: Int = Self.default.tabStopWidth,
-              enableSixelReported: Bool = Self.default.enableSixelReported, kittyImageCacheLimitBytes: Int = Self.default.kittyImageCacheLimitBytes, ansi256PaletteStrategy: Ansi256PaletteStrategy = Self.default.ansi256PaletteStrategy) {
+              enableSixelReported: Bool = Self.default.enableSixelReported, kittyImageCacheLimitBytes: Int = Self.default.kittyImageCacheLimitBytes, ansi256PaletteStrategy: Ansi256PaletteStrategy = Self.default.ansi256PaletteStrategy,
+              regionalIndicatorWidth: RegionalIndicatorWidth = Self.default.regionalIndicatorWidth) {
         self.cols = cols
         self.rows = rows
         self.convertEol = convertEol
@@ -89,5 +106,6 @@ public struct TerminalOptions {
         self.enableSixelReported = enableSixelReported
         self.kittyImageCacheLimitBytes = kittyImageCacheLimitBytes
         self.ansi256PaletteStrategy = ansi256PaletteStrategy
+        self.regionalIndicatorWidth = regionalIndicatorWidth
     }
 }

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/TerminalViewSearch.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/TerminalViewSearch.swift
@@ -51,6 +51,22 @@ extension TerminalView {
         return false
     }
 
+
+    /// Position of the current match among all matches for `term`: a 1-based
+    /// `index` (0 when there is no current match) and the `total` match count
+    /// (capped at `limit`). Drives a "2/14" style counter in a search UI.
+    public func searchMatchSummary (_ term: String, options: SearchOptions = SearchOptions(), limit: Int = 1000) -> (index: Int, total: Int) {
+        guard let search = search else {
+            return (0, 0)
+        }
+        let all = search.findAll(term: term, options: options, limit: limit)
+        guard let last = search.lastResult,
+              let i = all.firstIndex(where: { $0.row == last.row && $0.col == last.col }) else {
+            return (0, all.count)
+        }
+        return (i + 1, all.count)
+    }
+
     /// Clears the current search state and selection.
     public func clearSearch () {
         search?.reset()

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Utilities.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Utilities.swift
@@ -306,6 +306,40 @@ struct UnicodeUtil {
         return bisearch(rune: rune.value, table: UnicodeWidthData.emojiVs16Base, max: UnicodeWidthData.emojiVs16Base.count - 1) != 0
     }
 
+    /**
+     * True for a lone symbol whose Unicode default presentation is text (Emoji=Yes,
+     * Emoji_Presentation=No) and that carries no explicit variation selector.
+     *
+     * Renderers append U+FE0E (text variation selector) to such characters before shaping:
+     * when the base font lacks a glyph, Core Text's font fallback on iOS resolves them to
+     * Apple Color Emoji (e.g. U+2733 under SF Mono), rendering a full-color emoji where the
+     * terminal should show a monochrome, foreground-tinted glyph. An explicit VS15 steers
+     * the cascade to a text-presentation font instead, matching the Unicode default.
+     *
+     * Clusters that already carry a variation selector (VS15 or VS16) or any combining
+     * scalar are left untouched — the stream made an explicit choice.
+     */
+    static func prefersTextPresentation (_ ch: Character) -> Bool
+    {
+        let scalars = ch.unicodeScalars
+        guard scalars.count == 1, let scalar = scalars.first else {
+            return false
+        }
+        // ASCII-range emoji bases (#, *, 0-9) always have text glyphs in the base font.
+        guard scalar.value > 0xFF else {
+            return false
+        }
+        let properties = scalar.properties
+        return properties.isEmoji && !properties.isEmojiPresentation
+    }
+
+    /// The character as a shaping-ready string, with U+FE0E appended when
+    /// `prefersTextPresentation` applies.
+    static func textPresentationAdjusted (_ ch: Character) -> String
+    {
+        return prefersTextPresentation(ch) ? String(ch) + "\u{FE0E}" : String(ch)
+    }
+
     private static func isEastAsianWide (_ value: UInt32) -> Bool
     {
         if UnicodeWidthData.eastAsianWide.isEmpty {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/SwiftUITerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/SwiftUITerminalView.swift
@@ -63,6 +63,7 @@ private struct TerminalViewContainer: UIViewRepresentable {
         public func requestOpenLink(source: TerminalView, link: String, params: [String : String]) {}
         public func bell(source: TerminalView) {}
         public func clipboardCopy(source: TerminalView, content: Data) {}
+        public func clipboardRead(source: TerminalView) -> Data? { return nil }
         public func iTermContent(source: TerminalView, content: ArraySlice<UInt8>) {}
         public func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
     }

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSCaretView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSCaretView.swift
@@ -16,6 +16,9 @@ import CoreGraphics
 class CaretView: UIView {
     weak var terminal: TerminalView?
     var ctline: CTLine?
+    /// Cell width of the character currently under the caret (2 for full-width
+    /// CJK). Used to center its glyph within the caret, matching the text.
+    var glyphColumnWidth: Int = 1
     var bgColor: CGColor
     var tracksFocus = true
     
@@ -78,9 +81,10 @@ class CaretView: UIView {
     }
     
     func setText (ch: CharData) {
+        glyphColumnWidth = max(1, Int(ch.width))
         let character = terminal?.terminal.getCharacter(for: ch) ?? " "
         let res = NSAttributedString (
-            string: String (character),
+            string: UnicodeUtil.textPresentationAdjusted (character),
             attributes: terminal?.getAttributedValue(ch.attribute, usingFg: caretColor, andBg: caretTextColor ?? terminal?.nativeForegroundColor ?? TTColor.black))
         ctline = CTLineCreateWithAttributedString(res)
         setNeedsDisplay(bounds)

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -192,12 +192,25 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     var search: SearchService!
     var debug: UIView?
     var pendingDisplay: Bool = false
+    /// Output received shortly after local input is likely echo or prompt redraw;
+    /// render it without the 16.67ms frame-rate throttle so typing feels responsive.
+    var lastUserInputUptimeNs: UInt64 = 0
+    /// Guards lastUserInputUptimeNs, which is written on the main thread and
+    /// read from the (possibly background) feed thread.
+    let userInputLock = NSLock()
+    let interactiveInputDisplayWindowNs: UInt64 = 150_000_000
 #if canImport(MetalKit)
     var metalView: MTKView?
     var metalRenderer: MetalTerminalRenderer?
     var pendingMetalDisplay: Bool = false
     private var useMetalRenderer = false
     var metalDirtyRange: ClosedRange<Int>?
+    /// The cursor position last submitted to the Metal renderer. Used to
+    /// detect pure cursor-only moves (no rows dirty) such as the
+    /// CSI Ps C / CSI Ps D sequences shells emit in response to Option+Arrow
+    /// word jumps, which would otherwise leave the cursor visually stuck
+    /// because `MTKView` is paused and only redraws on demand.
+    var lastRenderedCursor: (x: Int, y: Int, hidden: Bool)?
 
     /// Whether the terminal view is currently using the Metal GPU renderer.
     ///
@@ -209,6 +222,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 #endif
     var cellDimension: CellDimension
     var caretView: CaretView?
+    var _lineSpacing: CGFloat = 1.0
     var terminal: Terminal!
     private var progressBarView: TerminalProgressBarView?
     private var progressReportTimer: Timer?
@@ -285,6 +299,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         self.fontSet = FontSet (font: font ?? FontSet.defaultFont)
         cellDimension = CellDimension(width: 1, height: 1)
         super.init (frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits.formUnion([.staticText, .causesPageTurn])
+        accessibilityTextualContext = .sourceCode
         setup()
     }
     
@@ -293,6 +310,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         self.fontSet = FontSet (font: FontSet.defaultFont)
         cellDimension = CellDimension(width: 1, height: 1)
         super.init (frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits.formUnion([.staticText, .causesPageTurn])
+        accessibilityTextualContext = .sourceCode
         setup()
     }
     
@@ -368,6 +388,14 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             mtkView.framebufferOnly = true
             mtkView.colorPixelFormat = .bgra8Unorm
             mtkView.isUserInteractionEnabled = false
+            // Tag the metal layer with sRGB so the compositor color-manages our
+            // pixels the same way as a regular UIView's layer. Without this,
+            // CAMetalLayer is untagged and raw bytes are treated as
+            // already-in-display-gamut, oversaturating colors on wide-gamut
+            // displays.
+            if let metalLayer = mtkView.layer as? CAMetalLayer {
+                metalLayer.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
+            }
             let renderer = try MetalTerminalRenderer(view: mtkView, terminalView: self)
             mtkView.delegate = renderer
             if let caretView = caretView {
@@ -660,9 +688,9 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     func encodeFlags (release: Bool) -> Int
     {
         let encodedFlags = terminal.encodeButton(
-            // Multiplex patch: a UIKit tap is the primary (left) button.
-            // SwiftTerm hard-coded xterm button 1 (middle), so mouse-aware
-            // TUI targets such as Claude Code's jump-to-bottom ignored taps.
+            // Outpost patch: taps/drags are the primary (left) button. Upstream
+            // hard-codes 1 (middle), so every tap arrives as a middle-click —
+            // vim pastes, and left-click targets in TUIs never fire. 0 = left.
             button: 0,
             release: release,
             shift: false,
@@ -696,11 +724,19 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         contentOffset.y = max(0, CGFloat(lines) - bottomVisibleLine) * cellDimension.height
     }
     
+    /// Returns true when the user is holding Shift on an attached hardware keyboard
+    /// and the running application has not opted in to capturing shift via XTSHIFTESCAPE.
+    /// In that case the gesture should fall through to local selection handling instead
+    /// of being forwarded to the application as a mouse event.
+    private func shiftBypassesMouseReporting(for gestureRecognizer: UIGestureRecognizer) -> Bool {
+        gestureRecognizer.modifierFlags.contains(.shift) && !terminal.mouseShiftCapture
+    }
+
     @objc func singleTap (_ gestureRecognizer: UITapGestureRecognizer)
     {
         if isFirstResponder {
             guard gestureRecognizer.view != nil else { return }
-                 
+
             if gestureRecognizer.state != .ended {
                 return
             }
@@ -711,7 +747,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
                 return
             }
 
-            if allowMouseReporting && terminal.mouseMode.sendButtonPress() {
+            if allowMouseReporting && !shiftBypassesMouseReporting(for: gestureRecognizer) && terminal.mouseMode.sendButtonPress() {
                 sharedMouseEvent(gestureRecognizer: gestureRecognizer, release: false)
 
                 if terminal.mouseMode.sendButtonRelease() {
@@ -743,12 +779,12 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     @objc func doubleTap (_ gestureRecognizer: UITapGestureRecognizer)
     {
         guard gestureRecognizer.view != nil else { return }
-               
+
         if gestureRecognizer.state != .ended {
             return
         }
-        
-        if allowMouseReporting && terminal.mouseMode.sendButtonPress() {
+
+        if allowMouseReporting && !shiftBypassesMouseReporting(for: gestureRecognizer) && terminal.mouseMode.sendButtonPress() {
             sharedMouseEvent(gestureRecognizer: gestureRecognizer, release: false)
             
             if terminal.mouseMode.sendButtonRelease() {
@@ -773,7 +809,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             return
         }
 
-        if allowMouseReporting && terminal.mouseMode.sendButtonPress() {
+        if allowMouseReporting && !shiftBypassesMouseReporting(for: gestureRecognizer) && terminal.mouseMode.sendButtonPress() {
             sharedMouseEvent(gestureRecognizer: gestureRecognizer, release: false)
 
             if terminal.mouseMode.sendButtonRelease() {
@@ -900,8 +936,22 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             || terminal.isCurrentBufferAlternate
     }
 
+    /// Preserve SwiftTerm 1.14's Shift+mouse bypass while Multiplex owns the
+    /// pan recognizer. Unless the remote explicitly captures Shift through
+    /// XTSHIFTESCAPE, a shifted pan must not emit remote mouse/wheel events;
+    /// an active local selection remains free to own its drag.
+    fileprivate func shouldBeginRemoteScroll (_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard remoteScrollApplies, !selection.active, let terminal else { return false }
+        return !(allowMouseReporting
+            && terminal.mouseMode != .off
+            && shiftBypassesMouseReporting(for: gestureRecognizer))
+    }
+
     @objc func panMouseHandler (_ gestureRecognizer: UIPanGestureRecognizer){
-        guard gestureRecognizer.view != nil, cellDimension.height > 0 else { return }
+        guard gestureRecognizer.view != nil,
+              cellDimension.height > 0,
+              shouldBeginRemoteScroll(gestureRecognizer)
+        else { return }
         switch gestureRecognizer.state {
         case .began:
             remoteScrollResidual = 0
@@ -1252,6 +1302,16 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         setupOptions(width: bounds.width, height: bounds.height)
         layer.backgroundColor = nativeBackgroundColor.cgColor
         nativeBackgroundColor = UIColor.clear
+        // The terminal background is provided by `layer.backgroundColor`, and
+        // `draw(_:)` paints glyph cells with a transparent backdrop so that the
+        // layer colour shows through the gaps. That only works if the view is
+        // non-opaque: an opaque view gets an alpha-less graphics context where
+        // the transparent fill is a no-op, leaving uninitialised backing-store
+        // garbage in every default-background region. When the scroll view blits
+        // and re-exposes strips during scrolling, that garbage becomes visible as
+        // flickering/striped corruption. Marking the view non-opaque makes the
+        // transparent compositing behave as intended.
+        isOpaque = false
     }
     
     var _nativeFg, _nativeBg: TTColor!
@@ -1343,11 +1403,63 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         }
     }
 
+    /// Whether the terminal currently has an active text selection.
+    ///
+    /// Exposed publicly so embedders (e.g. a UIScrollView subclass that
+    /// hosts the terminal) can veto their own gesture recognisers while
+    /// the user is dragging a selection handle. The underlying
+    /// `SelectionService` is intentionally `internal`; this read-only
+    /// accessor is the minimum public surface needed for the common
+    /// "don't scroll while I'm dragging the selection handle" pattern.
+    ///
+    /// Added by the meshTerm fork (`v1.13.0-meshterm.1`). An upstream
+    /// PR has been filed mirroring this accessor; once merged we will
+    /// switch back to upstream and drop the fork.
+    public var hasActiveSelection: Bool {
+        return selection?.active ?? false
+    }
+
+    /// Programmatically sets the selection range to the given buffer
+    /// positions. Useful for callers that want to highlight a region
+    /// without going through a drag gesture — e.g. a search overlay
+    /// that wants match cells to light up with the same visual
+    /// treatment as a user-driven selection. Coordinates are
+    /// buffer-relative `Position` values. The view's internal
+    /// selection rendering picks up the change automatically.
+    public func setSelectionRange(start: Position, end: Position) {
+        selection?.setSelection(start: start, end: end)
+    }
+
+    /// Clears any active selection. Companion to `setSelectionRange`
+    /// for callers that don't have a UIResponder hook into the menu
+    /// system (where `selectNone` would otherwise come from).
+    public func clearSelection() {
+        selection?.selectNone()
+    }
+
+    /// Programmatically presents SwiftTerm's standard Copy / Paste /
+    /// Select All context menu at the given point in the terminal's
+    /// coordinate space. Mirrors the path the built-in long-press
+    /// gesture takes — becomes first responder, computes the menu
+    /// region around the tap point, then calls the existing internal
+    /// `showContextMenu(forRegion:pos:)` presenter.
+    ///
+    /// Useful when a host app replaces the built-in long-press gesture
+    /// with custom behaviour (e.g. a cursor-drag mode) but still wants
+    /// the existing menu as a fallback for release-without-movement.
+    public func showStandardContextMenu(at point: CGPoint) {
+        _ = becomeFirstResponder()
+        let region = makeContextMenuRegionForTap(point: point)
+        let hit = calculateTapHit(point: point)
+        showContextMenu(forRegion: region, pos: hit.grid)
+    }
+
     var lineAscent: CGFloat = 0
     var lineDescent: CGFloat = 0
     var lineLeading: CGFloat = 0
     
     open func bufferActivated(source: Terminal) {
+        resetManualScrollTracking()
         updateScroller ()
         // Multiplex patch: entering/leaving the alternate buffer flips
         // whether pans scroll the remote or the local scrollback.
@@ -1443,8 +1555,27 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         let displayBuffer = terminal.displayBuffer
         contentSize = CGSize (width: CGFloat (displayBuffer.cols) * cellDimension.width,
                               height: CGFloat (displayBuffer.lines.count) * cellDimension.height)
-        //contentOffset = CGPoint (x: 0, y: CGFloat (displayBuffer.lines.count-displayBuffer.rows)*cellDimension.height)
-        contentOffset = CGPoint (x: 0, y: CGFloat (displayBuffer.lines.count-displayBuffer.rows)*cellDimension.height)
+        // Let the gesture own contentOffset while the finger is physically down
+        // (isTracking), and while frozen history coasts under momentum —
+        // re-asserting it there fights the drag and blocks the user from reaching
+        // the bottom. But when following the bottom (userScrolling == false) we
+        // must keep pinning to the bottom even during deceleration: otherwise
+        // streaming output grows the content faster than the coasting offset, the
+        // tail pulls away, and the view falls behind the live output.
+        //
+        // NOTE: isTracking (finger down), not isDragging — on device isDragging
+        // stays true through the whole momentum coast, so it cannot distinguish
+        // an active drag from post-lift deceleration. contentSize is still
+        // updated above so the newly appended rows remain reachable.
+        if isTracking || (userScrolling && isDecelerating) {
+            return
+        }
+        let rowOffset = CGFloat (displayBuffer.yDisp) * cellDimension.height
+        let desiredY = userScrolling ? rowOffset + manualScrollOffsetWithinRow : rowOffset
+        // Clamp to the scroll view's real maximum so following the bottom rests
+        // flush against the last line instead of over-scrolling past it.
+        let offsetY = min(desiredY, maxContentOffsetY())
+        setContentOffsetFromTerminal(CGPoint (x: 0, y: offsetY))
         //Xscroller.doubleValue = scrollPosition
         //Xscroller.knobProportion = scrollThumbsize
     }
@@ -1469,6 +1600,106 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 #endif
     
     var userScrolling = false
+    private var updatingContentOffsetFromTerminal = false
+    private var manualScrollOffsetWithinRow: CGFloat = 0
+
+    private var contentOffsetTolerance: CGFloat {
+        1 / max(backingScaleFactor(), 1)
+    }
+
+    private func maxDisplayRow(in displayBuffer: Buffer) -> Int {
+        max(0, displayBuffer.lines.count - displayBuffer.rows)
+    }
+
+    /// The largest resting `contentOffset.y` the scroll view can actually reach.
+    /// This is smaller than `maxDisplayRow * cellHeight` by the partial-row
+    /// remainder whenever the viewport height is not an exact multiple of the
+    /// cell height, so it — not the row offset — is the true "bottom" of the
+    /// content for both follow-mode positioning and at-bottom detection. The
+    /// `adjustedContentInset.bottom` term matches UIScrollView's own clamp: with
+    /// a bottom inset (accessory view, safe area, keyboard) the resting maximum
+    /// shifts, and ignoring it left the user unable to ever reach the bottom to
+    /// disengage the freeze — even by overscrolling.
+    private func maxContentOffsetY() -> CGFloat {
+        max(0, contentSize.height - bounds.height + adjustedContentInset.bottom)
+    }
+
+    private func setContentOffsetFromTerminal(_ newContentOffset: CGPoint) {
+        if abs(contentOffset.x - newContentOffset.x) <= contentOffsetTolerance &&
+            abs(contentOffset.y - newContentOffset.y) <= contentOffsetTolerance {
+            return
+        }
+
+        updatingContentOffsetFromTerminal = true
+        contentOffset = newContentOffset
+        updatingContentOffsetFromTerminal = false
+    }
+
+    private func setManualScrolling(_ enabled: Bool) {
+        userScrolling = enabled
+        terminal.userScrolling = enabled
+        if !enabled {
+            manualScrollOffsetWithinRow = 0
+        }
+    }
+
+    func resetManualScrollOffsetWithinRow() {
+        manualScrollOffsetWithinRow = 0
+    }
+
+    private func resetManualScrollTracking() {
+        setManualScrolling(false)
+
+        let displayBuffer = terminal.displayBuffer
+        terminal.setViewYDisp(maxDisplayRow(in: displayBuffer))
+        let bottomOffset = min(CGFloat(displayBuffer.yDisp) * cellDimension.height, maxContentOffsetY())
+        setContentOffsetFromTerminal(CGPoint(x: 0, y: bottomOffset))
+    }
+
+    private func syncYDispFromContentOffset() {
+        guard terminal != nil, !updatingContentOffsetFromTerminal, cellDimension.height > 0 else {
+            return
+        }
+
+        let displayBuffer = terminal.displayBuffer
+        let maxRow = maxDisplayRow(in: displayBuffer)
+        let maxContentOffset = maxContentOffsetY()
+        let offsetY = min(max(contentOffset.y, 0), maxContentOffset)
+
+        // A drag that lands within half a row of the bottom (or overscrolls past
+        // it) re-engages auto-follow. A sub-pixel tolerance was too tight —
+        // fractional cell heights and contentInset rounding left the user a hair
+        // short of the exact maximum, so the freeze never disengaged.
+        let atBottomThreshold = max(contentOffsetTolerance, cellDimension.height / 2)
+        if offsetY >= maxContentOffset - atBottomThreshold {
+            if displayBuffer.yDisp != maxRow {
+                terminal.setViewYDisp(maxRow)
+            }
+            setManualScrolling(false)
+            return
+        }
+
+        // Freeze auto-follow only while the finger is physically down
+        // (isTracking). Excluding the momentum coast is essential: after the
+        // finger lifts, deceleration keeps firing sync while streaming output
+        // extends the content and the bottom recedes ahead of the coasting
+        // offset — treating that "not at the bottom yet" reading as a manual
+        // scroll would re-freeze a view the user just flung to the bottom. This
+        // must key off isTracking, not isDragging: on device isDragging stays
+        // true through the entire coast, so it fails to exclude momentum. It also
+        // covers layout/system-driven offset changes (startup sizing, rotation,
+        // keyboard insets, buffer shrink), which are never a manual scroll.
+        guard isTracking else {
+            return
+        }
+
+        let row = max(0, min(maxRow, Int(floor((offsetY + contentOffsetTolerance) / cellDimension.height))))
+        manualScrollOffsetWithinRow = offsetY - CGFloat(row) * cellDimension.height
+        if displayBuffer.yDisp != row {
+            terminal.setViewYDisp(row)
+        }
+        setManualScrolling(true)
+    }
 
     func getCurrentGraphicsContext () -> CGContext?
     {
@@ -1549,12 +1780,38 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 
     open override var contentOffset: CGPoint {
         didSet {
+            syncYDispFromContentOffset()
 #if canImport(MetalKit)
             if useMetalRenderer, metalView != nil {
                 requestMetalDisplay()
             }
 #endif
         }
+    }
+
+    open override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
+        let pageHeight = max(bounds.height, cellDimension.height)
+        let maxOffsetY = max(0, contentSize.height - bounds.height)
+        let targetOffsetY: CGFloat
+
+        switch direction {
+        case .down, .right, .next:
+            targetOffsetY = min(maxOffsetY, contentOffset.y + pageHeight)
+        case .up, .left, .previous:
+            targetOffsetY = max(0, contentOffset.y - pageHeight)
+        default:
+            return super.accessibilityScroll(direction)
+        }
+
+        guard targetOffsetY != contentOffset.y else {
+            return false
+        }
+
+        setContentOffset(CGPoint(x: contentOffset.x, y: targetOffsetY), animated: false)
+        setNeedsDisplay(bounds)
+        // Based on WWDC 2019 presentation: argument is nil
+        UIAccessibility.post(notification: .pageScrolled, argument: nil)
+        return true
     }
 
     // iOS Keyboard input
@@ -1614,7 +1871,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
             return normalized
         }
         guard isAutoPeriodReplacement(text) else { return nil }
-        guard rangeToReplace.endPosition.offset == textInputStorage.count else { return nil }
+        guard rangeToReplace.endPosition.offset == textInputStorage.textInputUTF16Count else { return nil }
         guard oldText.count <= 2 else { return nil }
         guard oldText.allSatisfy({ $0 == " " }) else { return nil }
         if text == "." {
@@ -1640,7 +1897,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         pendingAutoPeriodDeleteWasSpace = false
         guard text == ". " else { return nil }
         guard rangeToReplace.isEmpty else { return nil }
-        guard rangeToReplace.endPosition.offset == textInputStorage.count else { return nil }
+        guard rangeToReplace.endPosition.offset == textInputStorage.textInputUTF16Count else { return nil }
         guard textInputStorage.last == " " else { return nil }
         uitiLog("auto-period insertion range text:\(text.debugDescription) -> \" \"")
         return " "
@@ -1670,7 +1927,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         let rangeStartIndex = rangeToReplace.startPosition.offset
         textInputStorage.replaceSubrange(rangeToReplace.fullRange(in: textInputStorage), with: textToInsert)
         _markedTextRange = nil
-        let insertedPosition = TextPosition(offset: rangeStartIndex + textToInsert.count)
+        let insertedOffset = textInputStorage.textInputValidUTF16Offset(
+            rangeStartIndex + textToInsert.textInputUTF16Count,
+            rounding: .forward)
+        let insertedPosition = TextPosition(offset: insertedOffset)
         _selectedTextRange = TextRange(from: insertedPosition, to: insertedPosition)
 
         endTextInputEdit()
@@ -2098,7 +2358,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     private func tryComposeKoreanFinal(_ text: String) -> Bool {
         guard let language = textInputMode?.primaryLanguage, language.hasPrefix("ko") else { return false }
         guard _markedTextRange == nil else { return false }
-        guard _selectedTextRange.isEmpty, _selectedTextRange.endPosition.offset == textInputStorage.count else { return false }
+        guard _selectedTextRange.isEmpty, _selectedTextRange.endPosition.offset == textInputStorage.textInputUTF16Count else { return false }
         guard text.count == 1, let jamo = text.first else { return false }
         guard let finalIndex = koreanFinalIndex[jamo] else { return false }
         guard let lastChar = textInputStorage.last else { return false }
@@ -2109,7 +2369,7 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         beginTextInputEdit()
         textInputStorage.removeLast()
         textInputStorage.append(composed)
-        let newOffset = textInputStorage.count
+        let newOffset = textInputStorage.textInputUTF16Count
         _markedTextRange = nil
         _selectedTextRange = TextRange(from: TextPosition(offset: newOffset), to: TextPosition(offset: newOffset))
         endTextInputEdit()
@@ -2158,11 +2418,18 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 
     func ensureCaretIsVisible ()
     {
+        guard !terminal.synchronizedOutputActive else { return }
         let displayBuffer = terminal.displayBuffer
-        contentOffset = CGPoint (x: 0, y: CGFloat (displayBuffer.lines.count-displayBuffer.rows)*cellDimension.height)
+        let realCaret = displayBuffer.y + displayBuffer.yBase
+        let viewportEnd = displayBuffer.yDisp + displayBuffer.rows
+
+        if userScrolling || terminal.userScrolling || realCaret >= viewportEnd || realCaret < displayBuffer.yDisp {
+            resetManualScrollTracking()
+            updateScroller()
+        }
     }
     
-    public func deleteBackward() {
+    open func deleteBackward() {
         uitiLog("deleteBackward() \(textInputStateDescription())")
 
         // after backward deletion, marked range is always cleared, and length of selected range is always zero
@@ -2184,12 +2451,18 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 
             beginTextInputEdit()
 
-            rangeStartIndex -= 1
-            let deleteIndex = textInputStorage.index(textInputStorage.startIndex, offsetBy: rangeStartIndex)
-            let deletedChar = textInputStorage[deleteIndex]
-            let deletingAtEnd = rangeStartPosition.offset == textInputStorage.count
+            guard let deleteRange = textInputStorage.textInputCharacterRange(beforeUTF16Offset: rangeStartIndex) else {
+                pendingAutoPeriodDeleteWasSpace = false
+                self.sendBackspaceKey()
+                uitiLog("deleteBackward() no text to delete, sending backspace")
+                endTextInputEdit()
+                return
+            }
+            rangeStartIndex = textInputStorage.textInputUTF16Offset(of: deleteRange.lowerBound)
+            let deletedChar = textInputStorage[deleteRange]
+            let deletingAtEnd = rangeStartPosition.offset == textInputStorage.textInputUTF16Count
             pendingAutoPeriodDeleteWasSpace = deletingAtEnd && deletedChar == " " && _markedTextRange == nil
-            textInputStorage.remove(at: deleteIndex)
+            textInputStorage.removeSubrange(deleteRange)
             rangeStartPosition = TextPosition(offset: rangeStartIndex)
 
             self.sendBackspaceKey()
@@ -2230,9 +2503,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         }
     }
  
-    /// Claim Escape before the Mac text system applies its default cancel
-    /// behavior. The normal `pressesBegan` path owns byte delivery; this no-op
-    /// command only keeps the terminal and its window focused.
+    /// Multiplex patch: claim Escape before the Mac text system applies its
+    /// default cancel behavior. The normal `pressesBegan` path owns byte
+    /// delivery; this no-op command only keeps the terminal and its window
+    /// focused.
     open override var keyCommands: [UIKeyCommand]? {
         guard ProcessInfo.processInfo.isiOSAppOnMac else {
             return super.keyCommands
@@ -2820,6 +3094,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     public func clipboardCopy(source: Terminal, content: Data) {
         terminalDelegate?.clipboardCopy(source: self, content: content)
     }
+    
+    public func clipboardRead(source: Terminal) -> Data? {
+        return terminalDelegate?.clipboardRead(source: self)
+    }
 
     public func iTermContent (source: Terminal, content: ArraySlice<UInt8>) {
         terminalDelegate?.iTermContent(source: self, content: content)
@@ -2840,7 +3118,7 @@ private class RemoteScrollGestureGate: NSObject, UIGestureRecognizerDelegate {
 
     func gestureRecognizerShouldBegin (_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard let view = terminalView else { return false }
-        return view.remoteScrollApplies && !view.selection.active
+        return view.shouldBeginRemoteScroll(gestureRecognizer)
     }
 }
 
@@ -2857,7 +3135,234 @@ extension TerminalViewDelegate {
     
     public func iTermContent (source: TerminalView, content: ArraySlice<UInt8>) {
     }
+    
+    public func clipboardCopy(source: TerminalView, content: Data) {
+    }
+    
+    public func clipboardRead(source: TerminalView) -> Data? {
+        return nil
+    }
 }
+
+extension TerminalView: UIAccessibilityReadingContent {
+    private func accessibilityBaseAttributes() -> [NSAttributedString.Key: Any] {
+        getAttributes(CharData.defaultAttr, withUrl: false) ?? [.font: fontSet.normal]
+    }
+
+    private func accessibilityAttributedLine(_ row: Int, endCol: Int = -1) -> NSAttributedString {
+        guard row >= 0, row < terminal.displayBuffer.lines.count else {
+            return NSAttributedString(string: "")
+        }
+
+        let line = terminal.displayBuffer.lines[row]
+        let rawLimit = endCol == -1 ? line.count : min(endCol, line.count)
+        let lineLimit = min(rawLimit, line.getTrimmedLength())
+        guard line.hasAnyContent(), lineLimit > 0 else {
+            return NSAttributedString(string: "")
+        }
+
+        let lineInfo = buildAttributedString(row: row, line: line, cols: lineLimit)
+        let result = NSMutableAttributedString()
+        for segment in lineInfo.segments {
+            result.append(segment.attributedString)
+        }
+        return result
+    }
+
+    private func accessibilityAttributedDisplayText(start: Position, end: Position) -> NSAttributedString {
+        let buffer = terminal.displayBuffer
+        guard !buffer.lines.isEmpty else {
+            return NSAttributedString(string: "")
+        }
+
+        var start = start
+        var end = end
+
+        switch Position.compare(start, end) {
+        case .equal:
+            return NSAttributedString(string: "")
+        case .after:
+            swap(&start, &end)
+        case .before:
+            break
+        }
+
+        guard start.row >= 0, start.row <= buffer.lines.count else {
+            return NSAttributedString(string: "")
+        }
+
+        if end.row >= buffer.lines.count {
+            end.row = buffer.lines.count - 1
+        }
+
+        let newline = NSAttributedString(string: "\n", attributes: accessibilityBaseAttributes())
+        var lines: [NSMutableAttributedString] = [NSMutableAttributedString()]
+        var currentLine = lines[0]
+        var blanks: [NSMutableAttributedString] = []
+
+        func addBlanks() {
+            guard !blanks.isEmpty else {
+                return
+            }
+            for blank in blanks {
+                lines.append(blank)
+            }
+            currentLine = blanks.last!
+            blanks.removeAll()
+        }
+
+        var bufferLine = buffer.lines[start.row]
+        if bufferLine.hasAnyContent() {
+            currentLine.append(accessibilityAttributedLine(start.row, endCol: start.row < end.row ? -1 : end.col))
+        }
+
+        var line = start.row + 1
+        var isWrapped = false
+        while line < end.row {
+            bufferLine = buffer.lines[line]
+            isWrapped = bufferLine.isWrapped
+
+            if bufferLine.hasAnyContent() {
+                addBlanks()
+
+                if !isWrapped {
+                    currentLine = NSMutableAttributedString()
+                    lines.append(currentLine)
+                }
+
+                currentLine.append(accessibilityAttributedLine(line))
+            } else {
+                if !isWrapped || blanks.isEmpty {
+                    blanks.append(NSMutableAttributedString())
+                }
+            }
+
+            line += 1
+        }
+
+        if end.row != start.row {
+            bufferLine = buffer.lines[end.row]
+            if bufferLine.hasAnyContent() {
+                addBlanks()
+
+                isWrapped = bufferLine.isWrapped
+                if !isWrapped {
+                    currentLine = NSMutableAttributedString()
+                    lines.append(currentLine)
+                }
+
+                currentLine.append(accessibilityAttributedLine(end.row, endCol: end.col))
+            }
+        }
+
+        let result = NSMutableAttributedString()
+        for (index, attributedLine) in lines.enumerated() {
+            if index > 0 {
+                result.append(newline)
+            }
+            result.append(attributedLine)
+        }
+        return result
+    }
+
+    public func accessibilityLineNumber(for point: CGPoint) -> Int {
+        return Int(floor(max(point.y,0) / cellDimension.height))
+    }
+    
+    func startingLine(forLineNumber lineNumber: Int) -> Int {
+        let lineWidth = terminal.buffer.lines[lineNumber].count
+        var startingLine = lineNumber
+        while startingLine >= 1 {
+            startingLine -= 1
+            if terminal.buffer.lines[startingLine + 1].isWrapped {
+                continue
+            }
+            let start = Position(col: 0, row: startingLine)
+            let end = Position(col: terminal.buffer.lines[startingLine].count, row: startingLine)
+            let text =  terminal.getDisplayText(start: start, end: end)
+            if (text.count != terminal.buffer.lines[startingLine].count || text.last != " ") {
+                // previous line is incomplete. Don't use it
+                startingLine += 1
+                break
+            }
+        }
+        return startingLine
+    }
+
+    func endingLine(forLineNumber lineNumber: Int) -> Int {
+        let lineWidth = terminal.buffer.lines[lineNumber].count
+        var endingLine = lineNumber
+        while (endingLine < terminal.buffer.lines.count - 1) {
+            let start = Position(col: 0, row: endingLine)
+            let end = Position(col: terminal.buffer.lines[endingLine].count, row: endingLine)
+            let text =  terminal.getDisplayText(start: start, end: end)
+            if (text.count != terminal.buffer.lines[endingLine].count || text.last != " ")
+            && !terminal.buffer.lines[endingLine + 1].isWrapped {
+                // this line is incomplete. We stop here.
+                break
+            }
+            endingLine += 1
+        }
+        return endingLine
+    }
+
+    public func accessibilityContent(forLineNumber lineNumber: Int) -> String? {
+        var startingLine = startingLine(forLineNumber: lineNumber)
+        var endingLine = endingLine(forLineNumber: lineNumber)
+        let start = Position(col: 0, row: startingLine)
+        let end = Position(col: terminal.buffer.lines[endingLine].count,
+                           row: endingLine)
+        var text =  terminal.getDisplayText(start: start, end: end)
+        return terminal.getDisplayText(start: start, end: end)
+    }
+
+    public func accessibilityFrame(forLineNumber lineNumber: Int) -> CGRect {
+        let topVisibleLine = Int(contentOffset.y/cellDimension.height)
+        let offset = contentOffset.y - CGFloat(topVisibleLine) * cellDimension.height
+        var startingLine = startingLine(forLineNumber: lineNumber)
+        var endingLine = endingLine(forLineNumber: lineNumber)
+        var verticalWidth = CGFloat(endingLine - startingLine + 1)
+        let lineOffset =  cellDimension.height * CGFloat (startingLine - topVisibleLine + 1)
+        let lineOrigin = CGPoint(x: 0, y: lineOffset)
+        let columnCount = terminal.buffer.lines[lineNumber].count
+        var rect = CGRect(
+            x: lineOrigin.x,
+            y: lineOrigin.y + 3 - offset,
+            width: CGFloat(columnCount) * cellDimension.width,
+            height: verticalWidth * cellDimension.height)
+        return rect
+    }
+
+    public func accessibilityPageContent() -> String? {
+        let pageHeight = max(bounds.height, cellDimension.height)
+        let lines = Int(floor(pageHeight/cellDimension.height))
+        let startLine = Int(floor(contentOffset.y / cellDimension.height))
+        let start = Position(col: 0, row: startLine)
+        let end = Position(col: terminal.buffer.lines[startLine].count,
+                           row: startLine + lines)
+        return terminal.getDisplayText(start: start, end: end)
+    }
+
+    public func accessibilityAttributedContent(forLineNumber lineNumber: Int) -> NSAttributedString? {
+        var startingLine = startingLine(forLineNumber: lineNumber)
+        var endingLine = endingLine(forLineNumber: lineNumber)
+        var start = Position(col: 0, row: startingLine)
+        var end = Position(col: terminal.buffer.lines[endingLine].count,
+                           row: endingLine)
+        return accessibilityAttributedDisplayText(start: start, end: end)
+    }
+
+    public func accessibilityAttributedPageContent() -> NSAttributedString? {
+        let pageHeight = max(bounds.height, cellDimension.height)
+        let lines = Int(floor(pageHeight/cellDimension.height))
+        let startLine = Int(floor(contentOffset.y / cellDimension.height))
+        let start = Position(col: 0, row: startLine)
+        let end = Position(col: terminal.buffer.lines[startLine].count,
+                           row: startLine + lines)
+        return accessibilityAttributedDisplayText(start: start, end: end)
+    }
+}
+
 
 #if canImport(UIKit) && DEBUG
 #Preview {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTextInput.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTextInput.swift
@@ -79,19 +79,30 @@ extension TerminalView: UITextInput {
     }
 
     private func clampOffset(_ offset: Int) -> Int {
-        return max(0, min(offset, textInputStorage.count))
+        return max(0, min(offset, textInputStorage.textInputUTF16Count))
+    }
+
+    private func normalizedOffset(_ offset: Int, rounding: TextInputUTF16Rounding) -> Int {
+        return textInputStorage.textInputValidUTF16Offset(clampOffset(offset), rounding: rounding)
     }
 
     private func coerceTextPosition(_ position: UITextPosition) -> TextPosition? {
         guard let tp = position as? TextPosition else { return nil }
-        let clamped = clampOffset(tp.offset)
-        return clamped == tp.offset ? tp : TextPosition(offset: clamped)
+        let normalized = normalizedOffset(tp.offset, rounding: .forward)
+        return normalized == tp.offset ? tp : TextPosition(offset: normalized)
     }
 
     private func coerceTextRange(_ range: UITextRange) -> TextRange? {
         if let r = range as? TextRange {
-            let start = clampOffset(r.startPosition.offset)
-            let end = clampOffset(r.endPosition.offset)
+            let start: Int
+            let end: Int
+            if r.startPosition.offset == r.endPosition.offset {
+                start = normalizedOffset(r.startPosition.offset, rounding: .forward)
+                end = start
+            } else {
+                start = normalizedOffset(r.startPosition.offset, rounding: .backward)
+                end = normalizedOffset(r.endPosition.offset, rounding: .forward)
+            }
             if start == r.startPosition.offset && end == r.endPosition.offset {
                 return r
             }
@@ -118,7 +129,7 @@ extension TerminalView: UITextInput {
     }
 
     public func text(in range: UITextRange) -> String? {
-        guard let r = range as? TextRange else { return nil }
+        guard let r = coerceTextRange(range) else { return nil }
 
         if r.isEmpty {
             uitiLog("text(in:\(r)) -> \"\" \(textInputStateDescription())")
@@ -131,7 +142,7 @@ extension TerminalView: UITextInput {
     }
     
     public func replace(_ range: UITextRange, withText text: String) {
-        guard let r = range as? TextRange else { return }
+        guard let r = coerceTextRange(range) else { return }
 
         guard _markedTextRange == nil else { return }
         uitiLog ("replace(range:\(r), withText:\(text.debugDescription)) \(textInputStateDescription())")
@@ -156,16 +167,19 @@ extension TerminalView: UITextInput {
 
         let insertionIndex = r.startPosition.offset
         textInputStorage.replaceSubrange(r.fullRange(in: textInputStorage), with: replacementText)
+        let replacementLength = replacementText.textInputUTF16Count
         if r.endPosition.offset <= _selectedTextRange.startPosition.offset {
             let selectionOffset = _selectedTextRange.startPosition.offset - insertionIndex
-            let newSelectionOffset = selectionOffset - r.length + replacementText.count
-            let newSelectionIndex = newSelectionOffset + insertionIndex
+            let newSelectionOffset = selectionOffset - r.length + replacementLength
+            let newSelectionIndex = textInputStorage.textInputValidUTF16Offset(newSelectionOffset + insertionIndex, rounding: .forward)
+            let newSelectionEndIndex = textInputStorage.textInputValidUTF16Offset(newSelectionIndex + _selectedTextRange.length, rounding: .forward)
             _selectedTextRange = TextRange(from: TextPosition(offset:newSelectionIndex), 
-                                            to: TextPosition(offset: newSelectionIndex + _selectedTextRange.length))
+                                            to: TextPosition(offset: newSelectionEndIndex))
         } else if r.startPosition.offset >= _selectedTextRange.endPosition.offset {
             // NOOP
         } else {
-            let insertionEndPosition = TextPosition(offset:insertionIndex + replacementText.count)            
+            let insertionEndIndex = textInputStorage.textInputValidUTF16Offset(insertionIndex + replacementLength, rounding: .forward)
+            let insertionEndPosition = TextPosition(offset: insertionEndIndex)
             _selectedTextRange = TextRange(from: insertionEndPosition,  to: insertionEndPosition)
         }
 
@@ -212,7 +226,12 @@ extension TerminalView: UITextInput {
             return _markedTextRange
         }
         set {
-            _markedTextRange = newValue as? TextRange
+            guard let newValue else {
+                _markedTextRange = nil
+                uitiLog("markedTextRange -> nil")
+                return
+            }
+            _markedTextRange = coerceTextRange(newValue)
             uitiLog("markedTextRange -> \(_markedTextRange)")
         }
     }
@@ -238,14 +257,18 @@ extension TerminalView: UITextInput {
             textInputStorage.replaceSubrange(rangeToReplace.fullRange(in: textInputStorage), with: newText)
             // Figure out the new selection range
             let rangeStartIndex = rangeStartPosition.offset
-            let newTextRange = Range(selectedRange, in: newText)!
-            let newTextRangeOffset = newText.distance(from: newText.startIndex, to: newTextRange.lowerBound)
-            let newTextRangeLength = newText.distance(from: newTextRange.lowerBound, to: newTextRange.upperBound)
+            let newTextLength = newText.textInputUTF16Count
+            let selectedStartInNewText = max(0, min(selectedRange.location, newTextLength))
+            let selectedRangeLength = max(0, min(selectedRange.length, newTextLength - selectedStartInNewText))
+            let selectedEndInNewText = selectedStartInNewText + selectedRangeLength
 
-            let selectionStartIndex = rangeStartIndex + newTextRangeOffset
-            _markedTextRange = TextRange(from: rangeStartPosition, maxOffset: newText.count, in: textInputStorage) 
+            let selectionStartIndex = textInputStorage.textInputValidUTF16Offset(
+                rangeStartIndex + selectedStartInNewText,
+                rounding: selectedRangeLength == 0 ? .forward : .backward)
+            let selectionEndIndex = textInputStorage.textInputValidUTF16Offset(rangeStartIndex + selectedEndInNewText, rounding: .forward)
+            _markedTextRange = TextRange(from: rangeStartPosition, maxOffset: newTextLength, in: textInputStorage)
             _selectedTextRange = TextRange(from: TextPosition(offset: selectionStartIndex), 
-                                           to: TextPosition(offset: selectionStartIndex + newTextRangeLength))
+                                           to: TextPosition(offset: selectionEndIndex))
         } else {
             textInputStorage.removeSubrange(rangeToReplace.fullRange(in: textInputStorage))
             _markedTextRange = nil
@@ -290,7 +313,7 @@ extension TerminalView: UITextInput {
     }
     
     public var endOfDocument: UITextPosition {
-        return TextPosition(offset: textInputStorage.count)
+        return TextPosition(offset: textInputStorage.textInputUTF16Count)
     }
     
     public func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange? {
@@ -306,7 +329,7 @@ extension TerminalView: UITextInput {
     
     public func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
         guard let from = position as? TextPosition else { return nil }
-        let newOffset = max(min(from.offset + offset, textInputStorage.count), 0)
+        let newOffset = textInputStorage.textInputOffset(from.offset, advancedByUTF16Distance: offset)
         let result = TextPosition(offset: newOffset)
         uitiLog("position(from:\(from.offset), offset:\(offset)) -> \(result.offset)")
         return result
@@ -360,7 +383,7 @@ extension TerminalView: UITextInput {
     }
     
     public func characterRange(at point: CGPoint) -> UITextRange? {
-        return TextRange(from: TextPosition(offset: 0), to: TextPosition(offset: textInputStorage.count))
+        return TextRange(from: TextPosition(offset: 0), to: TextPosition(offset: textInputStorage.textInputUTF16Count))
     }
 
     public func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? {
@@ -369,12 +392,16 @@ extension TerminalView: UITextInput {
 
     public func characterRange(byExtending position: UITextPosition, in direction: UITextLayoutDirection) -> UITextRange? {
         guard let p = position as? TextPosition else { return nil }
-        return TextRange(from: p, to: TextPosition(offset: textInputStorage.count))
+        return TextRange(from: p, to: TextPosition(offset: textInputStorage.textInputUTF16Count))
     }
     
     public func position(within range: UITextRange, atCharacterOffset offset: Int) -> UITextPosition? {
         guard let r = range as? TextRange else { return nil }
-        let endOffset = r.startPosition.offset + offset
+        let rawOffset = r.startPosition.offset + offset
+        guard rawOffset >= r.startPosition.offset else {
+            return nil
+        }
+        let endOffset = textInputStorage.textInputValidUTF16Offset(rawOffset, rounding: offset < 0 ? .backward : .forward)
         if endOffset > r.endPosition.offset {
             return nil
         }
@@ -447,13 +474,13 @@ extension TerminalView: UITextInput {
             if deltax > 0 {
                 data = terminal.applicationCursor ? EscapeSequences.moveLeftApp : EscapeSequences.moveLeftNormal
                 // Update the carret to the new position so that deleteBackward will delete the correct character
-                let newOffset = max(_selectedTextRange.startPosition.offset - 1, 0)
+                let newOffset = textInputStorage.textInputOffset(_selectedTextRange.startPosition.offset, advancedByUTF16Distance: -1)
                 selectedTextRange = TextRange(from: TextPosition(offset: newOffset), 
                     to: TextPosition(offset: newOffset))
             } else {
                 data = terminal.applicationCursor ? EscapeSequences.moveRightApp : EscapeSequences.moveRightNormal
                 // Update the carret to the new position so that deleteForward will delete the correct character
-                let newOffset = min(_selectedTextRange.startPosition.offset + 1, textInputStorage.count)
+                let newOffset = textInputStorage.textInputOffset(_selectedTextRange.startPosition.offset, advancedByUTF16Distance: 1)
                 selectedTextRange = TextRange(from: TextPosition(offset: newOffset), 
                     to: TextPosition(offset: newOffset))
             }

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTextStorage.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTextStorage.swift
@@ -1,4 +1,89 @@
 import Foundation
+
+enum TextInputUTF16Rounding {
+  case backward
+  case forward
+}
+
+extension String {
+  var textInputUTF16Count: Int {
+    utf16.count
+  }
+
+  func textInputIndex(atUTF16Offset offset: Int, rounding: TextInputUTF16Rounding) -> String.Index {
+    let clampedOffset = max(0, min(offset, utf16.count))
+
+    func index(at offset: Int) -> String.Index? {
+      let utf16Index = utf16.index(utf16.startIndex, offsetBy: offset)
+      return String.Index(utf16Index, within: self)
+    }
+
+    if let exactIndex = index(at: clampedOffset) {
+      return exactIndex
+    }
+
+    switch rounding {
+    case .backward:
+      var candidate = clampedOffset
+      while candidate > 0 {
+        candidate -= 1
+        if let roundedIndex = index(at: candidate) {
+          return roundedIndex
+        }
+      }
+      return startIndex
+    case .forward:
+      var candidate = clampedOffset
+      while candidate < utf16.count {
+        candidate += 1
+        if let roundedIndex = index(at: candidate) {
+          return roundedIndex
+        }
+      }
+      return endIndex
+    }
+  }
+
+  func textInputUTF16Offset(of index: String.Index) -> Int {
+    guard let utf16Index = index.samePosition(in: utf16) else {
+      return utf16.count
+    }
+    return utf16.distance(from: utf16.startIndex, to: utf16Index)
+  }
+
+  func textInputValidUTF16Offset(_ offset: Int, rounding: TextInputUTF16Rounding) -> Int {
+    textInputUTF16Offset(of: textInputIndex(atUTF16Offset: offset, rounding: rounding))
+  }
+
+  func textInputOffset(_ offset: Int, advancedByUTF16Distance distance: Int) -> Int {
+    let rawOffset = max(0, min(offset + distance, utf16.count))
+    return textInputValidUTF16Offset(rawOffset, rounding: distance < 0 ? .backward : .forward)
+  }
+
+  func textInputRange(startUTF16Offset: Int, endUTF16Offset: Int) -> Range<String.Index> {
+    let startOffset = max(0, min(startUTF16Offset, utf16.count))
+    let endOffset = max(startOffset, min(endUTF16Offset, utf16.count))
+
+    if startOffset == endOffset {
+      let insertionIndex = textInputIndex(atUTF16Offset: startOffset, rounding: .forward)
+      return insertionIndex..<insertionIndex
+    }
+
+    let lowerBound = textInputIndex(atUTF16Offset: startOffset, rounding: .backward)
+    let upperBound = textInputIndex(atUTF16Offset: endOffset, rounding: .forward)
+    return lowerBound..<upperBound
+  }
+
+  func textInputCharacterRange(beforeUTF16Offset offset: Int) -> Range<String.Index>? {
+    let endIndex = textInputIndex(atUTF16Offset: offset, rounding: .forward)
+    guard endIndex > startIndex else {
+      return nil
+    }
+    let startIndex = index(before: endIndex)
+    return startIndex..<endIndex
+  }
+}
+
 #if canImport(UIKit)
 import UIKit
 
@@ -7,6 +92,7 @@ import UIKit
     These are not part of the public API, but are used internally.
 */
 class TextPosition: UITextPosition {
+  // UITextInput communicates text ranges with NSRange-style UTF-16 offsets.
   let offset: Int
   
   init(offset: Int) {
@@ -40,7 +126,7 @@ class TextRange: UITextRange {
   init(from: TextPosition, maxOffset: Int, in baseString: String) {
     if maxOffset >= 0 {
       self.startPosition = from
-      let end = min(baseString.count, from.offset + maxOffset)
+      let end = min(baseString.textInputUTF16Count, from.offset + maxOffset)
       self.endPosition = TextPosition(offset: end)
     } else {
       self.endPosition = from
@@ -62,9 +148,7 @@ class TextRange: UITextRange {
   }
   
   func fullRange(in baseString: String) -> Range<String.Index> {
-    let beginIndex = baseString.index(baseString.startIndex, offsetBy: startPosition.offset)
-    let endIndex = baseString.index(beginIndex, offsetBy: endPosition.offset - startPosition.offset)
-    return beginIndex..<endIndex
+    return baseString.textInputRange(startUTF16Offset: startPosition.offset, endUTF16Offset: endPosition.offset)
   }
   
   var length: Int {
@@ -106,7 +190,7 @@ class TextSelectionRect: UITextSelectionRect {
   init(rect: CGRect, range: TextRange, string: String) {
     _rect = rect
     _containsStart = range.startPosition.offset == 0
-    _containsEnd = range.endPosition.offset == string.count
+    _containsEnd = range.endPosition.offset == string.textInputUTF16Count
   }
 }
 #endif

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/ColorTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/ColorTests.swift
@@ -16,6 +16,20 @@ final class ColorTests {
         return (Int(color.red / 257), Int(color.green / 257), Int(color.blue / 257))
     }
 
+    private func luminance(_ color: Color) -> Double {
+        let (r8, g8, b8) = rgb8(color)
+
+        func linearize(_ value: Int) -> Double {
+            let srgb = Double(value) / 255.0
+            return srgb > 0.04045 ? pow((srgb + 0.055) / 1.055, 2.4) : srgb / 12.92
+        }
+
+        let r = linearize(r8)
+        let g = linearize(g8)
+        let b = linearize(b8)
+        return r * 0.2126 + g * 0.7152 + b * 0.0722
+    }
+
     @Test func testExtendedColor() {
         let h = HeadlessTerminal (queue: SwiftTermTests.queue) { exitCode in }
         
@@ -91,6 +105,76 @@ final class ColorTests {
         #expect(rgb8(generated[232]) != rgb8(xterm[232]))
     }
 
+    @Test func testAnsi256PaletteDarkThemeHarmoniousMatchesBase16Lab() {
+        let bg = Color(red8: 0, green8: 0, blue8: 0)
+        let fg = Color(red8: 255, green8: 255, blue8: 255)
+
+        let normal = Color.setupDefaultAnsiColors(initialColors: Color.xtermColors,
+                                                  strategy: .base16Lab,
+                                                  backgroundColor: bg,
+                                                  foregroundColor: fg)
+        let harmonious = Color.setupDefaultAnsiColors(initialColors: Color.xtermColors,
+                                                      strategy: .base16LabHarmonious,
+                                                      backgroundColor: bg,
+                                                      foregroundColor: fg)
+
+        for i in 16..<256 {
+            #expect(normal[i] == harmonious[i])
+        }
+    }
+
+    @Test func testAnsi256PaletteLightThemeHarmoniousSkipsInversion() {
+        let bg = Color(red8: 255, green8: 255, blue8: 255)
+        let fg = Color(red8: 0, green8: 0, blue8: 0)
+
+        let inverted = Color.setupDefaultAnsiColors(initialColors: Color.xtermColors,
+                                                    strategy: .base16Lab,
+                                                    backgroundColor: bg,
+                                                    foregroundColor: fg)
+        let harmonious = Color.setupDefaultAnsiColors(initialColors: Color.xtermColors,
+                                                      strategy: .base16LabHarmonious,
+                                                      backgroundColor: bg,
+                                                      foregroundColor: fg)
+
+        #expect(harmonious[16] == bg)
+        #expect(inverted[16] != bg)
+
+        var differ = 0
+        for i in 16..<232 {
+            if inverted[i] != harmonious[i] {
+                differ += 1
+            }
+        }
+        #expect(differ > 0)
+    }
+
+    @Test func testAnsi256PaletteLightThemeHarmoniousGrayscaleRampDirection() {
+        let bg = Color(red8: 255, green8: 255, blue8: 255)
+        let fg = Color(red8: 0, green8: 0, blue8: 0)
+
+        let inverted = Color.setupDefaultAnsiColors(initialColors: Color.xtermColors,
+                                                    strategy: .base16Lab,
+                                                    backgroundColor: bg,
+                                                    foregroundColor: fg)
+        var previousLuminance = 0.0
+        for i in 232..<256 {
+            let currentLuminance = luminance(inverted[i])
+            #expect(currentLuminance >= previousLuminance)
+            previousLuminance = currentLuminance
+        }
+
+        let harmonious = Color.setupDefaultAnsiColors(initialColors: Color.xtermColors,
+                                                      strategy: .base16LabHarmonious,
+                                                      backgroundColor: bg,
+                                                      foregroundColor: fg)
+        previousLuminance = 1.0
+        for i in 232..<256 {
+            let currentLuminance = luminance(harmonious[i])
+            #expect(currentLuminance <= previousLuminance)
+            previousLuminance = currentLuminance
+        }
+    }
+
     @Test func testTerminalAnsi256PaletteStrategyRuntimeToggle() {
         let h = HeadlessTerminal(queue: SwiftTermTests.queue) { _ in }
         let terminal = h.terminal!
@@ -108,6 +192,49 @@ final class ColorTests {
         terminal.ansi256PaletteStrategy = .base16Lab
         #expect(rgb8(terminal.ansiColors[17]) == (24, 12, 46))
         #expect(rgb8(terminal.ansiColors[232]) == (14, 14, 14))
+    }
+
+    @Test func testTerminalAnsi256PaletteStrategyRuntimeToggleIncludesHarmonious() {
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue) { _ in }
+        let terminal = h.terminal!
+        terminal.backgroundColor = Color(red8: 255, green8: 255, blue8: 255)
+        terminal.foregroundColor = Color(red8: 0, green8: 0, blue8: 0)
+
+        terminal.installPalette(colors: Color.xtermColors)
+
+        terminal.ansi256PaletteStrategy = .base16Lab
+        let invertedCubeOrigin = rgb8(terminal.ansiColors[16])
+        let invertedGrayStart = rgb8(terminal.ansiColors[232])
+        let invertedGrayEnd = rgb8(terminal.ansiColors[255])
+
+        terminal.ansi256PaletteStrategy = .base16LabHarmonious
+        let harmoniousCubeOrigin = rgb8(terminal.ansiColors[16])
+        let harmoniousGrayStart = rgb8(terminal.ansiColors[232])
+        let harmoniousGrayEnd = rgb8(terminal.ansiColors[255])
+
+        #expect(invertedCubeOrigin != harmoniousCubeOrigin)
+        #expect(harmoniousCubeOrigin == (255, 255, 255))
+        #expect(invertedGrayStart != harmoniousGrayStart)
+        #expect(invertedGrayEnd != harmoniousGrayEnd)
+        #expect(luminance(terminal.ansiColors[232]) >= luminance(terminal.ansiColors[255]))
+    }
+
+    @Test func testTerminalHarmoniousPaletteRebuildsWhenThemeColorsChange() {
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue) { _ in }
+        let terminal = h.terminal!
+        terminal.installPalette(colors: Color.xtermColors)
+        terminal.ansi256PaletteStrategy = .base16LabHarmonious
+
+        terminal.backgroundColor = Color(red8: 255, green8: 255, blue8: 255)
+        terminal.foregroundColor = Color(red8: 0, green8: 0, blue8: 0)
+        let lightThemeGray = rgb8(terminal.ansiColors[232])
+
+        terminal.backgroundColor = Color(red8: 0, green8: 0, blue8: 0)
+        terminal.foregroundColor = Color(red8: 255, green8: 255, blue8: 255)
+        let darkThemeGray = rgb8(terminal.ansiColors[232])
+
+        #expect(lightThemeGray != darkThemeGray)
+        #expect(luminance(terminal.ansiColors[232]) <= luminance(terminal.ansiColors[255]))
     }
 }
 #endif

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/IOSTextInputOffsetTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/IOSTextInputOffsetTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import SwiftTerm
+
+final class IOSTextInputOffsetTests: XCTestCase {
+    func testTextInputRangeAcceptsUTF16EndOffsetForThaiInput() {
+        let text = "ฟหกดเ้"
+        XCTAssertEqual(text.count, 5)
+        XCTAssertEqual(text.textInputUTF16Count, 6)
+
+        let stringRange = text.textInputRange(startUTF16Offset: 6, endUTF16Offset: 6)
+
+        XCTAssertEqual(String(text[stringRange]), "")
+        XCTAssertEqual(text.textInputUTF16Offset(of: stringRange.lowerBound), 6)
+    }
+
+    func testFullRangeUsesUTF16OffsetsForThaiInput() {
+        let text = "ฟหกดเ้"
+        let range = text.textInputRange(startUTF16Offset: 0, endUTF16Offset: 6)
+
+        XCTAssertEqual(String(text[range]), text)
+    }
+
+    func testDeleteRangeBeforeUTF16OffsetKeepsThaiClusterTogether() {
+        let text = "ฟหกดเ้"
+        let range = text.textInputCharacterRange(beforeUTF16Offset: 6)
+
+        XCTAssertEqual(range.map { String(text[$0]) }, "เ้")
+        XCTAssertEqual(range.map { text.textInputUTF16Offset(of: $0.lowerBound) }, 4)
+    }
+
+#if canImport(UIKit)
+    func testTextRangeFullRangeUsesUTF16OffsetsForThaiInput() {
+        let text = "ฟหกดเ้"
+        let range = TextRange(from: TextPosition(offset: 0), to: TextPosition(offset: 6))
+
+        XCTAssertEqual(String(text[range.fullRange(in: text)]), text)
+    }
+#endif
+}

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/KittyOptionComposeTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/KittyOptionComposeTests.swift
@@ -1,0 +1,79 @@
+//
+//  KittyOptionComposeTests.swift
+//
+//  Regression coverage for Option-as-compose / AltGr input under the kitty
+//  keyboard protocol. On layouts where a printable character is produced via
+//  Option (e.g. Czech Option+2 = "@", German AltGr+Q = "@"), the composed
+//  character must reach the PTY even when the application negotiates
+//  reportAllKeys/reportAlternates without reportText. Previously the kitty
+//  encoder keyed off the base-layout codepoint and dropped the composed glyph.
+//
+#if os(macOS)
+import AppKit
+import Testing
+@testable import SwiftTerm
+
+final class KittyOptionComposeTests {
+
+    /// Captures bytes the view sends to the PTY.
+    private final class CapturingDelegate: TerminalViewDelegate {
+        var sent: [UInt8] = []
+        func send(source: TerminalView, data: ArraySlice<UInt8>) { sent.append(contentsOf: data) }
+        func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {}
+        func setTerminalTitle(source: TerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+        func scrolled(source: TerminalView, position: Double) {}
+        func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+        func bell(source: TerminalView) {}
+        func clipboardCopy(source: TerminalView, content: Data) {}
+        func clipboardRead(source: TerminalView) -> Data? { nil }
+        func iTermContent(source: TerminalView, content: ArraySlice<UInt8>) {}
+        func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+    }
+
+    private func optionKeyEvent(characters: String,
+                                charactersIgnoringModifiers: String,
+                                keyCode: UInt16) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .option,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode)!
+    }
+
+    /// Czech Option+2 produces "@" while the bare key produces "ě". With the
+    /// kitty protocol active (disambiguate + reportAlternates + reportAllKeys,
+    /// the Bubble Tea default that OpenCode uses) and Option not acting as Meta,
+    /// the PTY must receive the composed "@", not the base-layout key.
+    @Test func testOptionComposedCharacterSendsComposedText() {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let delegate = CapturingDelegate()
+        view.terminalDelegate = delegate
+        view.optionAsMetaKey = false
+
+        // Push kitty flags 11 = disambiguate(1) + reportAlternates(2) + reportAllKeys(8).
+        view.getTerminal().feed(text: "\u{1b}[>11u")
+
+        // kVK_ANSI_2 == 19. Bare key on the Czech layout yields "ě"; Option composes "@".
+        let event = optionKeyEvent(characters: "@", charactersIgnoringModifiers: "ě", keyCode: 19)
+        view.keyDown(with: event)
+
+        // keyDown sets the pending key event and forwards to interpretKeyEvents.
+        // In a headless test interpretKeyEvents is a no-op, so we drive the text
+        // commit ourselves. If a given environment *does* commit synchronously,
+        // keyDown already produced the output and we assert on that instead, so
+        // the test fails only when the composed character is actually wrong.
+        if delegate.sent.isEmpty {
+            view.insertText("@", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        #expect(delegate.sent == Array("@".utf8))
+    }
+}
+#endif

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/MouseTrackingTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/MouseTrackingTests.swift
@@ -1,0 +1,510 @@
+import Testing
+@testable import SwiftTerm
+
+#if os(macOS)
+import AppKit
+
+private final class MouseMotionCapturingDelegate: TerminalViewDelegate {
+    var sentData: [[UInt8]] = []
+
+    func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {}
+    func setTerminalTitle(source: TerminalView, title: String) {}
+    func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+    func send(source: TerminalView, data: ArraySlice<UInt8>) { sentData.append(Array(data)) }
+    func scrolled(source: TerminalView, position: Double) {}
+    func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+}
+#endif
+
+struct MouseTrackingTests {
+    private let esc = "\u{1b}"
+
+#if os(macOS)
+    @Test func trackingAreaAvoidsMouseMovedOnTahoe() {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        view.terminal.feed(text: "\(esc)[?1003h")
+
+        guard let tracking = view.tracking else {
+            Issue.record("All-motion mouse reporting should install a tracking area")
+            return
+        }
+
+        if #available(macOS 26, *) {
+            #expect(!tracking.options.contains(.mouseMoved))
+        } else {
+            #expect(tracking.options.contains(.mouseMoved))
+        }
+    }
+
+    @Test func commandReleaseDeregistersUnusedMouseTracking() {
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        view.commandActive = true
+        view.startTracking()
+        #expect(view.tracking != nil)
+
+        view.turnOffUrlPreview()
+        #expect(view.tracking == nil)
+    }
+
+    @Test @MainActor func TahoeFallbackForwardsWindowMouseMovedEvents() {
+        guard #available(macOS 26, *) else { return }
+
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 320, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = view
+        let wasAcceptingMouseMovedEvents = window.acceptsMouseMovedEvents
+
+        let delegate = MouseMotionCapturingDelegate()
+        view.terminalDelegate = delegate
+        view.terminal.feed(text: "\(esc)[?1003h\(esc)[?1006h")
+        #expect(window.acceptsMouseMovedEvents)
+
+        let event = NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: CGPoint(x: 20, y: 20),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 0,
+            pressure: 0
+        )!
+        NSApplication.shared.sendEvent(event)
+
+        #expect(!delegate.sentData.isEmpty)
+
+        view.terminal.feed(text: "\(esc)[?1003l")
+        #expect(window.acceptsMouseMovedEvents == wasAcceptingMouseMovedEvents)
+    }
+
+    @Test @MainActor func TahoeFallbackIgnoresOutOfBoundsMouseMoved() {
+        guard #available(macOS 26, *) else { return }
+
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 320, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = view
+
+        let delegate = MouseMotionCapturingDelegate()
+        view.terminalDelegate = delegate
+        view.terminal.feed(text: "\(esc)[?1003h\(esc)[?1006h")
+
+        // `acceptsMouseMovedEvents` delivers mouseMoved to the first responder regardless
+        // of the pointer's location, so a move outside the view must not be reported.
+        let outside = NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: CGPoint(x: 1000, y: 1000),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 0,
+            pressure: 0
+        )!
+        view.mouseMoved(with: outside)
+        #expect(delegate.sentData.isEmpty)
+
+        // A move inside the view is still reported.
+        let inside = NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: CGPoint(x: 20, y: 20),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 2,
+            clickCount: 0,
+            pressure: 0
+        )!
+        view.mouseMoved(with: inside)
+        #expect(!delegate.sentData.isEmpty)
+    }
+
+    @Test @MainActor func TahoeFallbackDoesNotClobberHostDisablingMouseMoved() {
+        guard #available(macOS 26, *) else { return }
+
+        let view = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 320, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = view
+        // The host has its own reason to want mouse-moved events on.
+        window.acceptsMouseMovedEvents = true
+
+        view.terminal.feed(text: "\(esc)[?1003h")
+        #expect(window.acceptsMouseMovedEvents)
+
+        // The host disables it while the terminal is still tracking.
+        window.acceptsMouseMovedEvents = false
+
+        // Ending the terminal's fallback must respect the host's choice, not force the
+        // captured original value back on.
+        view.terminal.feed(text: "\(esc)[?1003l")
+        #expect(!window.acceptsMouseMovedEvents)
+    }
+
+    @Test @MainActor func TahoeFallbackSharesWindowMouseMovedSettingAcrossTerminalViews() {
+        guard #available(macOS 26, *) else { return }
+
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 320, height: 160),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: CGRect(x: 0, y: 0, width: 320, height: 160))
+        let firstView = TerminalView(frame: CGRect(x: 0, y: 0, width: 160, height: 160))
+        let secondView = TerminalView(frame: CGRect(x: 160, y: 0, width: 160, height: 160))
+        container.addSubview(firstView)
+        container.addSubview(secondView)
+        window.contentView = container
+        let wasAcceptingMouseMovedEvents = window.acceptsMouseMovedEvents
+
+        firstView.terminal.feed(text: "\(esc)[?1003h")
+        secondView.terminal.feed(text: "\(esc)[?1003h")
+        #expect(window.acceptsMouseMovedEvents)
+
+        firstView.terminal.feed(text: "\(esc)[?1003l")
+        #expect(window.acceptsMouseMovedEvents)
+
+        secondView.terminal.feed(text: "\(esc)[?1003l")
+        #expect(window.acceptsMouseMovedEvents == wasAcceptingMouseMovedEvents)
+    }
+#endif
+
+    @Test func encodeButtonScrollUp() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        let flags = terminal.encodeButton(button: 4, release: false, shift: false, meta: false, control: false)
+        #expect(flags == 64)
+    }
+
+    @Test func encodeButtonScrollDown() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        let flags = terminal.encodeButton(button: 5, release: false, shift: false, meta: false, control: false)
+        #expect(flags == 65)
+    }
+
+    @Test func encodeButtonScrollUpWithShift() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        let flags = terminal.encodeButton(button: 4, release: false, shift: true, meta: false, control: false)
+        #expect(flags == 68)
+    }
+
+    @Test func encodeButtonScrollDownWithControl() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        let flags = terminal.encodeButton(button: 5, release: false, shift: false, meta: false, control: true)
+        #expect(flags == 81)
+    }
+
+    @Test func encodeButtonScrollUpWithAllModifiers() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        let flags = terminal.encodeButton(button: 4, release: false, shift: true, meta: true, control: true)
+        #expect(flags == 92)
+    }
+
+    @Test func encodeButtonIgnoresModifiersInX10Mode() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?9h")
+        #expect(terminal.mouseMode == .x10)
+        let flags = terminal.encodeButton(button: 4, release: false, shift: true, meta: true, control: true)
+        #expect(flags == 64)
+    }
+
+    @Test func allNonOffMouseModesForwardScrollEvents() {
+        let forwardingModes: [Terminal.MouseMode] = [.x10, .vt200, .buttonEventTracking, .anyEvent]
+        for mode in forwardingModes {
+            #expect(mode != .off, "Mode \(mode) should forward scroll events")
+        }
+        #expect(Terminal.MouseMode.off == .off)
+    }
+
+    @Test func mouseModeSetAndResetByCSISequences() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        #expect(terminal.mouseMode == .off)
+
+        terminal.feed(text: "\(esc)[?9h")
+        #expect(terminal.mouseMode == .x10)
+
+        terminal.feed(text: "\(esc)[?9l")
+        #expect(terminal.mouseMode == .off)
+
+        terminal.feed(text: "\(esc)[?1000h")
+        #expect(terminal.mouseMode == .vt200)
+
+        terminal.feed(text: "\(esc)[?1000l")
+        #expect(terminal.mouseMode == .off)
+
+        terminal.feed(text: "\(esc)[?1002h")
+        #expect(terminal.mouseMode == .buttonEventTracking)
+
+        terminal.feed(text: "\(esc)[?1002l")
+        #expect(terminal.mouseMode == .off)
+
+        terminal.feed(text: "\(esc)[?1003h")
+        #expect(terminal.mouseMode == .anyEvent)
+
+        terminal.feed(text: "\(esc)[?1003l")
+        #expect(terminal.mouseMode == .off)
+    }
+
+    @Test func scrollUpSendEventProducesSgrOutput() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        terminal.feed(text: "\(esc)[?1006h")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 4, release: false, shift: false, meta: false, control: false)
+        #expect(buttonFlags == 64)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 10, y: 5, pixelX: 10, pixelY: 5)
+
+        let sentString = String(bytes: delegate.sentData.flatMap { $0 }, encoding: .utf8) ?? ""
+        #expect(sentString == "\(esc)[<64;11;6M")
+    }
+
+    @Test func scrollDownSendEventProducesSgrOutput() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        terminal.feed(text: "\(esc)[?1006h")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 5, release: false, shift: false, meta: false, control: false)
+        #expect(buttonFlags == 65)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 0, y: 0, pixelX: 0, pixelY: 0)
+
+        let sentString = String(bytes: delegate.sentData.flatMap { $0 }, encoding: .utf8) ?? ""
+        #expect(sentString == "\(esc)[<65;1;1M")
+    }
+
+    @Test func scrollUpWithShiftSendEventEncodesSgrOutput() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        terminal.feed(text: "\(esc)[?1006h")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 4, release: false, shift: true, meta: false, control: false)
+        #expect(buttonFlags == 68)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 5, y: 3, pixelX: 5, pixelY: 3)
+
+        let sentString = String(bytes: delegate.sentData.flatMap { $0 }, encoding: .utf8) ?? ""
+        #expect(sentString == "\(esc)[<68;6;4M")
+    }
+
+    @Test func scrollEventUsesX10EncodingByDefault() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 4, release: false, shift: false, meta: false, control: false)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 10, y: 5, pixelX: 10, pixelY: 5)
+
+        let sentBytes = delegate.sentData.flatMap { $0 }
+        let expected: [UInt8] = [0x1b, UInt8(ascii: "["), UInt8(ascii: "M"), 96, 43, 38]
+        #expect(sentBytes == expected)
+    }
+
+    @Test func multipleScrollLinesSendMultipleEvents() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        terminal.feed(text: "\(esc)[?1006h")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 4, release: false, shift: false, meta: false, control: false)
+        for _ in 0..<3 {
+            terminal.sendEvent(buttonFlags: buttonFlags, x: 5, y: 3, pixelX: 5, pixelY: 3)
+        }
+
+        #expect(delegate.sentData.count == 3)
+        for data in delegate.sentData {
+            let sentString = String(bytes: data, encoding: .utf8) ?? ""
+            #expect(sentString == "\(esc)[<64;6;4M")
+        }
+    }
+
+    @Test func encodeButtonReleaseOverridesScrollValue() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        let flags = terminal.encodeButton(button: 4, release: true, shift: false, meta: false, control: false)
+        #expect(flags == 3)
+    }
+
+    @Test func scrollEventAtMaxCoordinates() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal(cols: 80, rows: 24)
+        terminal.feed(text: "\(esc)[?1000h")
+        terminal.feed(text: "\(esc)[?1006h")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 5, release: false, shift: false, meta: false, control: false)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 79, y: 23, pixelX: 79, pixelY: 23)
+
+        let sentString = String(bytes: delegate.sentData.flatMap { $0 }, encoding: .utf8) ?? ""
+        #expect(sentString == "\(esc)[<65;80;24M")
+    }
+
+    @Test func scrollEventAtOrigin() {
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1003h")
+        terminal.feed(text: "\(esc)[?1006h")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 4, release: false, shift: false, meta: false, control: false)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 0, y: 0, pixelX: 0, pixelY: 0)
+
+        let sentString = String(bytes: delegate.sentData.flatMap { $0 }, encoding: .utf8) ?? ""
+        #expect(sentString == "\(esc)[<64;1;1M")
+    }
+
+    @Test func xtshiftescapeDefaultsToOff() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        #expect(terminal.mouseShiftCapture == false)
+    }
+
+    @Test func xtshiftescapeEnableAndDisable() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+
+        terminal.feed(text: "\(esc)[>1s")
+        #expect(terminal.mouseShiftCapture == true)
+
+        terminal.feed(text: "\(esc)[>0s")
+        #expect(terminal.mouseShiftCapture == false)
+    }
+
+    @Test func xtshiftescapeMissingParameterDisables() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[>1s")
+        #expect(terminal.mouseShiftCapture == true)
+
+        // Per xterm, `CSI > s` with no Ps is equivalent to Ps = 0.
+        terminal.feed(text: "\(esc)[>s")
+        #expect(terminal.mouseShiftCapture == false)
+    }
+
+    @Test func xtshiftescapeIgnoresUnknownParameter() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[>1s")
+        #expect(terminal.mouseShiftCapture == true)
+
+        // Unknown Ps values must leave the current state untouched.
+        terminal.feed(text: "\(esc)[>9s")
+        #expect(terminal.mouseShiftCapture == true)
+    }
+
+    @Test func xtshiftescapeClearedByHardReset() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[>1s")
+        #expect(terminal.mouseShiftCapture == true)
+
+        terminal.resetToInitialState()
+        #expect(terminal.mouseShiftCapture == false)
+    }
+
+    @Test func csiSWithUnknownIntermediateDoesNotSaveCursor() {
+        // Regression: CSI <intermediate> s with an intermediate other than '>'
+        // must not be routed to save-cursor or DECSLRM.
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+
+        // Position cursor at (col 10, row 5) and send "CSI ? s". If misrouted to
+        // save-cursor, this position would be saved.
+        terminal.feed(text: "\(esc)[5;10H")
+        terminal.feed(text: "\(esc)[?s")
+
+        // Move somewhere else, then restore.
+        terminal.feed(text: "\(esc)[1;1H")
+        terminal.feed(text: "\(esc)[u")
+
+        // Restore must fall back to the default saved position (0,0), not (9,4).
+        #expect(terminal.buffer.x == 0)
+        #expect(terminal.buffer.y == 0)
+    }
+
+    // MARK: - DECRST on encoding modes (1005/1006/1015/1016) must not stop tracking
+
+    @Test func decrstEncodingModeKeepsTrackingEnabled() {
+        // 1005/1006/1015/1016 select the coordinate encoding and are independent of
+        // the tracking modes (9/1000-1003): resetting an encoding reverts how
+        // coordinates are encoded, it must not turn tracking off (in xterm these are
+        // separate state variables: extend_coords vs send_mouse_pos).
+        for encodingMode in [1005, 1006, 1015, 1016] {
+            let (terminal, _) = TerminalTestHarness.makeTerminal()
+            terminal.feed(text: "\(esc)[?1003h")
+            terminal.feed(text: "\(esc)[?\(encodingMode)h")
+            terminal.feed(text: "\(esc)[?\(encodingMode)l")
+            #expect(terminal.mouseMode == .anyEvent, "DECRST \(encodingMode) must not disable mouse tracking")
+        }
+    }
+
+    @Test func decrstEncodingModeStillResetsEncoding() {
+        // After ?1006l events are reported in the default X10 encoding again.
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1000h")
+        terminal.feed(text: "\(esc)[?1006h")
+        terminal.feed(text: "\(esc)[?1006l")
+        delegate.clearSentData()
+
+        let buttonFlags = terminal.encodeButton(button: 4, release: false, shift: false, meta: false, control: false)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 10, y: 5, pixelX: 10, pixelY: 5)
+
+        let sentBytes = delegate.sentData.flatMap { $0 }
+        let expected: [UInt8] = [0x1b, UInt8(ascii: "["), UInt8(ascii: "M"), 96, 43, 38]
+        #expect(sentBytes == expected)
+    }
+
+    @Test func decrstEncodingModeReportedViaDecrqm() {
+        // DECRQM after ?1006l: the encoding reports reset while tracking reports set.
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1003h")
+        terminal.feed(text: "\(esc)[?1006h")
+        terminal.feed(text: "\(esc)[?1006l")
+        delegate.clearSentData()
+
+        terminal.feed(text: "\(esc)[?1006$p")
+        terminal.feed(text: "\(esc)[?1003$p")
+
+        let responses = delegate.sentData.map { String(bytes: $0, encoding: .utf8) ?? "" }
+        #expect(responses == ["\(esc)[?1006;2$y", "\(esc)[?1003;1$y"])
+    }
+
+    @Test func moshStyleModeReassertKeepsTrackingAndSgrEncoding() {
+        // mosh re-asserts mouse state on every resize/reattach repaint as
+        // "CSI ?1003l ?1003h ?1004l ?1006l ?1006h"; the trailing ?1006l used to
+        // disable tracking right after ?1003h re-enabled it, leaving mouse
+        // reporting permanently off after the first resize.
+        let (terminal, delegate) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1003h\(esc)[?1006h") // app enables mouse reporting
+        terminal.feed(text: "\(esc)[?1003l\(esc)[?1003h\(esc)[?1004l\(esc)[?1006l\(esc)[?1006h")
+        #expect(terminal.mouseMode == .anyEvent)
+        delegate.clearSentData()
+
+        // Events must still flow, SGR-encoded.
+        let buttonFlags = terminal.encodeButton(button: 4, release: false, shift: false, meta: false, control: false)
+        terminal.sendEvent(buttonFlags: buttonFlags, x: 10, y: 5, pixelX: 10, pixelY: 5)
+
+        let sentString = String(bytes: delegate.sentData.flatMap { $0 }, encoding: .utf8) ?? ""
+        #expect(sentString == "\(esc)[<64;11;6M")
+    }
+
+    @Test func decrstTrackingModeStillDisablesTracking() {
+        // The tracking modes themselves still turn tracking off, also when an
+        // encoding is active.
+        let (terminal, _) = TerminalTestHarness.makeTerminal()
+        terminal.feed(text: "\(esc)[?1003h")
+        terminal.feed(text: "\(esc)[?1006h")
+        terminal.feed(text: "\(esc)[?1003l")
+        #expect(terminal.mouseMode == .off)
+    }
+}

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/OscTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/OscTests.swift
@@ -201,17 +201,111 @@ final class SwiftTermOsc {
         // Should not crash, ID helps group multi-line hyperlinks
     }
 
-    /// Test OSC 52 (clipboard) query
-    /// From Ghostty: "clipboard_contents"
-    @Test func testOscClipboardQuery() {
+    private final class ClipboardDelegate: TerminalDelegate {
+        var copiedContent: Data?
+        var clipboardData: Data?
+        var sentData: [UInt8] = []
+
+        func clipboardCopy(source: Terminal, content: Data) {
+            copiedContent = content
+        }
+
+        func clipboardRead(source: Terminal) -> Data? {
+            return clipboardData
+        }
+
+        func send(source: Terminal, data: ArraySlice<UInt8>) {
+            sentData.append(contentsOf: data)
+        }
+    }
+
+    /// Test OSC 52 clipboard write with selection type "c"
+    @Test func testOscClipboardWrite() {
+        let delegate = ClipboardDelegate()
+        let terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: 80, rows: 24, scrollback: 0)
+        )
+
+        // "hello" in base64 is "aGVsbG8="
+        terminal.feed(text: "\u{1b}]52;c;aGVsbG8=\u{07}")
+        #expect(delegate.copiedContent == "hello".data(using: .utf8))
+    }
+
+    /// Test OSC 52 clipboard write with primary selection type "p"
+    @Test func testOscClipboardWritePrimarySelection() {
+        let delegate = ClipboardDelegate()
+        let terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: 80, rows: 24, scrollback: 0)
+        )
+
+        terminal.feed(text: "\u{1b}]52;p;aGVsbG8=\u{07}")
+        #expect(delegate.copiedContent == "hello".data(using: .utf8))
+    }
+
+    /// Test OSC 52 clipboard write with empty selection (defaults to "c")
+    @Test func testOscClipboardWriteDefaultSelection() {
+        let delegate = ClipboardDelegate()
+        let terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: 80, rows: 24, scrollback: 0)
+        )
+
+        terminal.feed(text: "\u{1b}]52;;aGVsbG8=\u{07}")
+        #expect(delegate.copiedContent == "hello".data(using: .utf8))
+    }
+
+    /// Test OSC 52 clipboard write with invalid base64 is ignored
+    @Test func testOscClipboardWriteInvalidBase64() {
+        let delegate = ClipboardDelegate()
+        let terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: 80, rows: 24, scrollback: 0)
+        )
+
+        terminal.feed(text: "\u{1b}]52;c;not!valid!base64!!!\u{07}")
+        #expect(delegate.copiedContent == nil)
+    }
+
+    /// Test OSC 52 clipboard read query – delegate allows
+    @Test func testOscClipboardReadAllowed() {
+        let delegate = ClipboardDelegate()
+        delegate.clipboardData = "from clipboard".data(using: .utf8)
+        let terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: 80, rows: 24, scrollback: 0)
+        )
+
+        terminal.feed(text: "\u{1b}]52;c;?\u{07}")
+
+        let response = String(bytes: delegate.sentData, encoding: .utf8) ?? ""
+        let base64 = Data("from clipboard".utf8).base64EncodedString()
+        #expect(response.contains("52;c;\(base64)"))
+    }
+
+    /// Test OSC 52 clipboard read query – delegate denies (returns nil)
+    @Test func testOscClipboardReadDenied() {
+        let delegate = ClipboardDelegate()
+        delegate.clipboardData = nil
+        let terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: 80, rows: 24, scrollback: 0)
+        )
+
+        terminal.feed(text: "\u{1b}]52;c;?\u{07}")
+
+        // No response should be sent when denied
+        #expect(delegate.sentData.isEmpty)
+    }
+
+    /// Test OSC 52 clipboard read – default delegate denies
+    @Test func testOscClipboardReadDefaultDenied() {
         let h = HeadlessTerminal(queue: SwiftTermTests.queue) { _ in }
         let t = h.terminal!
 
-        // Query clipboard (sends '?' as data)
+        // Query clipboard — default clipboardRead returns nil, so no response
         t.feed(text: "\u{1b}]52;c;?\u{07}")
-
-        // Terminal should respond with clipboard contents or empty
-        // Response verification depends on implementation
     }
 
     /// Test OSC progress states

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/RetainCycleTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/RetainCycleTests.swift
@@ -1,0 +1,41 @@
+#if os(macOS)
+import Foundation
+import Testing
+
+@testable import SwiftTerm
+
+private class NoOpTerminalDelegate: TerminalDelegate {
+    func send(source: Terminal, data: ArraySlice<UInt8>) {}
+}
+
+final class RetainCycleTests {
+
+    @Test("Terminal deallocates after resetNormalBuffer()")
+    func terminalDeallocatesAfterResetNormalBuffer() {
+        weak var weakTerminal: Terminal?
+
+        autoreleasepool {
+            let delegate = NoOpTerminalDelegate()
+            let terminal = Terminal(delegate: delegate, options: TerminalOptions(cols: 80, rows: 24))
+            weakTerminal = terminal
+            terminal.resetNormalBuffer()
+        }
+
+        #expect(weakTerminal == nil, "Terminal leaked — retain cycle in resetNormalBuffer() scroll closure")
+    }
+
+    @Test("Terminal deallocates after resetToInitialState()")
+    func terminalDeallocatesAfterResetToInitialState() {
+        weak var weakTerminal: Terminal?
+
+        autoreleasepool {
+            let delegate = NoOpTerminalDelegate()
+            let terminal = Terminal(delegate: delegate, options: TerminalOptions(cols: 80, rows: 24))
+            weakTerminal = terminal
+            terminal.resetToInitialState()
+        }
+
+        #expect(weakTerminal == nil, "Terminal leaked — retain cycle after resetToInitialState()")
+    }
+}
+#endif

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/ScreenTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/ScreenTests.swift
@@ -399,6 +399,33 @@ final class ScreenTests {
         TerminalTestHarness.assertLineText(terminal.buffer, row: 4, equals: "line3")
     }
 
+    /// From Ghostty: Terminal: scrollDown left/right scroll region
+    @Test func testScrollDownLeftRightMargins() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal(cols: 10, rows: 10, scrollback: 0)
+        terminal.feed(text: "ABC123\r\nDEF456\r\nGHI789")
+        terminal.feed(text: "\(esc)[?69h")
+        terminal.feed(text: "\(esc)[2;4s")
+        terminal.feed(text: "\(esc)[2;2H")
+        terminal.feed(text: "\(esc)[1T")
+
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 0, equals: "A   23")
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 1, equals: "DBC156")
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 2, equals: "GEF489")
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 3, equals: " HI7")
+    }
+
+    @Test func testScrollDownOnAlternateBufferUsesFullWidthByDefault() {
+        let (terminal, _) = TerminalTestHarness.makeTerminal(cols: 4, rows: 4, scrollback: 0)
+        terminal.feed(text: "\(esc)[?1049h")
+        terminal.feed(text: "A0\r\nB1\r\nC2\r\nD3")
+        terminal.feed(text: "\(esc)[1T")
+
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 0, equals: "")
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 1, equals: "A0")
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 2, equals: "B1")
+        TerminalTestHarness.assertLineText(terminal.buffer, row: 3, equals: "C2")
+    }
+
     /// Test cursor movement: CUU (up), CUD (down), CUF (forward), CUB (back)
     @Test func testCursorMovement() {
         let (terminal, _) = TerminalTestHarness.makeTerminal(cols: 10, rows: 10, scrollback: 0)

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/SelectionTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/SelectionTests.swift
@@ -76,6 +76,37 @@ final class SelectionTests: TerminalDelegate {
         view.scrollTo(row: 1)
         #expect(view.calculateMouseHit(at: CGPoint(x: 0, y: 10)).grid.row == 1)
     }
+
+    @Test func testScrollToMarksTerminalAsUserScrolling() {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 400, height: 100)))
+
+        for i in 0..<30 {
+            view.terminal.feed(text: "line \(i)\r\n")
+        }
+
+        let bottom = view.terminal.displayBuffer.yDisp
+        let target = max(0, bottom - 3)
+        view.scrollTo(row: target)
+
+        #expect(view.terminal.userScrolling)
+        view.terminal.feed(text: "incoming\r\n")
+        #expect(view.terminal.displayBuffer.yDisp == target)
+
+        view.scrollTo(row: view.terminal.displayBuffer.yBase)
+        #expect(!view.terminal.userScrolling)
+    }
+
+    @Test func testZeroSizedResizeDoesNotChangeTerminalDimensions() {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 320, height: 160)))
+        let originalCols = view.terminal.cols
+        let originalRows = view.terminal.rows
+
+        let changed = view.processSizeChange(newSize: .zero)
+
+        #expect(!changed)
+        #expect(view.terminal.cols == originalCols)
+        #expect(view.terminal.rows == originalRows)
+    }
 #endif
 
     // MARK: - Selection Tests Ported from Ghostty
@@ -317,5 +348,38 @@ final class SelectionTests: TerminalDelegate {
         // The position should be set
         #expect(selection.start.col == 3)
         #expect(selection.end.col == 3)
+    }
+
+    /// After a double-click word selection, dragging *backwards* (to the left)
+    /// must keep the seed word in the selection. Regression test: previously the
+    /// drag pinned `start` to the seed word's start and dropped the seed word,
+    /// so dragging from "bbb" onto "aaa" selected only "aaa ".
+    @Test func testWordDragExtendBackwardIncludesSeedWord() {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: 20, rows: 1))
+        let selection = SelectionService(terminal: terminal)
+        terminal.feed(text: "aaa bbb ccc")
+
+        // Double-click "bbb"
+        selection.selectWordOrExpression(at: Position(col: 5, row: 0), in: terminal.buffer)
+        #expect(selection.getSelectedText() == "bbb")
+
+        // Drag left into "aaa"
+        selection.dragExtend(row: 0, col: 1)
+        #expect(selection.getSelectedText() == "aaa bbb")
+    }
+
+    /// After a double-click word selection, dragging forwards extends the
+    /// selection by whole words (this already worked and must keep working).
+    @Test func testWordDragExtendForwardExtendsByWords() {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: 20, rows: 1))
+        let selection = SelectionService(terminal: terminal)
+        terminal.feed(text: "aaa bbb ccc")
+
+        // Double-click "bbb"
+        selection.selectWordOrExpression(at: Position(col: 5, row: 0), in: terminal.buffer)
+
+        // Drag right into "ccc"
+        selection.dragExtend(row: 0, col: 9)
+        #expect(selection.getSelectedText() == "bbb ccc")
     }
 }

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/SynchronizedOutputTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/SynchronizedOutputTests.swift
@@ -1,8 +1,11 @@
+import Foundation
 import Testing
 @testable import SwiftTerm
 
 final class SynchronizedOutputTests {
     private class TestDelegate: TerminalDelegate {
+        var scrolledPositions: [Int] = []
+
         func showCursor(source: Terminal) {}
         func hideCursor(source: Terminal) {}
         func setTerminalTitle(source: Terminal, title: String) {}
@@ -10,7 +13,9 @@ final class SynchronizedOutputTests {
         func windowCommand(source: Terminal, command: Terminal.WindowManipulationCommand) -> [UInt8]? { return nil }
         func sizeChanged(source: Terminal) {}
         func send(source: Terminal, data: ArraySlice<UInt8>) {}
-        func scrolled(source: Terminal, yDisp: Int) {}
+        func scrolled(source: Terminal, yDisp: Int) {
+            scrolledPositions.append(yDisp)
+        }
         func linefeed(source: Terminal) {}
         func bufferActivated(source: Terminal) {}
         func bell(source: Terminal) {}
@@ -33,7 +38,14 @@ final class SynchronizedOutputTests {
         ).replacingOccurrences(of: "\u{0}", with: " ")
     }
 
-    @Test func testSynchronizedOutputBlocksDisplayUntilReset() {
+    /// Synchronized output (DEC mode 2026) no longer snapshots the buffer in
+    /// the core: `displayBuffer === buffer` and the live buffer is mutated
+    /// immediately. Display blocking is enforced at the view layer instead
+    /// (`AppleTerminalView.updateDisplay` early-returns while the flag is set,
+    /// covered by the view-level tests below). This test pins the core
+    /// contract: the active flag toggles on `?2026h`/`?2026l`, and the live
+    /// buffer always reflects the most recent content.
+    @Test func testSynchronizedOutputTracksLiveBufferAndTogglesFlag() {
         let terminal = Terminal(
             delegate: TestDelegate(),
             options: TerminalOptions(cols: 20, rows: 5, scrollback: 0)
@@ -42,14 +54,115 @@ final class SynchronizedOutputTests {
 
         terminal.feed(text: "\(esc)[2J\(esc)[HOLD")
         #expect(topLineText(from: terminal.displayBuffer).hasPrefix("OLD"))
+        #expect(!terminal.synchronizedOutputActive)
 
         terminal.feed(text: "\(esc)[?2026h")
-        terminal.feed(text: "\(esc)[2J\(esc)[HNEW")
+        #expect(terminal.synchronizedOutputActive)
 
-        #expect(topLineText(from: terminal.displayBuffer).hasPrefix("OLD"))
+        terminal.feed(text: "\(esc)[2J\(esc)[HNEW")
+        // Core does not freeze the buffer during sync; the new content is live
+        // immediately and displayBuffer mirrors it.
         #expect(topLineText(from: terminal.buffer).hasPrefix("NEW"))
+        #expect(topLineText(from: terminal.displayBuffer).hasPrefix("NEW"))
 
         terminal.feed(text: "\(esc)[?2026l")
+        #expect(!terminal.synchronizedOutputActive)
         #expect(topLineText(from: terminal.displayBuffer).hasPrefix("NEW"))
     }
+
+    /// Regression: setViewYDisp must update both live and frozen buffers
+    /// during synchronized output so user-initiated scrolling is not dropped.
+    @Test func testViewportScrollDuringSyncUpdatesBothBuffers() {
+        let terminal = Terminal(
+            delegate: TestDelegate(),
+            options: TerminalOptions(cols: 40, rows: 5, scrollback: 20)
+        )
+        let esc = "\u{1b}"
+
+        for i in 0..<25 {
+            terminal.feed(text: "line \(i)\r\n")
+        }
+
+        terminal.feed(text: "\(esc)[?2026h")
+        #expect(terminal.synchronizedOutputActive)
+
+        let yDispBefore = terminal.displayBuffer.yDisp
+        let scrollTarget = max(0, yDispBefore - 3)
+        terminal.setViewYDisp(scrollTarget)
+
+        #expect(terminal.displayBuffer.yDisp == scrollTarget)
+        #expect(terminal.buffer.yDisp == scrollTarget)
+
+        terminal.feed(text: "\(esc)[?2026l")
+    }
+
+    /// Regression: after sync ends the delegate must receive a scrolled
+    /// notification so host UI can update its scroll indicators.
+    @Test func testScrollDelegateFiredAfterSyncEnds() {
+        let delegate = TestDelegate()
+        let terminal = Terminal(
+            delegate: delegate,
+            options: TerminalOptions(cols: 40, rows: 5, scrollback: 20)
+        )
+        let esc = "\u{1b}"
+
+        for i in 0..<25 {
+            terminal.feed(text: "line \(i)\r\n")
+        }
+
+        delegate.scrolledPositions.removeAll()
+
+        terminal.feed(text: "\(esc)[?2026h")
+        terminal.feed(text: "new content\r\n")
+        terminal.feed(text: "\(esc)[?2026l")
+
+        #expect(!delegate.scrolledPositions.isEmpty)
+    }
+
+    // MARK: - View-level regression tests
+
+#if os(macOS)
+    /// Regression: scrollTo must not be blocked during synchronized output.
+    @Test func testViewScrollToDuringSyncIsNotBlocked() {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 400, height: 100)))
+        let esc = "\u{1b}"
+
+        for i in 0..<30 {
+            view.terminal.feed(text: "line \(i)\r\n")
+        }
+
+        let yDispBefore = view.terminal.displayBuffer.yDisp
+        #expect(yDispBefore > 0)
+
+        view.terminal.feed(text: "\(esc)[?2026h")
+        #expect(view.terminal.synchronizedOutputActive)
+
+        let target = max(0, yDispBefore - 5)
+        view.scrollTo(row: target)
+
+        #expect(view.terminal.displayBuffer.yDisp == target)
+
+        view.terminal.feed(text: "\(esc)[?2026l")
+    }
+
+    /// Regression: after the sync-end debounce fires, the view must emit
+    /// terminalDelegate?.scrolled so host scroll indicators update.
+    @Test func testViewEmitsScrollDelegateAfterSyncEnd() async {
+        let view = TerminalView(frame: CGRect(origin: .zero, size: .init(width: 400, height: 100)))
+        let esc = "\u{1b}"
+
+        for i in 0..<30 {
+            view.terminal.feed(text: "line \(i)\r\n")
+        }
+
+        view.terminal.feed(text: "\(esc)[?2026h")
+        view.terminal.feed(text: "output during sync\r\n")
+        view.terminal.feed(text: "\(esc)[?2026l")
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(!view.terminal.synchronizedOutputActive)
+        #expect(view.scrollPosition >= 0)
+    }
+#endif
 }

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/TerminalTestHarness.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/TerminalTestHarness.swift
@@ -20,6 +20,10 @@ final class TerminalTestDelegate: TerminalDelegate {
         sentData.append(Array(data))
     }
 
+    func clearSentData() {
+        sentData.removeAll()
+    }
+
     func cellSizeInPixels(source: Terminal) -> (width: Int, height: Int)? {
         return cellSizeInPixelsValue
     }

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/UnicodeTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/UnicodeTests.swift
@@ -473,6 +473,107 @@ final class SwiftTermUnicode {
         #expect(t.getCharacter(col: 4, row: 0) == "x")
     }
 
+    // MARK: - Narrow Regional Indicator mode (.narrow)
+
+    /// In narrow mode, individual RI symbols are width 1, matching system wcwidth().
+    @Test func testNarrowRIWidth() {
+        var opts = TerminalOptions.default
+        opts.regionalIndicatorWidth = .narrow
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: opts) { _ in }
+        let t = h.terminal!
+
+        t.feed(text: "\u{1F1EB}x")  // Single RI F + x
+        #expect(t.getCharData(col: 0, row: 0)?.width == 1)
+        #expect(t.getCharacter(col: 1, row: 0) == "x")
+    }
+
+    /// In narrow mode, two RIs combine into a width-2 flag.
+    @Test func testNarrowFlagCombinedWidth() {
+        var opts = TerminalOptions.default
+        opts.regionalIndicatorWidth = .narrow
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: opts) { _ in }
+        let t = h.terminal!
+
+        t.feed(text: "\u{1F1EB}\u{1F1F7}x")  // 🇫🇷 + x
+        #expect(t.getCharacter(col: 0, row: 0) == "🇫🇷")
+        #expect(t.getCharData(col: 0, row: 0)?.width == 2)
+        #expect(t.getCharData(col: 1, row: 0)?.width == 0)  // padding
+        #expect(t.getCharacter(col: 2, row: 0) == "x")
+    }
+
+    /// In narrow mode, cursor position matches wcwidth()-based expectations.
+    @Test func testNarrowFlagCursorPosition() {
+        var opts = TerminalOptions.default
+        opts.regionalIndicatorWidth = .narrow
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: opts) { _ in }
+        let t = h.terminal!
+
+        t.feed(text: "A\u{1F1E9}\u{1F1EA}B")  // A + 🇩🇪 + B
+        #expect(t.buffer.x == 4)  // A(1) + flag(2) + B(1)
+        #expect(t.getCharacter(col: 1, row: 0) == "🇩🇪")
+        #expect(t.getCharacter(col: 3, row: 0) == "B")
+    }
+
+    /// In narrow mode, overwriting an RI at the same position does not combine.
+    @Test func testNarrowRIOverwriteDoesNotCombine() {
+        var opts = TerminalOptions.default
+        opts.regionalIndicatorWidth = .narrow
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: opts) { _ in }
+        let t = h.terminal!
+
+        t.feed(text: "     \u{1F1EB}")  // F at col 5
+        #expect(t.getCharData(col: 5, row: 0)?.width == 1)
+
+        // Move cursor back to col 5 and write D — should overwrite, not combine
+        t.feed(text: "\u{1b}[1;6H\u{1F1E9}")
+        #expect(t.getCharacter(col: 5, row: 0) == "\u{1F1E9}")
+        #expect(t.getCharData(col: 5, row: 0)?.width == 1)
+    }
+
+    /// In narrow mode, flags on different lines combine correctly after cursor repositioning.
+    @Test func testNarrowFlagCombiningWithCursorRepositioning() {
+        var opts = TerminalOptions.default
+        opts.regionalIndicatorWidth = .narrow
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: opts) { _ in }
+        let t = h.terminal!
+
+        t.feed(text: "\u{1F1EB}\u{1F1F7}")  // 🇫🇷 on line 0
+        #expect(t.getCharacter(col: 0, row: 0) == "🇫🇷")
+
+        t.feed(text: "\r\n\u{1F1E9}\u{1F1EA}")  // 🇩🇪 on line 1
+        #expect(t.getCharacter(col: 0, row: 1) == "🇩🇪")
+
+        // Move back to line 0, repaint 🇫🇷
+        t.feed(text: "\u{1b}[1;1H\u{1F1EB}\u{1F1F7}")
+        #expect(t.getCharacter(col: 0, row: 0) == "🇫🇷")
+        #expect(t.getCharData(col: 0, row: 0)?.width == 2)
+    }
+
+    /// In narrow mode, odd number of RIs: flag + unpaired RI (width 1).
+    @Test func testNarrowOddRegionalIndicators() {
+        var opts = TerminalOptions.default
+        opts.regionalIndicatorWidth = .narrow
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue, options: opts) { _ in }
+        let t = h.terminal!
+
+        t.feed(text: "\u{1F1FA}\u{1F1F8}\u{1F1EC}x")
+        #expect(t.getCharacter(col: 0, row: 0) == "🇺🇸")
+        #expect(t.getCharData(col: 0, row: 0)?.width == 2)
+        #expect(t.getCharacter(col: 2, row: 0) == "\u{1F1EC}")
+        #expect(t.getCharData(col: 2, row: 0)?.width == 1)
+        #expect(t.getCharacter(col: 3, row: 0) == "x")
+    }
+
+    /// Default (wide) mode is unchanged — individual RIs are still width 2.
+    @Test func testDefaultWideRIUnchanged() {
+        let h = HeadlessTerminal(queue: SwiftTermTests.queue) { _ in }
+        let t = h.terminal!
+
+        t.feed(text: "\u{1F1EB}x")
+        #expect(t.getCharData(col: 0, row: 0)?.width == 2)
+        #expect(t.getCharacter(col: 2, row: 0) == "x")
+    }
+
     /// Test keycap emoji sequences (digit + VS16 + combining enclosing keycap)
     /// From Ghostty: keycap sequence handling
     @Test func testKeycapEmoji() {

--- a/project.yml
+++ b/project.yml
@@ -7,9 +7,10 @@ options:
     visionOS: "1.0"
 
 packages:
-  # Vendored 1.13.0 (rev 8e7a1e1, MIT) with one patch: keyboardType is
-  # settable so the terminal can default to an ASCII-capable (English)
-  # keyboard instead of the user's IME.
+  # Vendored 1.14.0 (rev 849e8a4, MIT). Multiplex keeps keyboardType
+  # settable, routes pans to remote scrolling/copy mode, and preserves
+  # iOS-app-on-Mac Escape and hardware Ctrl chords. Primary-button tap
+  # reporting is upstream as of this release.
   SwiftTerm:
     path: Vendor/SwiftTerm
   # Pinned to 0.12.0 on purpose: 0.12.1 moved its swift-nio-ssh dependency to


### PR DESCRIPTION
## Summary

- sync the vendored SwiftTerm tree from v1.13.0 to v1.14.0 (`849e8a4`)
- rebase Multiplex's settable keyboard type, remote pan/copy-mode, iOS-app-on-Mac Escape, and hardware Ctrl-chord patches
- retire the local primary-button tap patch now carried upstream
- import the new upstream sources and tests while continuing to omit upstream sample apps and repository metadata
- update vendor provenance in `AGENTS.md`, `README.md`, and `project.yml`

## Why

SwiftTerm 1.14.0 brings the current upstream input, accessibility, selection, rendering, and scrollback fixes. The vendor refresh keeps Multiplex on that release without losing the app-specific terminal interaction behavior required by visionOS and iPadOS.

## Impact

Terminal rendering and input now use SwiftTerm 1.14.0. Existing Multiplex keyboard, tmux Copy Mode, remote scrolling, and iOS-app-on-Mac behavior remain intact.

## Validation

- `swift test --package-path Vendor/SwiftTerm` — 481 tests passed
- `./Tools/build.sh all` — visionOS and iPadOS builds passed; 320 Multiplex tests passed
- `./Tools/build.sh verify vos` — live terminal E2E proof passed and screenshot inspected
- `./Tools/build.sh verify ipad` — live terminal E2E proof passed and screenshot inspected
- regenerated the Xcode project and repeated both platform builds successfully
