### PR TITLE
Improve app performance across UI and transports

### DIFF
--- a/Multiplex/Services/ConnectionHub.swift
+++ b/Multiplex/Services/ConnectionHub.swift
@@ -74,7 +74,11 @@ final class HostConnectionModel {
     let host: Host
     private(set) var phase: Phase = .idle
     private(set) var tmux: TmuxState = .unknown
-    private(set) var lastRefreshed: Date?
+    private var lastRefreshed: Date?
+    /// Observation-friendly summaries: views that only need liveness or a
+    /// badge count should not subscribe to the full pane/process tree.
+    private(set) var hasLiveProbe = false
+    private(set) var sessionCount = 0
     /// Session name → last visible lines of its active pane; the deck
     /// wall's live miniatures, refreshed by every probe (the probe's single
     /// exec carries the capture tails).
@@ -98,6 +102,7 @@ final class HostConnectionModel {
 
     private var connection: SSHConnection?
     private var refreshTask: Task<Void, Never>?
+    private var refreshGeneration = 0
     private var activePaneProbeInFlight = false
     private struct ActiveAgentCacheEntry {
         var fingerprint: TmuxPaneFingerprint
@@ -130,14 +135,19 @@ final class HostConnectionModel {
         guard case .unknown = tmux else { return }
         tmux = .sessions(snapshot.sessions)
         miniatures = snapshot.miniatures
+        sessionCount = snapshot.sessions.count
     }
 
     /// Connect if needed, then re-probe tmux sessions.
     func refresh() {
         guard refreshTask == nil else { return }
-        refreshTask = Task {
-            defer { refreshTask = nil }
-            await performRefresh()
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
+            await self.performRefresh(generation: generation, mayRetry: true)
+            guard self.refreshGeneration == generation else { return }
+            self.refreshTask = nil
         }
     }
 
@@ -259,14 +269,16 @@ final class HostConnectionModel {
         )
     }
 
-    private func performRefresh() async {
+    private func performRefresh(generation: Int, mayRetry: Bool) async {
+        guard refreshGeneration == generation, !Task.isCancelled else { return }
         // Whether this pass reuses an already-established link — if that
         // link fails mid-probe (Wi-Fi blip, server restart, socket severed
         // during suspension), one immediate reconnect beats surfacing
         // UNREACHABLE and waiting out a full feed interval.
         let reusedLink = connection != nil && phase == .connected
         do {
-            let connection = try await ensureConnection()
+            let connection = try await ensureConnection(refreshGeneration: generation)
+            guard refreshGeneration == generation, !Task.isCancelled else { return }
             // Only surface .probing before the first result — every later
             // state (sessions, no server, unreachable) is a settled answer.
             // The deck wall re-probes every few seconds, and flipping a
@@ -276,13 +288,22 @@ final class HostConnectionModel {
             let execStart = ContinuousClock.now
             let output = try await deadlined { try await connection.exec(TmuxProbe.probeCommand) }
             let execEnd = ContinuousClock.now
-            tmux = TmuxProbe.parse(output)
-            switch tmux {
+            guard refreshGeneration == generation, !Task.isCancelled else { return }
+            let parsed = await Task.detached(priority: .userInitiated) {
+                TmuxProbe.parseProbe(output)
+            }.value
+            let parseEnd = ContinuousClock.now
+            guard refreshGeneration == generation, !Task.isCancelled else { return }
+
+            if tmux != parsed.state { tmux = parsed.state }
+            if attentionTails != parsed.tails { attentionTails = parsed.tails }
+            if miniatures != parsed.miniatures { miniatures = parsed.miniatures }
+            if !hasLiveProbe { hasLiveProbe = true }
+            let nextSessionCount = parsed.state.sessions.count
+            if sessionCount != nextSessionCount { sessionCount = nextSessionCount }
+            switch parsed.state {
             case .sessions(let sessions):
                 seedActiveAgentCache(from: sessions)
-                let tails = TmuxProbe.parseTails(output, sessions: sessions)
-                attentionTails = tails
-                miniatures = tails.mapValues(TmuxProbe.miniatureTail)
                 onSnapshot?(DeckSnapshot(sessions: sessions, miniatures: miniatures))
             case .noServer, .tmuxMissing:
                 // A settled "nothing there" clears the cache — ghost tiles
@@ -294,13 +315,14 @@ final class HostConnectionModel {
             Self.timing.debug("""
                 \(self.host.name, privacy: .public) probe: exec \
                 \(Self.ms(execStart, execEnd), privacy: .public)ms, parse \
-                \(Self.ms(execEnd, .now), privacy: .public)ms, \
+                \(Self.ms(execEnd, parseEnd), privacy: .public)ms, \
                 \(output.utf8.count, privacy: .public)B
                 """)
             lastRefreshed = Date()
             evaluateAttention()
         } catch {
-            if reusedLink {
+            guard refreshGeneration == generation, !Task.isCancelled else { return }
+            if reusedLink, mayRetry {
                 // Retry silently: the rail keeps reading CONNECTED while a
                 // fresh link is attempted (ensureConnection never downgrades
                 // a non-idle phase), and only a failed retry surfaces.
@@ -308,7 +330,10 @@ final class HostConnectionModel {
                     Task { await connection.close() }
                 }
                 connection = nil
-                await performRefresh() // second pass has no link to reuse
+                await performRefresh(
+                    generation: generation,
+                    mayRetry: false
+                )
             } else {
                 markFailed(error)
             }
@@ -332,8 +357,11 @@ final class HostConnectionModel {
 
     private func markFailed(_ error: Error) {
         let message = friendlyMessage(for: error)
-        phase = .failed(message)
-        tmux = .failed(message)
+        let failedPhase = Phase.failed(message)
+        let failedTmux = TmuxState.failed(message)
+        if phase != failedPhase { phase = failedPhase }
+        if tmux != failedTmux { tmux = failedTmux }
+        if sessionCount != 0 { sessionCount = 0 }
         if let connection {
             // A link that timed out is usually black-holed; tearing it down
             // also unblocks any exec still hung on it. Never await this on
@@ -344,7 +372,7 @@ final class HostConnectionModel {
         evaluateAttention()
     }
 
-    private func ensureConnection() async throws -> SSHConnection {
+    private func ensureConnection(refreshGeneration expectedGeneration: Int? = nil) async throws -> SSHConnection {
         if let connection, phase == .connected {
             // A link whose last successful round-trip is several feed
             // intervals old was almost certainly severed while the app was
@@ -366,13 +394,23 @@ final class HostConnectionModel {
         // a retry actually lands.
         if phase == .idle { phase = .connecting }
         let secretsStart = ContinuousClock.now
-        let fresh = SSHConnection(host: host, secrets: .load(for: host))
+        let secrets = await HostSecrets.loadOffMain(for: host)
+        if let expectedGeneration,
+           (expectedGeneration != refreshGeneration || Task.isCancelled) {
+            throw CancellationError()
+        }
+        let fresh = SSHConnection(host: host, secrets: secrets)
         let connectStart = ContinuousClock.now
         do {
             try await deadlined(seconds: Self.connectDeadline) { try await fresh.connect() }
         } catch {
             Task { await fresh.close() }
             throw error
+        }
+        if let expectedGeneration,
+           (expectedGeneration != refreshGeneration || Task.isCancelled) {
+            await fresh.close()
+            throw CancellationError()
         }
         Self.timing.debug("""
             \(self.host.name, privacy: .public) connect: secrets \
@@ -404,25 +442,18 @@ final class HostConnectionModel {
         seconds: Double = HostConnectionModel.execDeadline,
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        let resumed = OSAllocatedUnfairLock(initialState: false)
         return try await withCheckedThrowingContinuation { continuation in
-            @Sendable func finish(_ result: Result<T, Error>) {
-                let first = resumed.withLock { done -> Bool in
-                    if done { return false }
-                    done = true
-                    return true
-                }
-                if first { continuation.resume(with: result) }
-            }
+            let gate = DeadlineGate(continuation)
             let work = Task {
-                do { finish(.success(try await operation())) }
-                catch { finish(.failure(error)) }
+                do { gate.finish(.success(try await operation()), winner: .work) }
+                catch { gate.finish(.failure(error), winner: .work) }
             }
-            Task {
-                try? await Task.sleep(for: .seconds(seconds))
-                finish(.failure(ProbeTimeoutError()))
-                work.cancel()
+            let timer = Task {
+                do { try await Task.sleep(for: .seconds(seconds)) }
+                catch { return }
+                gate.finish(.failure(ProbeTimeoutError()), winner: .timer)
             }
+            gate.install(work: work, timer: timer)
         }
     }
 
@@ -431,7 +462,7 @@ final class HostConnectionModel {
     /// probe pass — title and tail inputs arrive together.
     private func evaluateAttention() {
         guard case .sessions(let sessions) = tmux else {
-            attention = [:]
+            if !attention.isEmpty { attention = [:] }
             attentionTracker.reset()
             return
         }
@@ -469,7 +500,7 @@ final class HostConnectionModel {
             }
         }
         attentionTracker.prune(keeping: Set(sessions.map(\.name)))
-        attention = next
+        if attention != next { attention = next }
     }
 
     /// Create a detached tmux session over the control connection and
@@ -539,7 +570,9 @@ final class HostConnectionModel {
     private func kill(_ session: TmuxSession, over connection: SSHConnection) async {
         _ = try? await deadlined { try await connection.exec(TmuxProbe.killCommand(for: session)) }
         if case .sessions(let list) = tmux {
-            tmux = .sessions(list.filter { $0.id != session.id })
+            let remaining = list.filter { $0.id != session.id }
+            tmux = .sessions(remaining)
+            sessionCount = remaining.count
         }
         miniatures[session.name] = nil
         attentionTails[session.name] = nil
@@ -551,6 +584,7 @@ final class HostConnectionModel {
     }
 
     func disconnect() async {
+        refreshGeneration &+= 1
         refreshTask?.cancel()
         refreshTask = nil
         if let connection {
@@ -559,6 +593,8 @@ final class HostConnectionModel {
         connection = nil
         phase = .idle
         tmux = .unknown
+        hasLiveProbe = false
+        sessionCount = 0
         miniatures = [:]
         attentionTails = [:]
         attention = [:]
@@ -579,3 +615,51 @@ final class HostConnectionModel {
 /// A control-connection round-trip outlived its deadline — the link is
 /// treated as dead (see `HostConnectionModel.deadlined`).
 private struct ProbeTimeoutError: Error {}
+
+/// Resolves a deadline race once and cancels its losing task. In particular,
+/// a successful five-second wall probe no longer leaves a ten-second timer
+/// task alive behind it on every host and every tick.
+private final class DeadlineGate<Value>: @unchecked Sendable {
+    enum Winner: Equatable { case work, timer }
+
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var work: Task<Void, Never>?
+    private var timer: Task<Void, Never>?
+    private var finished = false
+
+    init(_ continuation: CheckedContinuation<Value, Error>) {
+        self.continuation = continuation
+    }
+
+    func install(work: Task<Void, Never>, timer: Task<Void, Never>) {
+        lock.lock()
+        if finished {
+            lock.unlock()
+            work.cancel()
+            timer.cancel()
+            return
+        }
+        self.work = work
+        self.timer = timer
+        lock.unlock()
+    }
+
+    func finish(_ result: Result<Value, Error>, winner: Winner) {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        let continuation = continuation
+        self.continuation = nil
+        let loser = winner == .work ? timer : work
+        work = nil
+        timer = nil
+        lock.unlock()
+
+        loser?.cancel()
+        continuation?.resume(with: result)
+    }
+}

--- a/Multiplex/Services/DeckSnapshotStore.swift
+++ b/Multiplex/Services/DeckSnapshotStore.swift
@@ -11,6 +11,13 @@ final class DeckSnapshotStore {
     private var snapshots: [UUID: DeckSnapshot] = [:]
     private let fileURL: URL
     private var saveTask: Task<Void, Never>?
+    /// JSON encoding plus atomic replacement can stall for several frames on
+    /// a busy fleet snapshot. A serial utility queue keeps writes ordered
+    /// without spending the deck's main actor budget.
+    private let writerQueue = DispatchQueue(
+        label: "app.multiplexterm.deck-snapshots",
+        qos: .utility
+    )
 
     init(fileURL: URL? = nil) {
         if let fileURL {
@@ -47,10 +54,15 @@ final class DeckSnapshotStore {
     /// Write pending changes now — the debounce timer may never fire when
     /// the app is being suspended.
     func flush() {
-        guard saveTask != nil else { return }
-        saveTask?.cancel()
-        saveTask = nil
-        save()
+        if saveTask != nil {
+            saveTask?.cancel()
+            saveTask = nil
+            save(synchronously: true)
+        } else {
+            // A debounced save may already be queued. Cross the serial queue
+            // before suspension so that write reaches stable storage too.
+            writerQueue.sync {}
+        }
     }
 
     private func scheduleSave() {
@@ -72,9 +84,20 @@ final class DeckSnapshotStore {
         })
     }
 
-    private func save() {
-        let raw = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.key.uuidString, $0.value) })
-        guard let data = try? JSONEncoder().encode(raw) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+    private func save(synchronously: Bool = false) {
+        let snapshot = snapshots
+        let fileURL = fileURL
+        let work = {
+            let raw = Dictionary(uniqueKeysWithValues: snapshot.map {
+                ($0.key.uuidString, $0.value)
+            })
+            guard let data = try? JSONEncoder().encode(raw) else { return }
+            try? data.write(to: fileURL, options: .atomic)
+        }
+        if synchronously {
+            writerQueue.sync(execute: work)
+        } else {
+            writerQueue.async(execute: work)
+        }
     }
 }

--- a/Multiplex/Services/Mosh/MoshCrypto.swift
+++ b/Multiplex/Services/Mosh/MoshCrypto.swift
@@ -28,6 +28,18 @@ struct Block128: Equatable {
         return out
     }
 
+    /// Append without materializing the temporary 16-byte array returned by
+    /// `bytes`. OCB emits one block after another, so this removes two tiny
+    /// heap candidates per full block on the packet hot path.
+    func appendBytes(to out: inout [UInt8]) {
+        for i in 0 ..< 8 {
+            out.append(UInt8(truncatingIfNeeded: hi >> (56 - 8 * i)))
+        }
+        for i in 0 ..< 8 {
+            out.append(UInt8(truncatingIfNeeded: lo >> (56 - 8 * i)))
+        }
+    }
+
     static func ^ (a: Block128, b: Block128) -> Block128 {
         var out = Block128()
         out.hi = a.hi ^ b.hi
@@ -106,11 +118,20 @@ final class MoshAEAD {
         out.reserveCapacity(plain.count + 16)
 
         let fullBlocks = plain.count / 16
+        var fullInputs: [Block128] = []
+        var fullOffsets: [Block128] = []
+        fullInputs.reserveCapacity(fullBlocks)
+        fullOffsets.reserveCapacity(fullBlocks)
         for i in 1 ... max(fullBlocks, 1) where fullBlocks > 0 {
             offset ^= l[i.trailingZeroBitCount]
             let p = Block128(plain[(i - 1) * 16 ..< i * 16])
-            out += (encrypt(p ^ offset) ^ offset).bytes
+            fullInputs.append(p ^ offset)
+            fullOffsets.append(offset)
             checksum ^= p
+        }
+        let encrypted = Self.transform(encryptor, fullInputs)
+        for index in encrypted.indices {
+            (encrypted[index] ^ fullOffsets[index]).appendBytes(to: &out)
         }
 
         let remainder = plain.count % 16
@@ -129,7 +150,7 @@ final class MoshAEAD {
 
         var tag = encrypt(checksum ^ offset ^ lDollar)
         tag ^= hash(associatedData)
-        out += tag.bytes
+        tag.appendBytes(to: &out)
         return Data(out)
     }
 
@@ -146,11 +167,20 @@ final class MoshAEAD {
         plain.reserveCapacity(cipher.count)
 
         let fullBlocks = cipher.count / 16
+        var fullInputs: [Block128] = []
+        var fullOffsets: [Block128] = []
+        fullInputs.reserveCapacity(fullBlocks)
+        fullOffsets.reserveCapacity(fullBlocks)
         for i in 1 ... max(fullBlocks, 1) where fullBlocks > 0 {
             offset ^= l[i.trailingZeroBitCount]
             let c = Block128(cipher[(i - 1) * 16 ..< i * 16])
-            let p = decrypt(c ^ offset) ^ offset
-            plain += p.bytes
+            fullInputs.append(c ^ offset)
+            fullOffsets.append(offset)
+        }
+        let decrypted = Self.transform(decryptor, fullInputs)
+        for index in decrypted.indices {
+            let p = decrypted[index] ^ fullOffsets[index]
+            p.appendBytes(to: &plain)
             checksum ^= p
         }
 
@@ -170,9 +200,9 @@ final class MoshAEAD {
 
         var expected = encrypt(checksum ^ offset ^ lDollar)
         expected ^= hash(associatedData)
-        var diff: UInt8 = 0
-        for (a, b) in zip(expected.bytes, tag) { diff |= a ^ b }
-        guard diff == 0 else { return nil }
+        let received = Block128(tag)
+        guard (expected.hi ^ received.hi) | (expected.lo ^ received.lo) == 0
+        else { return nil }
         return Data(plain)
     }
 
@@ -184,9 +214,14 @@ final class MoshAEAD {
         var offset = Block128.zero
 
         let fullBlocks = a.count / 16
+        var fullInputs: [Block128] = []
+        fullInputs.reserveCapacity(fullBlocks)
         for i in 1 ... max(fullBlocks, 1) where fullBlocks > 0 {
             offset ^= l[i.trailingZeroBitCount]
-            sum ^= encrypt(Block128(a[(i - 1) * 16 ..< i * 16]) ^ offset)
+            fullInputs.append(Block128(a[(i - 1) * 16 ..< i * 16]) ^ offset)
+        }
+        for encrypted in Self.transform(encryptor, fullInputs) {
+            sum ^= encrypted
         }
 
         let remainder = a.count % 16
@@ -237,12 +272,43 @@ final class MoshAEAD {
     private func decrypt(_ block: Block128) -> Block128 { Self.transform(decryptor, block) }
 
     private static func transform(_ cryptor: CCCryptorRef, _ block: Block128) -> Block128 {
-        var input = block.bytes
-        var output = [UInt8](repeating: 0, count: 16)
+        transform(cryptor, [block])[0]
+    }
+
+    /// ECB has no chaining dependency, so all full OCB blocks can cross the
+    /// CommonCrypto boundary in one update. A near-MTU packet used to make
+    /// roughly 75 `CCCryptorUpdate` calls (and allocate input/output arrays for
+    /// each); it now makes one for the full-block body plus the scalar pad/tag
+    /// operations required by OCB3.
+    private static func transform(
+        _ cryptor: CCCryptorRef,
+        _ blocks: [Block128]
+    ) -> [Block128] {
+        guard !blocks.isEmpty else { return [] }
+        var input: [UInt8] = []
+        input.reserveCapacity(blocks.count * 16)
+        for block in blocks { block.appendBytes(to: &input) }
+        var output = [UInt8](repeating: 0, count: input.count)
         var moved = 0
-        let status = CCCryptorUpdate(cryptor, &input, 16, &output, 16, &moved)
-        precondition(status == kCCSuccess && moved == 16, "AES-ECB block transform failed")
-        return Block128(output[...])
+        let outputCapacity = output.count
+        let status = CCCryptorUpdate(
+            cryptor,
+            &input,
+            input.count,
+            &output,
+            outputCapacity,
+            &moved
+        )
+        precondition(
+            status == kCCSuccess && moved == outputCapacity,
+            "AES-ECB block transform failed"
+        )
+        var result: [Block128] = []
+        result.reserveCapacity(blocks.count)
+        for offset in stride(from: 0, to: output.count, by: 16) {
+            result.append(Block128(output[offset ..< offset + 16]))
+        }
+        return result
     }
 }
 

--- a/Multiplex/Services/Mosh/MoshFragment.swift
+++ b/Multiplex/Services/Mosh/MoshFragment.swift
@@ -18,11 +18,21 @@ enum MoshFragmentWire {
     }
 
     static func decode(_ data: Data) -> (id: UInt64, number: UInt16, final: Bool, contents: Data)? {
-        let bytes = [UInt8](data)
-        guard bytes.count >= headerLength else { return nil }
-        let id = bytes[0 ..< 8].reduce(UInt64(0)) { $0 << 8 | UInt64($1) }
-        let combined = UInt16(bytes[8]) << 8 | UInt16(bytes[9])
-        return (id, combined & 0x7FFF, combined & 0x8000 != 0, Data(bytes[headerLength...]))
+        guard data.count >= headerLength else { return nil }
+        let start = data.startIndex
+        let idEnd = data.index(start, offsetBy: 8)
+        let id = data[start ..< idEnd].reduce(UInt64(0)) {
+            $0 << 8 | UInt64($1)
+        }
+        let numberEnd = data.index(idEnd, offsetBy: 2)
+        let combined = UInt16(data[idEnd]) << 8
+            | UInt16(data[data.index(after: idEnd)])
+        return (
+            id,
+            combined & 0x7FFF,
+            combined & 0x8000 != 0,
+            data[numberEnd...]
+        )
     }
 }
 
@@ -50,7 +60,10 @@ struct MoshFragmenter {
                 id: id,
                 number: UInt16(out.count),
                 final: final,
-                contents: bytes.subdata(in: bytes.startIndex + offset ..< bytes.startIndex + end)
+                contents: bytes[
+                    bytes.index(bytes.startIndex, offsetBy: offset)
+                        ..< bytes.index(bytes.startIndex, offsetBy: end)
+                ]
             ))
             offset = end
         } while offset < bytes.count
@@ -79,6 +92,14 @@ struct MoshFragmentAssembly {
         if id != currentID {
             reset()
             currentID = id
+        }
+
+        // Almost every mosh instruction fits one datagram. Return its payload
+        // slice directly instead of inserting it into a dictionary and copying
+        // it straight back out into an assembly buffer.
+        if number == 0, final {
+            reset()
+            return contents
         }
 
         if pieces.updateValue(contents, forKey: number) == nil {

--- a/Multiplex/Services/Mosh/MoshPacket.swift
+++ b/Multiplex/Services/Mosh/MoshPacket.swift
@@ -87,19 +87,23 @@ struct MoshPacketLayer {
     mutating func open(_ datagram: Data, now: UInt64) -> Opened? {
         // 8 nonce + 16 tag + 4 timestamps is the smallest honest packet.
         guard datagram.count >= 28 else { return nil }
-        let bytes = [UInt8](datagram)
-        let nonceValue = bytes[0 ..< 8].reduce(UInt64(0)) { $0 << 8 | UInt64($1) }
+        let nonceValue = datagram.prefix(8).reduce(UInt64(0)) {
+            $0 << 8 | UInt64($1)
+        }
 
         // Reject our own reflected packets before paying for the AEAD.
         guard nonceValue & ~Self.sequenceMask == direction.receiveBit else { return nil }
 
         guard let plaintext = aead.open(
-            Data(bytes[8...]), nonce: Self.nonceBytes(nonceValue)
+            datagram.dropFirst(8), nonce: Self.nonceBytes(nonceValue)
         ), plaintext.count >= 4 else { return nil }
 
-        let plain = [UInt8](plaintext)
-        let timestamp = UInt16(plain[0]) << 8 | UInt16(plain[1])
-        let reply = UInt16(plain[2]) << 8 | UInt16(plain[3])
+        let start = plaintext.startIndex
+        let timestamp = UInt16(plaintext[start]) << 8
+            | UInt16(plaintext[plaintext.index(after: start)])
+        let replyStart = plaintext.index(start, offsetBy: 2)
+        let reply = UInt16(plaintext[replyStart]) << 8
+            | UInt16(plaintext[plaintext.index(after: replyStart)])
 
         let sequence = nonceValue & Self.sequenceMask
         let isNew = sequence >= expectedReceiverSequence
@@ -125,7 +129,7 @@ struct MoshPacketLayer {
             }
         }
 
-        return Opened(payload: Data(plain[4...]), isNew: isNew)
+        return Opened(payload: plaintext.dropFirst(4), isNew: isNew)
     }
 
     // MARK: - Helpers

--- a/Multiplex/Services/Mosh/MoshProtobuf.swift
+++ b/Multiplex/Services/Mosh/MoshProtobuf.swift
@@ -40,15 +40,16 @@ enum MoshProto {
     struct Reader {
         enum Failure: Error { case truncated, unsupportedWireType }
 
-        private let bytes: [UInt8]
-        private var index = 0
+        private let bytes: Data
+        private var index: Data.Index
 
         init(_ data: Data) {
-            bytes = [UInt8](data)
+            bytes = data
+            index = data.startIndex
         }
 
         mutating func next() throws -> (field: Int, value: Value)? {
-            guard index < bytes.count else { return nil }
+            guard index < bytes.endIndex else { return nil }
             let tag = try varint()
             let field = Int(tag >> 3)
             switch tag & 7 {
@@ -59,9 +60,11 @@ enum MoshProto {
                 return try next()
             case 2:
                 let length = Int(try varint())
-                guard length <= bytes.count - index else { throw Failure.truncated }
-                let value = Data(bytes[index ..< index + length])
-                index += length
+                guard length <= bytes.distance(from: index, to: bytes.endIndex)
+                else { throw Failure.truncated }
+                let end = bytes.index(index, offsetBy: length)
+                let value = bytes[index ..< end]
+                index = end
                 return (field, .bytes(value))
             case 5: // fixed32 — likewise skip
                 try skip(4)
@@ -75,9 +78,9 @@ enum MoshProto {
             var result: UInt64 = 0
             var shift: UInt64 = 0
             while true {
-                guard index < bytes.count, shift < 64 else { throw Failure.truncated }
+                guard index < bytes.endIndex, shift < 64 else { throw Failure.truncated }
                 let byte = bytes[index]
-                index += 1
+                index = bytes.index(after: index)
                 result |= UInt64(byte & 0x7F) << shift
                 if byte & 0x80 == 0 { return result }
                 shift += 7
@@ -85,8 +88,9 @@ enum MoshProto {
         }
 
         private mutating func skip(_ count: Int) throws {
-            guard count <= bytes.count - index else { throw Failure.truncated }
-            index += count
+            guard count <= bytes.distance(from: index, to: bytes.endIndex)
+            else { throw Failure.truncated }
+            index = bytes.index(index, offsetBy: count)
         }
     }
 }

--- a/Multiplex/Services/Mosh/MoshSession.swift
+++ b/Multiplex/Services/Mosh/MoshSession.swift
@@ -39,6 +39,7 @@ actor MoshSession: TerminalTransport {
 
     private var connection: NWConnection?
     private var pumpTask: Task<Void, Never>?
+    private var receiveTask: Task<Void, Never>?
     private var wakeup: CheckedContinuation<Void, Never>?
     private var wakeupTimer: Task<Void, Never>?
     private var wakeupGeneration = 0
@@ -55,9 +56,32 @@ actor MoshSession: TerminalTransport {
     private var socketGeneration = 0
     private var socketState: NWConnection.State = .setup
     private var wakeupPending = false
+    /// Reused across port hops. Creating a fresh dispatch queue for every
+    /// replacement socket leaves avoidable queue objects and callback contexts
+    /// behind during roaming; each session still owns its own serial lane.
+    private let socketQueue = DispatchQueue(label: "mosh.udp")
+    private struct SocketEvent: @unchecked Sendable {
+        var data: Data?
+        var error: NWError?
+        var generation: Int
+    }
+    /// Network.framework callbacks push into this queue synchronously; one
+    /// actor task decrypts them in order. The former callback path created a
+    /// new unstructured Task for every UDP datagram.
+    private let socketEvents: AsyncStream<SocketEvent>
+    private let socketEventsContinuation: AsyncStream<SocketEvent>.Continuation
 
     init(target: MoshBootstrap.Target, cols: Int, rows: Int) throws {
         self.target = target
+        // UDP is explicitly loss-tolerant and the transport re-bases missed
+        // states. Bound pathological producer bursts instead of recreating
+        // the old unbounded pile of per-datagram tasks in another form.
+        let events = AsyncStream.makeStream(
+            of: SocketEvent.self,
+            bufferingPolicy: .bufferingNewest(256)
+        )
+        socketEvents = events.stream
+        socketEventsContinuation = events.continuation
         engine = try MoshTransportEngine(
             key: target.key,
             cols: cols,
@@ -85,6 +109,7 @@ actor MoshSession: TerminalTransport {
         self.onClose = onClose
         self.onContact = onContact
 
+        receiveTask = Task { await receiveLoop() }
         startSocket()
         pumpTask = Task { await pump() }
 
@@ -93,7 +118,7 @@ actor MoshSession: TerminalTransport {
         guard !everContacted else { return }
         let timeout = Task {
             try? await Task.sleep(for: Self.firstContactTimeout)
-            await self.failFirstContact()
+            self.failFirstContact()
         }
         defer { timeout.cancel() }
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
@@ -136,6 +161,7 @@ actor MoshSession: TerminalTransport {
         default:
             break
         }
+        engine.requestHeartbeat(now: Self.now())
         kick()
     }
 
@@ -162,8 +188,12 @@ actor MoshSession: TerminalTransport {
             guard better, let self else { return }
             Task { await self.pathImproved(generation: generation) }
         }
-        nwConnection.start(queue: DispatchQueue(label: "mosh.udp"))
-        armReceive(nwConnection, generation: generation)
+        nwConnection.start(queue: socketQueue)
+        Self.armReceive(
+            nwConnection,
+            generation: generation,
+            continuation: socketEventsContinuation
+        )
     }
 
     private func socketStateChanged(_ state: NWConnection.State, generation: Int) {
@@ -186,28 +216,49 @@ actor MoshSession: TerminalTransport {
 
     private func recreateSocket() {
         connection?.cancel()
+        // Make the next pump pass emit on the fresh source port immediately;
+        // waking it alone can otherwise leave the normal 3 s ACK deadline in
+        // place and make foreground/path recovery feel stalled.
+        engine.requestHeartbeat(now: Self.now())
         startSocket()
         kick()
     }
 
-    private func armReceive(_ nwConnection: NWConnection, generation: Int) {
-        nwConnection.receiveMessage { [weak self] data, _, _, error in
-            guard let self else { return }
-            Task {
-                if let data, !data.isEmpty {
-                    await self.handleDatagram(data)
-                }
-                await self.rearmOrRecover(nwConnection, generation: generation, error: error)
-            }
+    private nonisolated static func armReceive(
+        _ nwConnection: NWConnection,
+        generation: Int,
+        continuation: AsyncStream<SocketEvent>.Continuation
+    ) {
+        nwConnection.receiveMessage { data, _, _, error in
+            continuation.yield(SocketEvent(
+                data: data,
+                error: error,
+                generation: generation
+            ))
+            guard error == nil else { return }
+            armReceive(
+                nwConnection,
+                generation: generation,
+                continuation: continuation
+            )
         }
     }
 
-    private func rearmOrRecover(_ nwConnection: NWConnection, generation: Int, error: NWError?) {
-        guard !closed, generation == socketGeneration else { return }
-        if error != nil {
-            recreateSocket()
-        } else {
-            armReceive(nwConnection, generation: generation)
+    private func receiveLoop() async {
+        var batchCount = 0
+        for await event in socketEvents {
+            guard !closed else { return }
+            if let data = event.data, !data.isEmpty {
+                handleDatagram(data)
+            }
+            if event.error != nil, event.generation == socketGeneration {
+                recreateSocket()
+            }
+            batchCount += 1
+            if batchCount == 16 {
+                batchCount = 0
+                await Task.yield()
+            }
         }
     }
 
@@ -244,9 +295,14 @@ actor MoshSession: TerminalTransport {
     }
 
     private func send(_ datagrams: [Data]) {
-        guard let connection else { return }
-        for datagram in datagrams {
-            connection.send(content: datagram, completion: .contentProcessed { _ in })
+        guard let connection, !datagrams.isEmpty else { return }
+        // Mosh transport states are replay-safe. `idempotent` avoids allocating
+        // a completion closure whose error was deliberately ignored, and one
+        // Network.framework batch lets fragmented repaints share flush work.
+        connection.batch {
+            for datagram in datagrams {
+                connection.send(content: datagram, completion: .idempotent)
+            }
         }
     }
 
@@ -311,7 +367,7 @@ actor MoshSession: TerminalTransport {
             wakeup = continuation
             wakeupTimer = Task {
                 try? await Task.sleep(for: .milliseconds(delay))
-                await self.timerFired(generation)
+                self.timerFired(generation)
             }
         }
         wakeupPending = false
@@ -346,6 +402,9 @@ actor MoshSession: TerminalTransport {
         firstContact = nil
         pumpTask?.cancel()
         pumpTask = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        socketEventsContinuation.finish()
         fireWakeup()
         connection?.cancel()
         connection = nil

--- a/Multiplex/Services/Mosh/MoshTransport.swift
+++ b/Multiplex/Services/Mosh/MoshTransport.swift
@@ -59,7 +59,10 @@ struct MoshTransportEngine {
 
     /// Suffix of user events not yet known to be received; `eventOffset`
     /// is how many acknowledged events were dropped from the front.
-    private var events: [MoshUserEvent] = []
+    /// A slice makes dropping acknowledged prefixes O(1). Under packet loss a
+    /// client can accumulate thousands of small key events; repeatedly calling
+    /// `Array.removeFirst` shifted that whole suffix on every acknowledgement.
+    private var events: ArraySlice<MoshUserEvent> = []
     private var eventOffset = 0
     private var totalEvents: Int { eventOffset + events.count }
 
@@ -107,12 +110,40 @@ struct MoshTransportEngine {
 
     mutating func input(_ data: Data) {
         guard !shutdownInProgress, !data.isEmpty else { return }
+        // Input arriving inside the send-mindelay window has not appeared in a
+        // numbered state yet. Fold it into that unsent event now instead of
+        // retaining one allocation per UIKit key callback and rediscovering the
+        // same coalescing on every retransmit encode.
+        if totalEvents > sentStates.last!.eventCount,
+           let lastIndex = events.indices.last,
+           case .keys(var pending) = events[lastIndex] {
+            pending.append(data)
+            events[lastIndex] = .keys(pending)
+            return
+        }
         events.append(.keys(data))
     }
 
     mutating func resize(cols: Int, rows: Int) {
         guard !shutdownInProgress else { return }
+        // Window drags can emit several sizes inside one transport frame. Only
+        // the newest unsent size matters; a size already present in a numbered
+        // state is immutable because retransmission diffs refer to that state.
+        if totalEvents > sentStates.last!.eventCount,
+           let lastIndex = events.indices.last,
+           case .resize = events[lastIndex] {
+            events[lastIndex] = .resize(cols: cols, rows: rows)
+            return
+        }
         events.append(.resize(cols: cols, rows: rows))
+    }
+
+    /// A fresh UDP socket needs a packet immediately so the server learns the
+    /// new source port. Merely waking `tick` is insufficient while the normal
+    /// three-second acknowledgement deadline is still in the future.
+    mutating func requestHeartbeat(now: UInt64) {
+        guard !shutdownInProgress else { return }
+        nextAckTime = min(nextAckTime, now)
     }
 
     mutating func startShutdown(now: UInt64) {
@@ -178,6 +209,16 @@ struct MoshTransportEngine {
         if confirmed > eventOffset {
             events.removeFirst(confirmed - eventOffset)
             eventOffset = confirmed
+            // ArraySlice intentionally retains its original storage. Release a
+            // long acknowledged prefix occasionally so a roaming session does
+            // not pin old key payloads forever; the rare compaction amortizes
+            // the O(n) copy over at least 1,024 removals.
+            if events.isEmpty {
+                events = []
+            } else if events.startIndex >= 1_024,
+                      events.startIndex > events.count {
+                events = ArraySlice(Array(events))
+            }
         }
     }
 
@@ -212,6 +253,7 @@ struct MoshTransportEngine {
         // every packet carry all unacknowledged input.
         var baseNum = assumedReceiverNum
         var baseCount = sentStates.first(where: { $0.num == baseNum })?.eventCount ?? sentStates[0].eventCount
+        var diff: Data
         if baseNum != sentStates[0].num {
             let cumulative = encodeDiff(fromEventCount: sentStates[0].eventCount)
             let proposed = encodeDiff(fromEventCount: baseCount)
@@ -219,9 +261,13 @@ struct MoshTransportEngine {
                 || (cumulative.count < 1000 && cumulative.count - proposed.count < 100) {
                 baseNum = sentStates[0].num
                 baseCount = sentStates[0].eventCount
+                diff = cumulative
+            } else {
+                diff = proposed
             }
+        } else {
+            diff = encodeDiff(fromEventCount: baseCount)
         }
-        let diff = encodeDiff(fromEventCount: baseCount)
 
         var datagrams: [Data] = []
         if diff.isEmpty {
@@ -287,7 +333,7 @@ struct MoshTransportEngine {
 
     private func encodeDiff(fromEventCount count: Int) -> Data {
         guard count < totalEvents else { return Data() }
-        return MoshUserMessage.encode(events[(count - eventOffset)...])
+        return MoshUserMessage.encode(events.dropFirst(count - eventOffset))
     }
 
     private static func chaff() -> Data {

--- a/Multiplex/Services/Mosh/MoshZlib.swift
+++ b/Multiplex/Services/Mosh/MoshZlib.swift
@@ -27,17 +27,24 @@ enum MoshZlib {
     }
 
     static func decompress(_ compressed: Data, maxSize: Int = maxDecompressedSize) throws -> Data {
-        let bytes = [UInt8](compressed)
+        let start = compressed.startIndex
         // Header: deflate method, header checksum multiple of 31, no preset
         // dictionary (mosh never sets one).
-        guard bytes.count >= 6,
-              bytes[0] & 0x0F == 8,
-              (Int(bytes[0]) << 8 | Int(bytes[1])) % 31 == 0,
-              bytes[1] & 0x20 == 0
+        guard compressed.count >= 6 else { throw Failure.corrupt }
+        let flagsIndex = compressed.index(after: start)
+        let method = compressed[start]
+        let flags = compressed[flagsIndex]
+        guard method & 0x0F == 8,
+              (Int(method) << 8 | Int(flags)) % 31 == 0,
+              flags & 0x20 == 0
         else { throw Failure.corrupt }
 
-        let raw = Data(bytes[2 ..< bytes.count - 4])
-        let expected = bytes[(bytes.count - 4)...].reduce(UInt32(0)) { $0 << 8 | UInt32($1) }
+        let trailerStart = compressed.index(compressed.endIndex, offsetBy: -4)
+        let rawStart = compressed.index(start, offsetBy: 2)
+        let raw = compressed[rawStart ..< trailerStart]
+        let expected = compressed[trailerStart...].reduce(UInt32(0)) {
+            $0 << 8 | UInt32($1)
+        }
 
         let plain = try inflate(raw, maxSize: maxSize)
         guard adler32(plain) == expected else { throw Failure.checksumMismatch }
@@ -73,18 +80,19 @@ enum MoshZlib {
     private static func storedDeflate(_ plain: Data) -> Data {
         var out = Data()
         var offset = 0
-        let bytes = [UInt8](plain)
         repeat {
-            let chunk = min(65535, bytes.count - offset)
-            let final: UInt8 = offset + chunk >= bytes.count ? 1 : 0
+            let chunk = min(65535, plain.count - offset)
+            let final: UInt8 = offset + chunk >= plain.count ? 1 : 0
             out.append(final) // BTYPE=00 stored, BFINAL in bit 0
             out.append(UInt8(chunk & 0xFF))
             out.append(UInt8(chunk >> 8))
             out.append(UInt8(~chunk & 0xFF))
             out.append(UInt8((~chunk >> 8) & 0xFF))
-            out.append(contentsOf: bytes[offset ..< offset + chunk])
+            let start = plain.index(plain.startIndex, offsetBy: offset)
+            let end = plain.index(start, offsetBy: chunk)
+            out.append(contentsOf: plain[start ..< end])
             offset += chunk
-        } while offset < bytes.count
+        } while offset < plain.count
         return out
     }
 

--- a/Multiplex/Services/SSHConnection.swift
+++ b/Multiplex/Services/SSHConnection.swift
@@ -17,6 +17,15 @@ struct HostSecrets: Sendable {
             passphrase: KeychainStore.get(for: host.id, kind: .keyPassphrase)
         )
     }
+
+    /// Synchronizable Keychain reads may consult securityd/iCloud state and
+    /// occasionally take long enough to miss frames. Connection setup is
+    /// already asynchronous, so keep that blocking work off the UI actor.
+    static func loadOffMain(for host: Host) async -> HostSecrets {
+        await Task.detached(priority: .userInitiated) {
+            load(for: host)
+        }.value
+    }
 }
 
 enum SSHConnectionError: Error {
@@ -39,6 +48,11 @@ enum SSHConnectionError: Error {
     }
 }
 
+struct SSHUpload {
+    var data: Data
+    var preferredName: String
+}
+
 /// One SSH connection: exec channels for probing, plus at most one
 /// interactive PTY shell. Built on Citadel (SwiftNIO SSH).
 actor SSHConnection {
@@ -46,6 +60,11 @@ actor SSHConnection {
     private let secrets: HostSecrets
 
     private var client: SSHClient?
+    /// Actor methods are reentrant at awaits. Join concurrent callers to one
+    /// handshake instead of opening duplicate TCP/SSH transports when a user
+    /// action lands during a background connection attempt.
+    private var connectTask: Task<SSHClient, Error>?
+    private var connectGeneration = 0
     private var stdinWriter: TTYStdinWriter?
     private var shellTask: Task<Void, Never>?
     /// Set by `close()`. A connect that was abandoned on a deadline can
@@ -62,30 +81,49 @@ actor SSHConnection {
 
     func connect() async throws {
         guard client == nil else { return }
-        let method = try authenticationMethod()
+        guard !isClosed else { throw SSHConnectionError.notConnected }
+        let task: Task<SSHClient, Error>
+        let generation: Int
+        if let inFlight = connectTask {
+            task = inFlight
+            generation = connectGeneration
+        } else {
+            let method = try authenticationMethod()
+            connectGeneration &+= 1
+            generation = connectGeneration
+            task = Task {
+                try await SSHClient.connect(
+                    host: host.hostname,
+                    port: host.port,
+                    authenticationMethod: method,
+                    hostKeyValidator: .acceptAnything(),
+                    reconnect: .never
+                )
+            }
+            connectTask = task
+        }
         do {
-            client = try await SSHClient.connect(
-                host: host.hostname,
-                port: host.port,
-                authenticationMethod: method,
-                hostKeyValidator: .acceptAnything(),
-                reconnect: .never
-            )
+            let connected = try await task.value
+            guard generation == connectGeneration, !isClosed else {
+                try? await connected.close()
+                throw SSHConnectionError.notConnected
+            }
+            client = connected
+            connectTask = nil
         } catch let error as SSHConnectionError {
+            if generation == connectGeneration { connectTask = nil }
             throw error
         } catch {
+            if generation == connectGeneration { connectTask = nil }
             throw SSHConnectionError.connectFailed(shortDescription(of: error))
-        }
-        if isClosed {
-            let late = client
-            client = nil
-            try? await late?.close()
-            throw SSHConnectionError.notConnected
         }
     }
 
     func close() async {
         isClosed = true
+        connectGeneration &+= 1
+        connectTask?.cancel()
+        connectTask = nil
         shellTask?.cancel()
         shellTask = nil
         stdinWriter = nil
@@ -135,18 +173,17 @@ actor SSHConnection {
 
     // MARK: SFTP (file drops)
 
-    /// Upload one dropped file into `directory`, resolving name collisions
+    /// Upload dropped files into `directory`, resolving name collisions
     /// atomically (`.forceCreate` = O_EXCL, so two clients can't clobber
-    /// each other) and reporting whole-file progress. Returns the file
-    /// name actually used. Rides the same connection as the shell — Citadel
-    /// multiplexes the SFTP subsystem channel alongside the PTY.
-    func uploadFile(
-        _ data: Data,
+    /// each other) and reporting per-file progress. The batch shares one
+    /// SFTP subsystem/channel instead of negotiating one per attachment.
+    /// Returns the file names actually used in request order.
+    func uploadFiles(
+        _ uploads: [SSHUpload],
         toDirectory directory: String,
-        preferredName: String,
         prepareGitIgnoredDirectory: Bool = false,
-        onProgress: @escaping @Sendable (Double) -> Void
-    ) async throws -> String {
+        onProgress: @escaping @Sendable (_ index: Int, _ fraction: Double) -> Void
+    ) async throws -> [String] {
         guard let client else { throw SSHConnectionError.notConnected }
         return try await client.withSFTP { sftp in
             if prepareGitIgnoredDirectory {
@@ -162,46 +199,53 @@ actor SSHConnection {
                     try? await gitignore.close()
                 }
             }
-            var file: SFTPFile?
-            var name = preferredName
-            for attempt in 0..<8 {
-                let candidate = DropText.candidate(preferredName, attempt: attempt)
-                let path = directory.hasSuffix("/")
-                    ? directory + candidate
-                    : directory + "/" + candidate
+            var names: [String] = []
+            names.reserveCapacity(uploads.count)
+            for (index, upload) in uploads.enumerated() {
+                var file: SFTPFile?
+                var name = upload.preferredName
+                for attempt in 0..<8 {
+                    let candidate = DropText.candidate(upload.preferredName, attempt: attempt)
+                    let path = directory.hasSuffix("/")
+                        ? directory + candidate
+                        : directory + "/" + candidate
+                    do {
+                        file = try await sftp.openFile(
+                            filePath: path,
+                            flags: [.write, .create, .forceCreate]
+                        )
+                        name = candidate
+                        break
+                    } catch {
+                        // Usually "already exists" (O_EXCL); a persistent
+                        // error (permissions, bad dir) surfaces on last try.
+                        if attempt == 7 { throw error }
+                    }
+                }
+                guard let file else {
+                    throw DropError(message: "Couldn't create \(upload.preferredName)")
+                }
                 do {
-                    file = try await sftp.openFile(
-                        filePath: path,
-                        flags: [.write, .create, .forceCreate]
-                    )
-                    name = candidate
-                    break
+                    let chunkSize = 512 * 1024
+                    var offset = 0
+                    while offset < upload.data.count {
+                        let end = min(offset + chunkSize, upload.data.count)
+                        try await file.write(
+                            ByteBuffer(bytes: upload.data[offset..<end]),
+                            at: UInt64(offset)
+                        )
+                        offset = end
+                        onProgress(index, Double(offset) / Double(upload.data.count))
+                    }
+                    if upload.data.isEmpty { onProgress(index, 1) }
+                    try await file.close()
+                    names.append(name)
                 } catch {
-                    // Usually "already exists" (O_EXCL); a persistent error
-                    // (permissions, bad dir) surfaces after the last try.
-                    if attempt == 7 { throw error }
+                    try? await file.close()
+                    throw error
                 }
             }
-            guard let file else { throw DropError(message: "Couldn't create \(preferredName)") }
-            do {
-                let chunkSize = 512 * 1024
-                var offset = 0
-                while offset < data.count {
-                    let end = min(offset + chunkSize, data.count)
-                    try await file.write(
-                        ByteBuffer(bytes: data[offset..<end]),
-                        at: UInt64(offset)
-                    )
-                    offset = end
-                    onProgress(Double(offset) / Double(data.count))
-                }
-                if data.isEmpty { onProgress(1) }
-                try await file.close()
-            } catch {
-                try? await file.close()
-                throw error
-            }
-            return name
+            return names
         }
     }
 

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 import SwiftTerm
 import UIKit
 
@@ -108,12 +109,24 @@ final class TerminalSessionController {
     /// threshold. Input still queues and the link self-heals; the chrome
     /// just shows it truthfully. Always false on SSH tabs.
     private(set) var contactLost = false
-    private var pendingOutput = Data()
+    private var pendingOutput: [UInt8] = []
+    /// One short-delay drain per transport run replaces a MainActor Task and a
+    /// Data→Array copy for every network chunk. Parsing remains on the main
+    /// actor because SwiftTerm's view/delegate/display machinery is UIKit.
+    private var outputCoalescer: TerminalOutputCoalescer?
     private var lastCols = 80
     private var lastRows = 24
     private var started = false
+    private var transportGeneration = 0
+    private var runTask: Task<Void, Never>?
     private var inputTask: Task<Void, Never>?
     private var inputContinuation: AsyncStream<Data>.Continuation?
+    private struct TerminalSize: Sendable {
+        var cols: Int
+        var rows: Int
+    }
+    private var resizeTask: Task<Void, Never>?
+    private var resizeContinuation: AsyncStream<TerminalSize>.Continuation?
     /// Background cadence for a plain PTY. The focused TerminalWindow may
     /// request a faster refresh, coalesced by the same in-flight/staleness
     /// gates; tmux tabs continue to use ConnectionHub's fleet probe.
@@ -150,7 +163,7 @@ final class TerminalSessionController {
         view.allowMouseReporting = !tmuxCopyModeUIActive
         view.forceRemoteCursorScroll = tmuxCopyModeUIActive
         if !pendingOutput.isEmpty {
-            view.feed(byteArray: [UInt8](pendingOutput)[...])
+            view.feed(byteArray: pendingOutput[...])
             pendingOutput.removeAll()
         }
     }
@@ -210,48 +223,99 @@ final class TerminalSessionController {
     func start() {
         guard !started else { return }
         started = true
-        Task { await run() }
+        beginTransportRun()
     }
 
-    private func run() async {
-        if host.useMosh {
-            await runMosh()
-        } else {
-            await runSSH()
+    private func beginTransportRun() {
+        transportGeneration &+= 1
+        let generation = transportGeneration
+        let output = TerminalOutputCoalescer { [weak self] bytes in
+            guard let self, self.transportGeneration == generation else { return }
+            self.feed(bytes)
+        }
+        outputCoalescer = output
+        runTask?.cancel()
+        runTask = Task { [weak self] in
+            guard let self else { return }
+            await self.run(generation: generation, output: output)
+            if self.transportGeneration == generation {
+                self.runTask = nil
+            }
         }
     }
 
-    private func runSSH() async {
-        let connection = SSHConnection(host: host, secrets: .load(for: host))
+    private func run(
+        generation: Int,
+        output: TerminalOutputCoalescer
+    ) async {
+        if host.useMosh {
+            await runMosh(generation: generation, output: output)
+        } else {
+            await runSSH(generation: generation, output: output)
+        }
+    }
+
+    private func runSSH(
+        generation: Int,
+        output: TerminalOutputCoalescer
+    ) async {
+        let secrets = await HostSecrets.loadOffMain(for: host)
+        guard transportGeneration == generation, !Task.isCancelled else { return }
+        let connection = SSHConnection(host: host, secrets: secrets)
+        guard transportGeneration == generation else {
+            await connection.close()
+            return
+        }
         self.connection = connection
         transport = connection
         do {
             try await connection.connect()
+            try Task.checkCancellation()
+            guard transportGeneration == generation,
+                  self.connection === connection
+            else {
+                await connection.close()
+                return
+            }
+            let openedSize = TerminalSize(cols: lastCols, rows: lastRows)
             try await connection.openShell(
                 command: route.remoteCommand,
-                cols: lastCols,
-                rows: lastRows,
-                onData: { [weak self] data in
-                    Task { @MainActor [weak self] in
-                        self?.feed(data)
-                    }
+                cols: openedSize.cols,
+                rows: openedSize.rows,
+                onData: { data in
+                    output.append(data)
                 },
                 onClose: { [weak self] reason in
                     Task { @MainActor [weak self] in
-                        self?.handleClose(reason: reason)
+                        self?.handleClose(
+                            reason: reason,
+                            generation: generation,
+                            output: output
+                        )
                     }
                 }
             )
-            startInputPump(for: connection)
+            try Task.checkCancellation()
+            guard transportGeneration == generation,
+                  self.connection === connection
+            else {
+                await connection.close()
+                return
+            }
+            startTransportPumps(for: connection, openedAt: openedSize)
             status = .live
             startDirectShellMonitoring()
         } catch {
+            await connection.close()
+            guard transportGeneration == generation,
+                  self.connection === connection
+            else { return }
             let message = (error as? SSHConnectionError)?.userMessage(host: host)
                 ?? "Couldn't reach \(host.name). \(error.localizedDescription)"
             status = .ended(message)
             self.connection = nil
             transport = nil
-            await connection.close()
+            outputCoalescer = nil
         }
     }
 
@@ -259,56 +323,83 @@ final class TerminalSessionController {
     /// session itself rides UDP — resilient to roaming and sleep. The
     /// deck's probe (and file drops) stay SSH; this tab simply has no
     /// exec surface.
-    private func runMosh() async {
+    private func runMosh(
+        generation: Int,
+        output: TerminalOutputCoalescer
+    ) async {
         contactLost = false
         do {
+            let secrets = await HostSecrets.loadOffMain(for: host)
+            try Task.checkCancellation()
+            guard transportGeneration == generation else { return }
             let target = try await MoshBootstrap.start(
                 host: host,
-                secrets: .load(for: host),
+                secrets: secrets,
                 remoteCommand: route.moshRemoteCommand
             )
-            let session = try MoshSession(target: target, cols: lastCols, rows: lastRows)
+            try Task.checkCancellation()
+            guard transportGeneration == generation else { return }
+            let openedSize = TerminalSize(cols: lastCols, rows: lastRows)
+            let session = try MoshSession(
+                target: target,
+                cols: openedSize.cols,
+                rows: openedSize.rows
+            )
             moshSession = session
             transport = session
             try await session.open(
-                onData: { [weak self] data in
-                    Task { @MainActor [weak self] in
-                        self?.feed(data)
-                    }
+                onData: { data in
+                    output.append(data)
                 },
                 onClose: { [weak self] reason in
                     Task { @MainActor [weak self] in
-                        self?.handleClose(reason: reason)
+                        self?.handleClose(
+                            reason: reason,
+                            generation: generation,
+                            output: output
+                        )
                     }
                 },
                 onContact: { [weak self] lost in
                     Task { @MainActor [weak self] in
+                        guard self?.transportGeneration == generation else { return }
                         self?.contactLost = lost
                     }
                 }
             )
-            startInputPump(for: session)
+            try Task.checkCancellation()
+            guard transportGeneration == generation,
+                  moshSession === session
+            else {
+                await session.close()
+                return
+            }
+            startTransportPumps(for: session, openedAt: openedSize)
             status = .live
             startDirectShellMonitoring()
         } catch {
+            let session = moshSession
+            await session?.close()
+            guard transportGeneration == generation,
+                  moshSession === session
+            else { return }
             let message = (error as? MoshBootstrapError)?.userMessage(host: host)
                 ?? (error as? MoshSession.Failure)?.userMessage(host: host)
                 ?? (error as? SSHConnectionError)?.userMessage(host: host)
                 ?? "Couldn't reach \(host.name) over mosh. \(error.localizedDescription)"
             status = .ended(message)
-            let session = moshSession
             moshSession = nil
             transport = nil
-            Task { await session?.close() }
+            outputCoalescer = nil
         }
     }
 
-    private func feed(_ data: Data) {
+    private func feed(_ bytes: [UInt8]) {
         guard let terminalView else {
-            pendingOutput.append(data)
+            pendingOutput.append(contentsOf: bytes)
             return
         }
-        terminalView.feed(byteArray: [UInt8](data)[...])
+        terminalView.feed(byteArray: bytes[...])
     }
 
     /// OSC title updates are also the no-exec fallback signal for direct mosh
@@ -331,13 +422,30 @@ final class TerminalSessionController {
         }
     }
 
-    private func handleClose(reason: String?) {
-        stopInputPump()
+    private func handleClose(
+        reason: String?,
+        generation: Int,
+        output: TerminalOutputCoalescer
+    ) {
+        // Network callbacks enqueue bytes synchronously before their close
+        // callback. Flush that final tail before ending the run, then ignore a
+        // late close from any superseded transport generation.
+        output.flush()
+        guard transportGeneration == generation,
+              outputCoalescer === output
+        else { return }
+        stopTransportPumps()
         stopDirectShellMonitoring()
         setTmuxCopyModeUIActive(false)
         resetHistoryState()
-        if case .ended = status { return }
         status = .ended(reason)
+        contactLost = false
+        let endedTransport = transport
+        transport = nil
+        connection = nil
+        moshSession = nil
+        outputCoalescer = nil
+        Task { await endedTransport?.close() }
     }
 
     // MARK: Plain-shell agent monitoring
@@ -491,6 +599,48 @@ final class TerminalSessionController {
         inputTask = nil
     }
 
+    /// Resize callbacks can arrive for every layout pass while a window is
+    /// dragged. Keep only the newest dimensions and let one ordered task talk
+    /// to the transport, rather than minting an unbounded task per callback.
+    private func startResizePump(for transport: any TerminalTransport) {
+        stopResizePump()
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: TerminalSize.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        resizeContinuation = continuation
+        resizeTask = Task {
+            for await size in stream {
+                try? await transport.resize(cols: size.cols, rows: size.rows)
+            }
+        }
+    }
+
+    private func stopResizePump() {
+        resizeContinuation?.finish()
+        resizeContinuation = nil
+        resizeTask?.cancel()
+        resizeTask = nil
+    }
+
+    private func startTransportPumps(
+        for transport: any TerminalTransport,
+        openedAt size: TerminalSize
+    ) {
+        startInputPump(for: transport)
+        startResizePump(for: transport)
+        // Layout may have changed while the handshake/open call was awaiting;
+        // reconcile once with the newest geometry before normal coalescing.
+        if lastCols != size.cols || lastRows != size.rows {
+            resizeContinuation?.yield(TerminalSize(cols: lastCols, rows: lastRows))
+        }
+    }
+
+    private func stopTransportPumps() {
+        stopInputPump()
+        stopResizePump()
+    }
+
     // MARK: Terminal view events
 
     func sendInput(_ data: Data) {
@@ -570,7 +720,8 @@ final class TerminalSessionController {
             return
         }
 
-        let control = SSHConnection(host: host, secrets: .load(for: host))
+        let secrets = await HostSecrets.loadOffMain(for: host)
+        let control = SSHConnection(host: host, secrets: secrets)
         do {
             try await control.connect()
             _ = try await control.exec(command)
@@ -589,7 +740,8 @@ final class TerminalSessionController {
         _ body: (SSHConnection) async throws -> T
     ) async throws -> T {
         if let connection { return try await body(connection) }
-        let control = SSHConnection(host: host, secrets: .load(for: host))
+        let secrets = await HostSecrets.loadOffMain(for: host)
+        let control = SSHConnection(host: host, secrets: secrets)
         try await control.connect()
         do {
             let value = try await body(control)
@@ -865,10 +1017,11 @@ final class TerminalSessionController {
     #endif
 
     func terminalResized(cols: Int, rows: Int) {
+        guard cols != lastCols || rows != lastRows else { return }
         lastCols = cols
         lastRows = rows
-        guard status == .live, let transport else { return }
-        Task { try? await transport.resize(cols: cols, rows: rows) }
+        guard status == .live else { return }
+        resizeContinuation?.yield(TerminalSize(cols: cols, rows: rows))
     }
 
     /// Scene became active again: a mosh transport heartbeats immediately
@@ -915,28 +1068,36 @@ final class TerminalSessionController {
     private func performDrop(_ files: [DroppedFile], over connection: SSHConnection) async {
         do {
             let destination = try await dropDestination(over: connection)
-            var typedPaths: [String] = []
-            for file in files {
+            let uploads = try files.map { file -> SSHUpload in
                 guard file.data.count <= DropText.maxBytes else {
                     throw DropError(message: "\(file.name) is over 64 MB")
                 }
-                dropState = .uploading(name: file.name, fraction: 0)
-                let finalName = try await connection.uploadFile(
-                    file.data,
-                    toDirectory: destination.directory,
-                    preferredName: DropText.sanitizedName(file.name),
-                    prepareGitIgnoredDirectory: destination.prepareGitIgnoredDirectory,
-                    onProgress: { [weak self] fraction in
-                        Task { @MainActor [weak self] in
-                            guard case .uploading = self?.dropState else { return }
-                            self?.dropState = .uploading(name: file.name, fraction: fraction)
-                        }
-                    }
+                return SSHUpload(
+                    data: file.data,
+                    preferredName: DropText.sanitizedName(file.name)
                 )
+            }
+            let displayNames = files.map(\.name)
+            dropState = .uploading(name: files[0].name, fraction: 0)
+            let finalNames = try await connection.uploadFiles(
+                uploads,
+                toDirectory: destination.directory,
+                prepareGitIgnoredDirectory: destination.prepareGitIgnoredDirectory,
+                onProgress: { [weak self] index, fraction in
+                    Task { @MainActor [weak self] in
+                        guard case .uploading = self?.dropState else { return }
+                        self?.dropState = .uploading(
+                            name: displayNames[index],
+                            fraction: fraction
+                        )
+                    }
+                }
+            )
+            let typedPaths = finalNames.map { finalName in
                 // Relative names read best in a prompt, but only when the
                 // file verifiably sits under the pane's cwd.
-                typedPaths.append(destination.typedPrefix.map { $0 + finalName }
-                    ?? destination.directory + "/" + finalName)
+                destination.typedPrefix.map { $0 + finalName }
+                    ?? destination.directory + "/" + finalName
             }
             dropState = nil
             sendInput(Data(DropText.typedPaths(typedPaths).utf8))
@@ -1007,7 +1168,12 @@ final class TerminalSessionController {
         dropTask = nil
         dropClearTask?.cancel()
         dropState = nil
-        stopInputPump()
+        outputCoalescer?.flush()
+        transportGeneration &+= 1
+        runTask?.cancel()
+        runTask = nil
+        outputCoalescer = nil
+        stopTransportPumps()
         stopDirectShellMonitoring()
         setTmuxCopyModeUIActive(false)
         resetHistoryState()
@@ -1025,6 +1191,63 @@ final class TerminalSessionController {
         setTmuxCopyModeUIActive(false)
         resetHistoryState()
         status = .connecting
-        Task { await run() }
+        beginTransportRun()
+    }
+}
+
+/// Receives transport data on NIO / Network.framework queues, then presents
+/// one compact byte array to SwiftTerm per short display interval. A terminal
+/// still parses every byte in order; only cross-thread hops and array copies
+/// are coalesced.
+private final class TerminalOutputCoalescer: @unchecked Sendable {
+    private struct State {
+        var chunks: [Data] = []
+        var byteCount = 0
+        var drainScheduled = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let deliver: @MainActor ([UInt8]) -> Void
+
+    init(deliver: @escaping @MainActor ([UInt8]) -> Void) {
+        self.deliver = deliver
+    }
+
+    func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+        let schedule = state.withLock { state -> Bool in
+            state.chunks.append(data)
+            state.byteCount += data.count
+            guard !state.drainScheduled else { return false }
+            state.drainScheduled = true
+            return true
+        }
+        guard schedule else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(2)) { [weak self] in
+            self?.drain()
+        }
+    }
+
+    @MainActor
+    func flush() {
+        drain()
+    }
+
+    @MainActor
+    private func drain() {
+        let batch = state.withLock { state -> ([Data], Int) in
+            let batch = (state.chunks, state.byteCount)
+            state.chunks.removeAll(keepingCapacity: true)
+            state.byteCount = 0
+            state.drainScheduled = false
+            return batch
+        }
+        guard batch.1 > 0 else { return }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(batch.1)
+        for chunk in batch.0 {
+            bytes.append(contentsOf: chunk)
+        }
+        deliver(bytes)
     }
 }

--- a/Multiplex/Services/TmuxProbe.swift
+++ b/Multiplex/Services/TmuxProbe.swift
@@ -40,10 +40,10 @@ enum TmuxProbe {
     /// active-pane capture for the live miniatures. A second capture exec
     /// used to follow the probe; folding it in halves the per-tick channel
     /// opens, login-shell spawns, and round-trips.
-    static var probeCommand: String {
+    static let probeCommand: String = {
         let sessionFormat = "S #{session_id} #{session_attached} #{session_created} #{session_name}"
         let windowFormat = "W #{session_id} #{window_index} #{window_active} #{window_bell_flag} #{window_activity_flag} #{window_name}"
-        let paneFormat = paneFormat(tag: "P")
+        let paneLineFormat = paneFormat(tag: "P")
         return pathPrefix
             + "command -v tmux >/dev/null 2>&1 || { echo MULTIPLEX_NO_TMUX; exit 0; }; "
             + "tmux list-sessions -F '\(sessionFormat)' 2>/dev/null "
@@ -51,7 +51,7 @@ enum TmuxProbe {
             // Keep the pane listing in one shell variable: it is printed for
             // the parser and reused to derive every pane-process root,
             // avoiding a second list-panes call in the process stage.
-            + "&& panes=$(tmux list-panes -a -F '\(paneFormat)' 2>/dev/null) "
+            + "&& panes=$(tmux list-panes -a -F '\(paneLineFormat)' 2>/dev/null) "
             + "&& printf '%s\\n' \"$panes\" "
             + "&& { echo MULTIPLEX_PS; \(psPaneSubtreeCommand); } "
             + "|| true; "
@@ -60,6 +60,28 @@ enum TmuxProbe {
             + "echo \"MPXS $s\"; "
             + "tmux capture-pane -p -t \"$s\" -S -\(captureDepth) 2>/dev/null; "
             + "done; echo MPXE"
+    }()
+
+    /// Everything derived from one probe response. Keeping this pure bundle
+    /// together lets callers move the process-tree walk, capture trimming,
+    /// and miniature clipping off the UI actor in one hop.
+    struct ParsedProbe {
+        var state: TmuxState
+        var tails: [String: [String]]
+        var miniatures: [String: [String]]
+    }
+
+    static func parseProbe(_ output: String) -> ParsedProbe {
+        let state = parse(output)
+        guard case .sessions(let sessions) = state else {
+            return ParsedProbe(state: state, tails: [:], miniatures: [:])
+        }
+        let tails = parseTails(output, sessions: sessions)
+        return ParsedProbe(
+            state: state,
+            tails: tails,
+            miniatures: tails.mapValues(miniatureTail)
+        )
     }
 
     /// One host-wide process snapshot, clipped to every tmux pane subtree
@@ -92,8 +114,6 @@ enum TmuxProbe {
 
     /// Parse combined probe output into a `TmuxState`.
     static func parse(_ output: String) -> TmuxState {
-        if output.contains("MULTIPLEX_NO_TMUX") { return .tmuxMissing }
-
         struct SessionInfo {
             var name: String
             var clients: Int
@@ -106,10 +126,13 @@ enum TmuxProbe {
         var psRows: [PSRow] = []
         var inPSSection = false
 
-        for line in output.split(separator: "\n") {
-            // Everything after the tails sentinel is raw pane content —
-            // arbitrary bytes that must never be read as S/W/P/ps lines.
-            if line == "MULTIPLEX_TAILS" { break }
+        // String.split is eager. Slice before the capture section first so a
+        // large wall repaint is not tokenized once as probe records and then
+        // again as terminal lines.
+        let records = tailsMarker(in: output).map { output[..<$0.lowerBound] }
+            ?? output[...]
+        for line in records.split(separator: "\n") {
+            if line == "MULTIPLEX_NO_TMUX" { return .tmuxMissing }
             if line == "MULTIPLEX_PS" {
                 inPSSection = true
                 continue
@@ -449,7 +472,6 @@ enum TmuxProbe {
             names[session.tmuxID] = session.name
         }
         var result: [String: [String]] = [:]
-        var inTails = false
         var currentName: String?
         var lines: [String] = []
         func flush() {
@@ -457,12 +479,11 @@ enum TmuxProbe {
             currentName = nil
             lines = []
         }
-        for raw in output.split(separator: "\n", omittingEmptySubsequences: false) {
+        let marker = tailsMarker(in: output)
+        guard let marker else { return [:] }
+        for raw in output[marker.upperBound...]
+            .split(separator: "\n", omittingEmptySubsequences: false) {
             let line = String(raw)
-            if !inTails {
-                if line == "MULTIPLEX_TAILS" { inTails = true }
-                continue
-            }
             if line.hasPrefix("MPXS ") {
                 flush()
                 currentName = names[String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)]
@@ -497,5 +518,10 @@ enum TmuxProbe {
         var s = Substring(line)
         while let last = s.last, last == " " || last == "\t" { s = s.dropLast() }
         return String(s)
+    }
+
+    private static func tailsMarker(in output: String) -> Range<String.Index>? {
+        output.range(of: "\nMULTIPLEX_TAILS\n")
+            ?? output.range(of: "MULTIPLEX_TAILS\n", options: .anchored)
     }
 }

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -85,6 +85,26 @@ enum FleetTileGridSizing {
     }
 }
 
+/// Narrow Observation boundary for one host. Capture-pane text and attention
+/// changes now invalidate only that host section; the parent wall observes
+/// the lightweight fleet/session summaries used for global layout.
+private struct HostSectionObservation<Content: View>: View {
+    let model: HostConnectionModel
+    let content: (HostConnectionModel) -> Content
+
+    init(
+        model: HostConnectionModel,
+        @ViewBuilder content: @escaping (HostConnectionModel) -> Content
+    ) {
+        self.model = model
+        self.content = content
+    }
+
+    var body: some View {
+        content(model)
+    }
+}
+
 /// The deck: the whole fleet as one broadcast monitor wall. Every host
 /// probes concurrently under a thin rail; every session is a live tile
 /// showing its actual last lines (capture-pane over the host's control
@@ -263,13 +283,16 @@ struct FleetWall: View {
         )
 
         return ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
+            LazyVStack(alignment: .leading, spacing: 0) {
                 if showHeader { header }
                 if store.hosts.isEmpty {
                     awaitingSignal
                 } else {
                     ForEach(store.hosts) { host in
-                        hostSection(host, columns: columns)
+                        let model = hub.model(for: host)
+                        HostSectionObservation(model: model) { observed in
+                            hostSection(host, model: observed, columns: columns)
+                        }
                     }
                 }
             }
@@ -319,10 +342,7 @@ struct FleetWall: View {
     /// sections above and below it.
     private var tileCount: Int {
         let counts = store.hosts.map { host -> Int in
-            if case .sessions(let sessions) = hub.model(for: host).tmux {
-                return sessions.count + 1
-            }
-            return 1
+            max(1, hub.model(for: host).sessionCount + 1)
         }
         return counts.max() ?? 1
     }
@@ -352,6 +372,18 @@ struct FleetWall: View {
     /// refresh its miniatures. Skips work while the app is backgrounded;
     /// `.task(id:)` restarts the loop when the fleet changes.
     private func runFeed() async {
+        let models = store.hosts.map { hub.model(for: $0) }
+        await withTaskGroup(of: Void.self) { group in
+            for model in models {
+                group.addTask { await runFeed(for: model) }
+            }
+        }
+    }
+
+    /// Each host owns its cadence. A black-holed SSH link can consume its
+    /// ten-second deadline without stretching healthy hosts from five to
+    /// fifteen seconds between live captures.
+    private func runFeed(for model: HostConnectionModel) async {
         while !Task.isCancelled {
             guard UIApplication.shared.applicationState == .active else {
                 // Not active YET: a cold launch runs the first tick before
@@ -360,22 +392,13 @@ struct FleetWall: View {
                 // briefly instead — the task id also restarts this loop the
                 // moment the scene turns active, and iOS suspends the
                 // process outright in the background, so this never spins.
-                try? await Task.sleep(for: .milliseconds(200))
+                do { try await Task.sleep(for: .milliseconds(200)) }
+                catch { return }
                 continue
             }
-            // Resolve models on the main actor first, then let every host
-            // run its own probe (one exec round-trip carrying sessions,
-            // agent detection, and miniature tails). One slow host must
-            // not delay the rest of the fleet.
-            let models = store.hosts.map { hub.model(for: $0) }
-            await withTaskGroup(of: Void.self) { group in
-                for model in models {
-                    group.addTask {
-                        await model.refreshAndWait(ifStaleFor: 4)
-                    }
-                }
-            }
-            try? await Task.sleep(for: Self.feedInterval)
+            await model.refreshAndWait(ifStaleFor: 4)
+            do { try await Task.sleep(for: Self.feedInterval) }
+            catch { return }
         }
     }
 
@@ -479,7 +502,7 @@ struct FleetWall: View {
 
     private var fleetSummary: String {
         let sessions = store.hosts.reduce(0) { count, host in
-            count + hub.model(for: host).tmux.sessions.count
+            count + hub.model(for: host).sessionCount
         }
         let hosts = store.hosts.count
         return "\(hosts) HOST\(hosts == 1 ? "" : "S") · \(sessions) SESSION\(sessions == 1 ? "" : "S")"
@@ -517,9 +540,11 @@ struct FleetWall: View {
     // MARK: Host rail + tiles
 
     @ViewBuilder
-    private func hostSection(_ host: Host, columns: [GridItem]) -> some View {
-        let model = hub.model(for: host)
-
+    private func hostSection(
+        _ host: Host,
+        model: HostConnectionModel,
+        columns: [GridItem]
+    ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             rail(host, model: model)
             tiles(host, model: model, columns: columns)
@@ -836,7 +861,7 @@ struct FleetWall: View {
             session: session,
             lines: model.miniatures[session.name] ?? [],
             attention: model.attention[session.name],
-            hasLiveAgentState: model.lastRefreshed != nil,
+            hasLiveAgentState: model.hasLiveProbe,
             hasOpenTab: workspace.hasTab(hostID: host.id, sessionName: session.name),
             compact: presentation == .shellRail,
             selected: selectedTerminal?.hostID == host.id
@@ -864,7 +889,27 @@ struct FleetWall: View {
         if reduceMotion {
             grid
         } else {
-            grid.animation(.easeOut(duration: 0.3), value: state)
+            grid.animation(.easeOut(duration: 0.3), value: gridIdentity(for: state))
+        }
+    }
+
+    private enum GridIdentity: Hashable {
+        case unknown
+        case probing
+        case sessions([String])
+        case noServer
+        case tmuxMissing
+        case failed
+    }
+
+    private func gridIdentity(for state: TmuxState) -> GridIdentity {
+        switch state {
+        case .unknown: .unknown
+        case .probing: .probing
+        case .sessions(let sessions): .sessions(sessions.map(\.name))
+        case .noServer: .noServer
+        case .tmuxMissing: .tmuxMissing
+        case .failed: .failed
         }
     }
 

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -67,6 +67,7 @@ struct SwiftTermView: UIViewRepresentable {
             view.inputAccessoryView = nil
             #endif
         }
+        view.renderUpdatesEnabled = isActive
         apply(theme, to: view, coordinator: context.coordinator)
         if view.font.pointSize != fontSize {
             view.font = .monospacedSystemFont(ofSize: fontSize, weight: .regular)
@@ -180,6 +181,9 @@ struct SwiftTermView: UIViewRepresentable {
         // (about to be torn down) representable gets one last update.
         guard let view = context.coordinator.terminalView,
               view.isDescendant(of: container) else { return }
+        if view.renderUpdatesEnabled != isActive {
+            view.renderUpdatesEnabled = isActive
+        }
         let fontChanged = view.font.pointSize != fontSize
         if fontChanged {
             view.font = .monospacedSystemFont(ofSize: fontSize, weight: .regular)

--- a/MultiplexTests/MoshFragmentTests.swift
+++ b/MultiplexTests/MoshFragmentTests.swift
@@ -68,6 +68,20 @@ final class MoshFragmentTests: XCTestCase {
         XCTAssertNil(assembly.add(first[2]))
     }
 
+    func testSingleFragmentFastPathAbandonsPartialAssembly() {
+        var fragmenter = MoshFragmenter()
+        var assembly = MoshFragmentAssembly()
+
+        let partial = fragmenter.fragments(
+            of: Data(repeating: 1, count: 90), budget: 40
+        )
+        let complete = fragmenter.fragments(of: Data("next".utf8), budget: 40)
+        XCTAssertNil(assembly.add(partial[0]))
+        XCTAssertEqual(assembly.add(complete[0]), Data("next".utf8))
+        XCTAssertNil(assembly.add(partial[1]))
+        XCTAssertNil(assembly.add(partial[2]))
+    }
+
     func testFragmentIDsAdvancePerInstruction() {
         var fragmenter = MoshFragmenter()
         let a = fragmenter.fragments(of: Data("a".utf8), budget: 100)

--- a/MultiplexTests/MoshTransportTests.swift
+++ b/MultiplexTests/MoshTransportTests.swift
@@ -70,6 +70,22 @@ final class MoshTransportTests: XCTestCase {
         )
     }
 
+    func testUnsentInputsAndResizesCoalesce() throws {
+        var (engine, server) = try makePair()
+
+        engine.resize(cols: 100, rows: 30)
+        engine.resize(cols: 90, rows: 25)
+        engine.input(Data("a".utf8))
+        engine.input(Data("bc".utf8))
+
+        let instructions = server.receive(engine.tick(now: 1000).datagrams, now: 1005)
+        let instruction = try XCTUnwrap(instructions.first)
+        XCTAssertEqual(
+            MoshUserMessage.decode(instruction.diff),
+            [.resize(cols: 90, rows: 25), .keys(Data("abc".utf8))]
+        )
+    }
+
     func testUnackedInputRetransmitsUntilAcked() throws {
         var (engine, server) = try makePair()
         _ = engine.tick(now: 1000) // initial resize goes out (and is lost)
@@ -222,6 +238,29 @@ final class MoshTransportTests: XCTestCase {
             now = next
         }
         XCTAssertGreaterThanOrEqual(heartbeats, 2)
+    }
+
+    func testRequestedHeartbeatIsImmediate() throws {
+        var (engine, server) = try makePair()
+        _ = server.receive(engine.tick(now: 1000).datagrams, now: 1000)
+        for datagram in server.send(old: 0, new: 1, ack: 1, now: 1010) {
+            _ = engine.receive(datagram, now: 1015)
+        }
+
+        // First discharge the delayed acknowledgement caused by receiving
+        // the server state, leaving only the normal idle heartbeat pending.
+        _ = engine.tick(now: 1015)
+        _ = server.receive(engine.tick(now: 1115).datagrams, now: 1115)
+        let (quiet, deadline) = engine.tick(now: 1200)
+        XCTAssertTrue(quiet.isEmpty)
+        XCTAssertGreaterThan(deadline, 1200)
+
+        engine.requestHeartbeat(now: 1200)
+        let immediate = server.receive(engine.tick(now: 1200).datagrams, now: 1200)
+        XCTAssertFalse(immediate.isEmpty)
+        XCTAssertTrue(immediate.allSatisfy {
+            MoshUserMessage.decode($0.diff)?.isEmpty ?? false
+        })
     }
 
     func testClientShutdownHandshake() throws {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -1737,6 +1737,9 @@ extension TerminalView {
     func updateDisplay (notifyAccessibility: Bool)
     {
         defer { pendingDisplay = false }
+        #if os(iOS) || os(visionOS)
+        guard renderUpdatesEnabled else { return }
+        #endif
         if terminal.synchronizedOutputActive {
             return
         }
@@ -1914,6 +1917,9 @@ extension TerminalView {
     // It is also cheap, so should be called when new data has been posted or received.
     func queuePendingDisplay ()
     {
+        #if os(iOS) || os(visionOS)
+        guard renderUpdatesEnabled else { return }
+        #endif
         if terminal.synchronizedOutputActive {
             return
         }
@@ -1932,6 +1938,9 @@ extension TerminalView {
 
 #if canImport(MetalKit)
     func requestMetalDisplay() {
+        #if os(iOS) || os(visionOS)
+        guard renderUpdatesEnabled else { return }
+        #endif
         guard let metalView = metalView else {
             return
         }
@@ -1939,6 +1948,9 @@ extension TerminalView {
     }
 
     func queueMetalDisplay() {
+        #if os(iOS) || os(visionOS)
+        guard renderUpdatesEnabled else { return }
+        #endif
         guard metalView != nil else {
             return
         }
@@ -2181,6 +2193,9 @@ extension TerminalView {
     }
 
     private func displayImmediately() {
+        #if os(iOS) || os(visionOS)
+        guard renderUpdatesEnabled else { return }
+        #endif
         guard !Thread.isMainThread else {
             updateDisplay()
             return

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -56,6 +56,40 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     public static var textInputDebugEnabled: Bool = ProcessInfo.processInfo.environment["SWIFTTERM_TEXT_INPUT_DEBUG"] == "1"
     internal static var textInputLogCounter: Int = 0
 
+    // Multiplex patch: inactive tabs must keep parsing bytes so their buffer
+    // and scrollback remain current, but they do not need UIKit invalidations,
+    // cursor placement, or accessibility notifications while fully obscured.
+    // The lock matters because feed() is allowed on a background thread.
+    private let renderUpdatesLock = NSLock()
+    private var _renderUpdatesEnabled = true
+    public var renderUpdatesEnabled: Bool {
+        get {
+            renderUpdatesLock.lock()
+            defer { renderUpdatesLock.unlock() }
+            return _renderUpdatesEnabled
+        }
+        set {
+            renderUpdatesLock.lock()
+            let shouldRefresh = newValue && !_renderUpdatesEnabled
+            _renderUpdatesEnabled = newValue
+            renderUpdatesLock.unlock()
+            guard shouldRefresh else { return }
+            let refresh = { [weak self] in
+                guard let self else { return }
+                self.terminal.refresh(
+                    startRow: 0,
+                    endRow: max(0, self.terminal.rows - 1)
+                )
+                self.queuePendingDisplay()
+            }
+            if Thread.isMainThread {
+                refresh()
+            } else {
+                DispatchQueue.main.async(execute: refresh)
+            }
+        }
+    }
+
     struct FontSet {
         public let normal: UIFont
         let bold: UIFont


### PR DESCRIPTION
## Summary

- reduce Fleet Wall rendering and main-actor work with per-host observation, independent polling, lazy layout, unchanged-state guards, and background parsing and persistence
- make SSH connection setup, deadlines, cancellation, teardown, credential loading, and batched SFTP uploads more efficient and race-safe
- coalesce terminal output and resize traffic while suppressing redraw work for inactive SwiftTerm tabs
- reduce Mosh task creation, buffer copies, fragmentation overhead, and crypto calls while coalescing input and resizes and improving heartbeat behavior

## Why

The performance-critical paths performed avoidable work at fleet scale: host probes were serialized, unchanged observable state caused redraws, terminal and UDP chunks created many short-lived tasks, inactive tabs continued rendering, and the protocol stack repeatedly copied buffers. Connection lifecycle races could also retain work or parent SSH connections after a terminal transport closed.

These changes keep ordered input and protocol behavior intact while moving expensive work off the main actor, bounding queues, batching high-frequency operations, and making cancellation and teardown deterministic.

## Impact

Large fleets and multi-tab terminal workspaces should use less CPU and allocate less transient memory. Slow hosts no longer delay healthy host tiles, hidden terminals avoid unnecessary display work, output and resize bursts produce fewer scheduler hops, and SSH and Mosh reconnection behavior is more predictable.

## Validation

- `./Tools/build.sh test vos` — 351 tests passed
- `./Tools/build.sh build vos`
- `./Tools/build.sh build ipad`
- `./Tools/build.sh interop` — real `mosh-server` idle pump, echo, shutdown, and peer-exit checks passed
- `./Tools/build.sh verify vos` — live SSH → PTY → tmux → SwiftTerm path
- `./Tools/build.sh verify ipad` — live SSH → PTY → tmux → SwiftTerm path
- `git diff --check`
