### PR TITLE
Add per-host session setup scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ vars to drive the real SSH→PTY→tmux→SwiftTerm path headlessly:
 
 - `MULTIPLEX_SEED_HOST=<path to seed.json>` — imports a ready `devbox` host
   (idempotent; stable UUID across relaunches so restored scenes stay valid).
+  Optional `workingDirs` / `sessionScripts` keys feed headless checks of the
+  New Session pickers and the setup-script creation paths.
 - `MULTIPLEX_AUTO_ATTACH=main,scratch` — opens a terminal per comma entry via
   the same route the Attach button uses; `+` inside an entry groups sessions
   as tabs of one window (`main+scratch,deploy`). Fires **once per process**.
@@ -471,6 +473,31 @@ views.
   runner falls back to ordinary tmux on macOS/BSD or when the systemd user
   manager is unavailable (a headless Linux host with logind cleanup then needs
   user lingering enabled or `KillUserProcesses=no`).
+- **Session setup scripts are chosen, then typed — never implicit**
+  (`SessionScript`, `Host.sessionScripts`; editor in Host Settings below the
+  working dirs): a newly *created* session types the selected script into the
+  fresh shell through the same send-keys-then-Enter discipline as the agent
+  launch, BEFORE the launch line — same shell, so its exports/activations are
+  live for the launch. Sequential, never `&&`-gated: a failing script leaves
+  its error visible above a launch that still runs (and a script that reads
+  stdin eats the launch line as input — documented footgun, unsolvable
+  app-side). Shell-only sessions get the script too; attach never types
+  anything, and the legacy PTY-side `.create` route stays untouched (nothing
+  rides on `TerminalRoute`). The New Session sheet's single REMEMBER opt-in
+  covers the per-host script choice (`NewSessionPreferences`, device-local
+  host-UUID → script-id map; deleted ids fail soft to NONE), and while it is
+  on, the pickerless creation paths — + TAB and the widget/Shortcuts router —
+  inherit the remembered script the way + TAB inherits the pane cwd. List
+  order is presentation only: a script never runs merely because it exists or
+  sits first, and the sheet picker is the Starts-in Menu grammar, not a
+  choice bar (user lists are unbounded). Script ids are load-bearing (the
+  remember map points at them), so the editor preserves them across edits;
+  bodies get the custom-command sanitize (controls stripped, interior
+  newlines/tabs kept). Scripts ride the synced Host record (`updatedAt`
+  bumps), are zeroed out of `connectionModelConfiguration` so edits don't
+  drop the probe link, never enter the widget projection, and are free-tier
+  host plumbing, not an agent-helper surface. The dev seed may carry a
+  `sessionScripts` array for headless checks of these paths.
 - **mosh is a second `TerminalTransport`, not a fork of the SSH path**
   (`Services/Mosh/`, `Host.useMosh`). SSH stays the control plane — deck
   probing, capture-pane, file-drop SFTP, and the mosh bootstrap itself all

--- a/Multiplex/Models/Host.swift
+++ b/Multiplex/Models/Host.swift
@@ -33,6 +33,11 @@ struct Host: Identifiable, Codable, Hashable {
     /// the first is the default; the rest are choices in the New Session
     /// prompt. Empty means $HOME.
     var workingDirs: [String] = []
+    /// Named setup scripts, in the user's order (order is presentation only
+    /// — a script runs only when chosen, never because it exists). The
+    /// selected one is typed into a freshly created session's shell before
+    /// the optional agent launch line.
+    var sessionScripts: [SessionScript] = []
     /// Agent-helper commands and built-in Bar/More placement for this host.
     /// This is part of the mirrored host record so the setup follows the host
     /// to the user's other devices through iCloud Keychain.
@@ -62,6 +67,9 @@ extension Host {
         moshServerPath = try container.decodeIfPresent(String.self, forKey: .moshServerPath)
         moshPorts = try container.decodeIfPresent(String.self, forKey: .moshPorts)
         workingDirs = try container.decodeIfPresent([String].self, forKey: .workingDirs) ?? []
+        sessionScripts = SessionScript.normalized(
+            try container.decodeIfPresent([SessionScript].self, forKey: .sessionScripts) ?? []
+        )
         agentCommandConfiguration = try container.decodeIfPresent(
             AgentCommandConfiguration.self,
             forKey: .agentCommandConfiguration
@@ -70,11 +78,13 @@ extension Host {
     }
 
     /// Hashable identity for the connection model and the wall feed that
-    /// drives it. Command-setup edits must not tear down the probe connection;
-    /// every other current/future Host field remains part of the identity.
+    /// drives it. Command-setup and setup-script edits must not tear down the
+    /// probe connection; every other current/future Host field remains part
+    /// of the identity.
     var connectionModelConfiguration: Host {
         var configuration = self
         configuration.agentCommandConfiguration = AgentCommandConfiguration()
+        configuration.sessionScripts = []
         configuration.updatedAt = .distantPast
         return configuration
     }

--- a/Multiplex/Models/SessionScript.swift
+++ b/Multiplex/Models/SessionScript.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// One named setup script for a host. When a new session is created, the
+/// chosen script is typed into the fresh login shell before the optional
+/// agent launch line, so whatever it sets up (nvm, a virtualenv, sourced
+/// secrets) is live for the launch — and for the shell when nothing
+/// launches. Typing is sequential, never gated: the launch line still runs
+/// when the script fails, with the failure visible above it. Attaching to
+/// an existing session never types anything.
+///
+/// Scripts are part of the Codable `Host` record, so they follow the host
+/// across devices through the synchronizable Keychain mirror. They never
+/// enter the widget projection.
+struct SessionScript: Identifiable, Hashable {
+    /// Menu rows and captions keep at most this many characters of a
+    /// nameless script's first line.
+    private static let maximumFallbackNameLength = 36
+
+    var id: UUID = UUID()
+    /// Optional label; `displayName` falls back to the body's first line.
+    var name: String = ""
+    var body: String = ""
+
+    /// The canonical bytes persisted and typed — the custom-command policy:
+    /// normalize pasted Windows/classic-Mac line endings, strip invisible
+    /// terminal controls (especially tmux's Ctrl-B prefix), keep interior
+    /// tabs and newlines, trim only the outside.
+    var normalizedBody: String {
+        let normalizedLineEndings = body
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let safeText = normalizedLineEndings.unicodeScalars.reduce(into: "") {
+            result, scalar in
+            let allowedControl = scalar.value == 0x09 || scalar.value == 0x0A
+            if allowedControl || !CharacterSet.controlCharacters.contains(scalar) {
+                result.append(Character(scalar))
+            }
+        }
+        return safeText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Picker and row title: the trimmed name, or the body's first line
+    /// truncated when the name is blank — a fragment beats an unlabeled row.
+    var displayName: String {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedName.isEmpty { return trimmedName }
+        let firstLine = normalizedBody
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .first.map(String.init) ?? ""
+        let collapsed = firstLine
+            .split(whereSeparator: \Character.isWhitespace)
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return "Script" }
+        guard collapsed.count > Self.maximumFallbackNameLength else { return collapsed }
+        return String(collapsed.prefix(Self.maximumFallbackNameLength - 1)) + "…"
+    }
+
+    /// Resolve editor rows before persistence: canonicalize bodies, trim
+    /// names, drop rows with nothing to type, and keep ids unique. Ids are
+    /// load-bearing — the remembered-selection memory points at them — so
+    /// normalization never reminted an id.
+    static func normalized(_ scripts: [SessionScript]) -> [SessionScript] {
+        var seenIDs = Set<UUID>()
+        var result: [SessionScript] = []
+        for var script in scripts {
+            let body = script.normalizedBody
+            guard !body.isEmpty, seenIDs.insert(script.id).inserted else { continue }
+            script.body = body
+            script.name = script.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            result.append(script)
+        }
+        return result
+    }
+}
+
+// Decoding lives in an extension so the memberwise initializer survives.
+// Every field is optional on decode — a record written by a newer schema on
+// another device must not drop the whole host list.
+extension SessionScript: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id, name, body
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        body = try container.decodeIfPresent(String.self, forKey: .body) ?? ""
+    }
+}

--- a/Multiplex/Services/ConnectionHub.swift
+++ b/Multiplex/Services/ConnectionHub.swift
@@ -594,15 +594,16 @@ final class HostConnectionModel {
     /// Create a detached tmux session over the control connection and
     /// return its final name — in `sourceSession`'s active-pane cwd ($HOME
     /// when nil or unresolvable), or in an explicit `directory` (a host
-    /// working dir) when there is no source, optionally with `launch` typed
-    /// into its fresh shell. The wanted name derives from `base` against the
-    /// latest probe; the server settles races (see
-    /// `TmuxProbe.newSessionCommand`). Unlike the fail-soft probe helpers
-    /// this connects on demand — it's a user-initiated action — and returns
-    /// nil on failure.
+    /// working dir) when there is no source, optionally with `script` (a
+    /// host setup script) then `launch` typed into its fresh shell. The
+    /// wanted name derives from `base` against the latest probe; the server
+    /// settles races (see `TmuxProbe.newSessionCommand`). Unlike the
+    /// fail-soft probe helpers this connects on demand — it's a
+    /// user-initiated action — and returns nil on failure.
     func createSession(
         base: String, inDirectoryOf sourceSession: String?,
-        startingIn directory: String? = nil, typing launch: String?
+        startingIn directory: String? = nil, running script: String? = nil,
+        typing launch: String?
     ) async -> String? {
         resetConnectRetryBackoff()
         let reusedLink = connection != nil && phase == .connected
@@ -613,6 +614,7 @@ final class HostConnectionModel {
                     base: base, existing: tmux.sessions.map(\.name)),
                 sourceSessionName: sourceSession,
                 startDirectory: directory,
+                script: script,
                 launch: launch
             )
             let name = TmuxProbe.parseNewSession(

--- a/Multiplex/Services/ExternalActionRouter.swift
+++ b/Multiplex/Services/ExternalActionRouter.swift
@@ -139,10 +139,14 @@ enum ExternalActionPerformer {
             if context.workspace.focusTab(hostID: host.id, sessionName: target) { return }
             open(sessionName: target, on: host, context: context)
         } else {
+            // Headless creation inherits the New Session sheet's remembered
+            // setup script (nil unless its REMEMBER opt-in is on) — a widget
+            // tap must not produce a lesser session than the sheet would.
             guard let created = await model.createSession(
                 base: "main",
                 inDirectoryOf: nil,
                 startingIn: host.workingDirs.first,
+                running: NewSessionPreferences().rememberedScript(for: host)?.normalizedBody,
                 typing: nil
             ) else {
                 presentCreateFailure(for: model, host: host, context: context)
@@ -159,10 +163,12 @@ enum ExternalActionPerformer {
         guard let model = await connectedModel(for: host, context: context) else { return }
         // nil = the host's default working dir; the sheet's explicit Home
         // choice arrives as "~", which the quoting layer expands to $HOME.
+        // The remembered setup script rides like the shell path above.
         guard let created = await model.createSession(
             base: agent.launchCommand,
             inDirectoryOf: nil,
             startingIn: directory ?? host.workingDirs.first,
+            running: NewSessionPreferences().rememberedScript(for: host)?.normalizedBody,
             typing: agent.launchCommand(initialPrompt: prompt ?? "")
         ) else {
             presentCreateFailure(for: model, host: host, context: context)

--- a/Multiplex/Services/HostStore.swift
+++ b/Multiplex/Services/HostStore.swift
@@ -289,6 +289,11 @@ final class HostStore {
         // Optional so existing seeds leave the host's dirs alone; used by
         // headless checks of the Starts-in pickers.
         if let dirs = seed.workingDirs { host.workingDirs = dirs }
+        // Same deal for setup scripts — headless checks of the script paths
+        // seed one with a known id so the remembered choice can target it.
+        if let scripts = seed.sessionScripts {
+            host.sessionScripts = SessionScript.normalized(scripts)
+        }
         if let key = seed.privateKey { KeychainStore.set(key, for: host.id, kind: .privateKey) }
         if let password = seed.password { KeychainStore.set(password, for: host.id, kind: .password) }
         if hosts.contains(where: { $0.id == host.id }) {
@@ -311,6 +316,7 @@ final class HostStore {
         var moshServerPath: String?
         var moshPorts: String?
         var workingDirs: [String]?
+        var sessionScripts: [SessionScript]?
     }
     #endif
 }

--- a/Multiplex/Services/NewSessionPreferences.swift
+++ b/Multiplex/Services/NewSessionPreferences.swift
@@ -4,9 +4,15 @@ import Foundation
 /// separate from the selected agent so remembering "Shell only" is distinct
 /// from not remembering a launch choice at all. The one-shot initial prompt
 /// is deliberately never persisted.
+///
+/// The same single opt-in also covers the setup-script choice — per host,
+/// because script ids are host-scoped. While it is on, the remembered script
+/// is what the pickerless creation paths (+ TAB, widget/Shortcuts) type
+/// into their fresh sessions; off means every path types nothing.
 struct NewSessionPreferences {
     private static let remembersLastLaunchKey = "newSession.remembersLastLaunch"
     private static let lastAgentKey = "newSession.lastAgent"
+    private static let lastScriptsKey = "newSession.lastScripts"
 
     private let defaults: UserDefaults
 
@@ -27,7 +33,22 @@ struct NewSessionPreferences {
         return AgentKind(rawValue: rawValue)
     }
 
-    func save(remembersLastLaunch: Bool, agent: AgentKind?) {
+    /// The host's remembered setup script, resolved against its current
+    /// list. `nil` means NONE — an absent entry and a remembered id whose
+    /// script was since deleted or unsynced read the same way, silently.
+    func rememberedScript(for host: Host) -> SessionScript? {
+        guard remembersLastLaunch,
+              let stored = defaults.dictionary(forKey: Self.lastScriptsKey),
+              let rawValue = stored[host.id.uuidString] as? String,
+              let scriptID = UUID(uuidString: rawValue)
+        else { return nil }
+        return host.sessionScripts.first { $0.id == scriptID }
+    }
+
+    func save(
+        remembersLastLaunch: Bool, agent: AgentKind?,
+        script: SessionScript?, hostID: UUID
+    ) {
         defaults.set(remembersLastLaunch, forKey: Self.remembersLastLaunchKey)
         if remembersLastLaunch, let agent {
             defaults.set(agent.rawValue, forKey: Self.lastAgentKey)
@@ -36,6 +57,22 @@ struct NewSessionPreferences {
             // clearing it while disabled also prevents a stale agent returning
             // if the preference is enabled again later.
             defaults.removeObject(forKey: Self.lastAgentKey)
+        }
+
+        // Same policy per host for the script: no entry is the canonical
+        // NONE, and turning remembering off forgets every host's choice.
+        var scripts = remembersLastLaunch
+            ? (defaults.dictionary(forKey: Self.lastScriptsKey) as? [String: String]) ?? [:]
+            : [:]
+        if remembersLastLaunch, let script {
+            scripts[hostID.uuidString] = script.id.uuidString
+        } else {
+            scripts.removeValue(forKey: hostID.uuidString)
+        }
+        if scripts.isEmpty {
+            defaults.removeObject(forKey: Self.lastScriptsKey)
+        } else {
+            defaults.set(scripts, forKey: Self.lastScriptsKey)
         }
     }
 }

--- a/Multiplex/Services/TmuxProbe.swift
+++ b/Multiplex/Services/TmuxProbe.swift
@@ -375,6 +375,12 @@ enum TmuxProbe {
     /// - `startDirectory`: an explicit start directory (a host working dir
     ///   picked in the New Session prompt); consulted only when there is no
     ///   source session, and skipped for $HOME when missing on the host.
+    /// - `script`: the host's chosen setup script, typed into the fresh
+    ///   shell exactly like `launch` but before it — same shell, so what it
+    ///   exports/activates is live for the launch line. Sequential, never
+    ///   gated: a failing script leaves its error visible above a launch
+    ///   that still runs. (Known limit, documented not solved: a script
+    ///   that reads stdin consumes the launch line as its input.)
     /// - `launch`: typed into the fresh shell via send-keys (literal text,
     ///   then Enter) — never the session's command argv, so the agent
     ///   exiting leaves a shell, and the login shell's own PATH resolves it
@@ -391,7 +397,8 @@ enum TmuxProbe {
     /// failed create must read as "no sentinel", not a torn-down control
     /// connection.
     static func newSessionCommand(
-        name: String, sourceSessionName: String?, startDirectory: String? = nil, launch: String?
+        name: String, sourceSessionName: String?, startDirectory: String? = nil,
+        script: String? = nil, launch: String?
     ) -> String {
         var command = pathPrefix + TmuxSessionLaunch.persistentRunnerDefinition
         if let source = sourceSessionName {
@@ -408,8 +415,8 @@ enum TmuxProbe {
         command += "i=$(\(create) -s \(name.shellQuoted) 2>/dev/null)"
             + " || i=$(\(create) 2>/dev/null); "
         var onSuccess = ""
-        if let launch {
-            onSuccess += "tmux send-keys -t \"${i%% *}\" -l -- \(launch.shellQuoted); "
+        for typed in [script, launch].compactMap({ $0 }) {
+            onSuccess += "tmux send-keys -t \"${i%% *}\" -l -- \(typed.shellQuoted); "
                 + "tmux send-keys -t \"${i%% *}\" Enter; "
         }
         onSuccess += "printf 'MULTIPLEX_NEW %s\\n' \"${i#* }\""

--- a/Multiplex/Views/Deck/AddHostSheet.swift
+++ b/Multiplex/Views/Deck/AddHostSheet.swift
@@ -21,6 +21,7 @@ struct AddHostSheet: View {
     @State private var moshPorts = ""
     @State private var workingDirs: [WorkingDir] = []
     @State private var newWorkingDir = ""
+    @State private var scripts: [ScriptRow] = []
     @State private var testState: TestState = .idle
     @State private var showingPaywall = false
 
@@ -31,6 +32,31 @@ struct AddHostSheet: View {
     private struct WorkingDir: Identifiable, Equatable {
         let id = UUID()
         var path: String
+    }
+
+    /// Same row discipline for setup scripts, except the identity is the
+    /// script's own persisted id: the remembered-selection memory points at
+    /// it, so editing a script must never remint it.
+    private struct ScriptRow: Identifiable, Equatable {
+        let id: UUID
+        var name: String
+        var body: String
+
+        init(_ script: SessionScript) {
+            id = script.id
+            name = script.name
+            body = script.body
+        }
+
+        init() {
+            id = UUID()
+            name = ""
+            body = ""
+        }
+
+        var script: SessionScript {
+            SessionScript(id: id, name: name, body: body)
+        }
     }
 
     private enum TestState: Equatable {
@@ -48,6 +74,7 @@ struct AddHostSheet: View {
                     credentialsSection
                     testSection
                     workingDirsSection
+                    scriptsSection
                     transportSection
                 }
                 .frame(maxWidth: 680)
@@ -436,6 +463,100 @@ struct AddHostSheet: View {
         newWorkingDir = ""
     }
 
+    // MARK: Session setup scripts
+
+    private var scriptsSection: some View {
+        TallyFormSection("Session setup scripts", detail: scriptsDetail) {
+            ForEach(scripts) { row in
+                TallyFormRow {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 8) {
+                            TextField("Name", text: scriptBinding(for: row, \.name))
+                                .font(.ui(11, weight: .medium))
+                                .foregroundStyle(Theme.signal)
+                                .textFieldStyle(.plain)
+                                .padding(.horizontal, 9)
+                                .padding(.vertical, 8)
+                                .background(Theme.screen)
+                                .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.never)
+
+                            let index = scripts.firstIndex(where: { $0.id == row.id }) ?? 0
+                            workingDirButton(
+                                "arrow.up",
+                                label: "Move script up",
+                                disabled: index == 0
+                            ) { moveScript(id: row.id, offset: -1) }
+                            workingDirButton(
+                                "arrow.down",
+                                label: "Move script down",
+                                disabled: index >= scripts.count - 1
+                            ) { moveScript(id: row.id, offset: 1) }
+                            workingDirButton("trash", label: "Delete script") {
+                                scripts.removeAll { $0.id == row.id }
+                            }
+                        }
+
+                        TextField(
+                            "source ~/.venv/bin/activate",
+                            text: scriptBinding(for: row, \.body),
+                            axis: .vertical
+                        )
+                        .lineLimit(2...6)
+                        .font(.mono(11))
+                        .foregroundStyle(Theme.signal)
+                        .textFieldStyle(.plain)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 8)
+                        .background(Theme.screen)
+                        .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .accessibilityLabel("Script commands")
+                    }
+                }
+            }
+
+            TallyFormRow {
+                ChassisChip("ADD SCRIPT", systemImage: "plus") {
+                    scripts.append(ScriptRow())
+                }
+            }
+        }
+    }
+
+    private var scriptsDetail: String {
+        scripts.isEmpty
+            ? "New Session can type a chosen script into the fresh shell before anything launches. Add one to make it available."
+            : "New Session offers these by name; the chosen one is typed into the fresh shell before the launch command."
+    }
+
+    /// Same late-write discipline as the working-dir rows: resolve through
+    /// the row id, never a captured array index.
+    private func scriptBinding(
+        for snapshot: ScriptRow, _ keyPath: WritableKeyPath<ScriptRow, String>
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                (scripts.first(where: { $0.id == snapshot.id }) ?? snapshot)[keyPath: keyPath]
+            },
+            set: { value in
+                guard let index = scripts.firstIndex(where: { $0.id == snapshot.id }) else {
+                    return
+                }
+                scripts[index][keyPath: keyPath] = value
+            }
+        )
+    }
+
+    private func moveScript(id: UUID, offset: Int) {
+        guard let source = scripts.firstIndex(where: { $0.id == id }) else { return }
+        let destination = source + offset
+        guard scripts.indices.contains(destination) else { return }
+        scripts.swapAt(source, destination)
+    }
+
     /// What gets saved: rows trimmed, emptied rows dropped, duplicates
     /// (possible now that rows are editable) collapsed to the first, and a
     /// directory typed but not yet added folded in — losing text sitting
@@ -512,6 +633,7 @@ struct AddHostSheet: View {
         moshServerPath = host.moshServerPath ?? ""
         moshPorts = host.moshPorts ?? ""
         workingDirs = host.workingDirs.map { WorkingDir(path: $0) }
+        scripts = host.sessionScripts.map(ScriptRow.init)
         password = KeychainStore.get(for: host.id, kind: .password) ?? ""
         privateKey = KeychainStore.get(for: host.id, kind: .privateKey) ?? ""
         passphrase = KeychainStore.get(for: host.id, kind: .keyPassphrase) ?? ""
@@ -538,6 +660,9 @@ struct AddHostSheet: View {
         let ports = moshPorts.trimmingCharacters(in: .whitespaces)
         host.moshPorts = ports.isEmpty ? nil : ports
         host.workingDirs = resolvedWorkingDirs
+        // Rows with nothing to type drop out; ids survive edits so the
+        // remembered-selection memory keeps pointing at the same script.
+        host.sessionScripts = SessionScript.normalized(scripts.map(\.script))
         return host
     }
 

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -191,13 +191,14 @@ struct FleetWall: View {
             NewSessionSheet(
                 host: host,
                 existingNames: hub.model(for: host).tmux.sessions.map(\.name),
-                create: { name, agent, initialPrompt, directory in
+                create: { name, agent, initialPrompt, directory, script in
                     createSession(
                         on: host,
                         named: name,
                         launching: agent,
                         initialPrompt: initialPrompt,
-                        startingIn: directory
+                        startingIn: directory,
+                        running: script
                     )
                 }
             )
@@ -1039,7 +1040,8 @@ struct FleetWall: View {
     /// the problem.
     private func createSession(
         on host: Host, named rawName: String, launching agent: AgentKind?,
-        initialPrompt: String, startingIn directory: String?
+        initialPrompt: String, startingIn directory: String?,
+        running script: SessionScript?
     ) {
         let name = TmuxProbe.sanitizedSessionName(rawName)
         let model = hub.model(for: host)
@@ -1048,6 +1050,7 @@ struct FleetWall: View {
                 base: name,
                 inDirectoryOf: nil,
                 startingIn: directory,
+                running: script?.normalizedBody,
                 typing: agent?.launchCommand(initialPrompt: initialPrompt)
             ) else { return }
             open(TerminalRoute(hostID: host.id, mode: .attach(sessionName: created)))
@@ -1102,12 +1105,14 @@ private struct SessionDropTarget: Equatable {
 /// -2, -3…) so Create is one tap; picking an agent re-prefills it unless
 /// the user already typed their own. Each agent can receive a one-shot first
 /// prompt as its CLI argument. An opt-in remembers only the submitted launch
-/// choice for the next sheet. Hosts with working directories also get a
-/// "Starts in" picker, defaulting to the first (the host's own default).
+/// and setup-script choices for the next sheet. Hosts with working
+/// directories also get a "Starts in" picker, defaulting to the first (the
+/// host's own default); hosts with setup scripts get a "Runs first" picker,
+/// defaulting to NONE unless one is remembered.
 private struct NewSessionSheet: View {
     let host: Host
     let existingNames: [String]
-    let create: (String, AgentKind?, String, String?) -> Void
+    let create: (String, AgentKind?, String, String?, SessionScript?) -> Void
 
     private let preferences: NewSessionPreferences
 
@@ -1117,12 +1122,13 @@ private struct NewSessionSheet: View {
     @State private var agent: AgentKind?
     @State private var initialPrompt: String
     @State private var directory: String?
+    @State private var script: SessionScript?
     @State private var remembersLastLaunch: Bool
 
     init(
         host: Host,
         existingNames: [String],
-        create: @escaping (String, AgentKind?, String, String?) -> Void,
+        create: @escaping (String, AgentKind?, String, String?, SessionScript?) -> Void,
         preferences: NewSessionPreferences = NewSessionPreferences()
     ) {
         self.host = host
@@ -1135,6 +1141,7 @@ private struct NewSessionSheet: View {
         _agent = State(initialValue: agent)
         _initialPrompt = State(initialValue: "")
         _directory = State(initialValue: host.workingDirs.first)
+        _script = State(initialValue: preferences.rememberedScript(for: host))
         _remembersLastLaunch = State(initialValue: remembersLastLaunch)
         _name = State(initialValue: TmuxProbe.uniqueSessionName(
             base: agent?.launchCommand ?? "main", existing: existingNames))
@@ -1208,6 +1215,33 @@ private struct NewSessionSheet: View {
                         }
                     }
 
+                    if !host.sessionScripts.isEmpty {
+                        TallyFormSection("Setup script", detail: scriptDetail) {
+                            TallyFormField("Runs first") {
+                                Menu {
+                                    ForEach(host.sessionScripts) { candidate in
+                                        Button(candidate.displayName) { script = candidate }
+                                    }
+                                    Divider()
+                                    Button("None") { script = nil }
+                                } label: {
+                                    HStack(spacing: 10) {
+                                        Text(script?.displayName ?? "None")
+                                            .lineLimit(1)
+                                        Spacer()
+                                        Image(systemName: "chevron.down")
+                                            .font(.ui(9, weight: .semibold))
+                                            .foregroundStyle(Theme.signal2)
+                                    }
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .chassisHover(2)
+                                .accessibilityLabel("Setup script")
+                            }
+                        }
+                    }
+
                     TallyFormSection("Directory", detail: directoryDetail) {
                         if host.workingDirs.isEmpty {
                             TallyFormRow {
@@ -1262,9 +1296,11 @@ private struct NewSessionSheet: View {
                     Button("Create & Attach") {
                         preferences.save(
                             remembersLastLaunch: remembersLastLaunch,
-                            agent: agent
+                            agent: agent,
+                            script: script,
+                            hostID: host.id
                         )
-                        create(name, agent, initialPrompt, directory)
+                        create(name, agent, initialPrompt, directory, script)
                         dismiss()
                     }
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
@@ -1302,10 +1338,20 @@ private struct NewSessionSheet: View {
     }
 
     private var launchDetail: String {
+        let remembers = host.sessionScripts.isEmpty
+            ? "REMEMBER saves only the launch choice."
+            : "REMEMBER saves the launch and setup-script choices."
         guard let agent else {
-            return "Creates the tmux session, then attaches to its login shell. REMEMBER saves only this launch choice."
+            return "Creates the tmux session, then attaches to its login shell. \(remembers)"
         }
-        return "Starts \(agent.displayName) in the fresh shell. The optional prompt becomes its first message; REMEMBER saves only the launch choice."
+        return "Starts \(agent.displayName) in the fresh shell. The optional prompt becomes its first message; \(remembers)"
+    }
+
+    private var scriptDetail: String {
+        guard let script else {
+            return "Nothing extra runs. A setup script is typed into the fresh shell before the launch."
+        }
+        return "Types \(script.displayName) into the fresh shell first, so the launch inherits what it sets up."
     }
 
     private var directoryDetail: String {
@@ -1697,7 +1743,7 @@ private enum FleetWallPreviewData {
     NewSessionSheet(
         host: FleetWallPreviewData.host,
         existingNames: ["main", "scratch"],
-        create: { _, _, _, _ in },
+        create: { _, _, _, _, _ in },
         preferences: NewSessionPreferences(
             defaults: UserDefaults(
                 suiteName: "app.multiplexterm.multiplex.preview.new-session"

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -443,7 +443,9 @@ struct TerminalWindowRoot: View {
     /// same host, same directory as its pane (an agent variant also types
     /// its launch command into the new shell) — and attach it as a new tab
     /// of this window. The session exists before the tab appears, so the
-    /// attach can't race it.
+    /// attach can't race it. The host's remembered setup script rides along
+    /// while the New Session sheet's REMEMBER opt-in is on — the quick path
+    /// inherits the choice made there, the way it inherits the pane's cwd.
     private func openNewTab(launching agent: AgentKind?) {
         guard !creatingTab,
               let activeTab,
@@ -453,11 +455,13 @@ struct TerminalWindowRoot: View {
         // A plain shell tab has no pane to inherit a directory from —
         // the new session starts in $HOME, named after the host's habit.
         let source = activeTab.sessionName
+        let script = NewSessionPreferences().rememberedScript(for: host)
         Task {
             defer { creatingTab = false }
             guard let name = await hub.model(for: host).createSession(
                 base: agent?.launchCommand ?? source ?? "main",
                 inDirectoryOf: source,
+                running: script?.normalizedBody,
                 typing: agent?.launchCommand
             ) else {
                 newTabFailedHost = host.name

--- a/MultiplexTests/NewSessionPreferencesTests.swift
+++ b/MultiplexTests/NewSessionPreferencesTests.swift
@@ -5,6 +5,12 @@ final class NewSessionPreferencesTests: XCTestCase {
     private var suiteName: String!
     private var defaults: UserDefaults!
 
+    private let script = SessionScript(name: "venv", body: "source .venv/bin/activate")
+    private lazy var host = Host(
+        name: "devbox", hostname: "devbox.example.com", username: "dev",
+        sessionScripts: [script]
+    )
+
     override func setUp() {
         super.setUp()
         suiteName = "NewSessionPreferencesTests.\(UUID().uuidString)"
@@ -24,12 +30,15 @@ final class NewSessionPreferencesTests: XCTestCase {
 
         XCTAssertFalse(preferences.remembersLastLaunch)
         XCTAssertNil(preferences.rememberedAgent)
+        XCTAssertNil(preferences.rememberedScript(for: host))
     }
 
     func testPersistsRememberedAgentAcrossInstances() {
         NewSessionPreferences(defaults: defaults).save(
             remembersLastLaunch: true,
-            agent: .codex
+            agent: .codex,
+            script: nil,
+            hostID: host.id
         )
 
         let reloaded = NewSessionPreferences(defaults: defaults)
@@ -40,7 +49,9 @@ final class NewSessionPreferencesTests: XCTestCase {
     func testPersistsRememberedPiAcrossInstances() {
         NewSessionPreferences(defaults: defaults).save(
             remembersLastLaunch: true,
-            agent: .pi
+            agent: .pi,
+            script: nil,
+            hostID: host.id
         )
 
         let reloaded = NewSessionPreferences(defaults: defaults)
@@ -50,19 +61,70 @@ final class NewSessionPreferencesTests: XCTestCase {
 
     func testCanRememberShellOnly() {
         let preferences = NewSessionPreferences(defaults: defaults)
-        preferences.save(remembersLastLaunch: true, agent: nil)
+        preferences.save(
+            remembersLastLaunch: true, agent: nil, script: nil, hostID: host.id
+        )
 
         XCTAssertTrue(preferences.remembersLastLaunch)
         XCTAssertNil(preferences.rememberedAgent)
+        XCTAssertNil(preferences.rememberedScript(for: host))
     }
 
     func testDisablingClearsStaleAgent() {
         let preferences = NewSessionPreferences(defaults: defaults)
-        preferences.save(remembersLastLaunch: true, agent: .claudeCode)
-        preferences.save(remembersLastLaunch: false, agent: .claudeCode)
+        preferences.save(
+            remembersLastLaunch: true, agent: .claudeCode,
+            script: script, hostID: host.id
+        )
+        preferences.save(
+            remembersLastLaunch: false, agent: .claudeCode,
+            script: script, hostID: host.id
+        )
 
         XCTAssertFalse(preferences.remembersLastLaunch)
         XCTAssertNil(preferences.rememberedAgent)
         XCTAssertNil(defaults.string(forKey: "newSession.lastAgent"))
+        XCTAssertNil(preferences.rememberedScript(for: host))
+        // The whole per-host map goes, not just this host's entry.
+        XCTAssertNil(defaults.dictionary(forKey: "newSession.lastScripts"))
+    }
+
+    func testRemembersScriptPerHost() {
+        let otherHost = Host(
+            name: "prod", hostname: "prod.example.com", username: "dev",
+            sessionScripts: [SessionScript(name: "warm caches", body: "make warm")]
+        )
+        let preferences = NewSessionPreferences(defaults: defaults)
+        preferences.save(
+            remembersLastLaunch: true, agent: nil, script: script, hostID: host.id
+        )
+
+        let reloaded = NewSessionPreferences(defaults: defaults)
+        XCTAssertEqual(reloaded.rememberedScript(for: host)?.id, script.id)
+        // Script ids are host-scoped; another host has no memory.
+        XCTAssertNil(reloaded.rememberedScript(for: otherHost))
+    }
+
+    func testRememberingNoneClearsTheHostEntry() {
+        let preferences = NewSessionPreferences(defaults: defaults)
+        preferences.save(
+            remembersLastLaunch: true, agent: nil, script: script, hostID: host.id
+        )
+        preferences.save(
+            remembersLastLaunch: true, agent: nil, script: nil, hostID: host.id
+        )
+
+        XCTAssertNil(preferences.rememberedScript(for: host))
+    }
+
+    func testDeletedScriptFailsSoftToNone() {
+        let preferences = NewSessionPreferences(defaults: defaults)
+        preferences.save(
+            remembersLastLaunch: true, agent: nil, script: script, hostID: host.id
+        )
+
+        var edited = host
+        edited.sessionScripts = []
+        XCTAssertNil(preferences.rememberedScript(for: edited))
     }
 }

--- a/MultiplexTests/SessionScriptTests.swift
+++ b/MultiplexTests/SessionScriptTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import Multiplex
+
+final class SessionScriptTests: XCTestCase {
+    func testNormalizedBodyStripsControlsKeepsNewlinesAndTabs() {
+        let script = SessionScript(
+            name: "setup",
+            body: "  export A=1\r\n\tnvm use 20\u{02}\u{1B}\rsource .env  \n"
+        )
+        // CRLF/CR normalize, tabs and interior newlines survive, invisible
+        // controls (including tmux's Ctrl-B, 0x02) are removed, and only the
+        // outside is trimmed.
+        XCTAssertEqual(script.normalizedBody, "export A=1\n\tnvm use 20\nsource .env")
+    }
+
+    func testDisplayNamePrefersTrimmedName() {
+        let script = SessionScript(name: "  venv  ", body: "source .venv/bin/activate")
+        XCTAssertEqual(script.displayName, "venv")
+    }
+
+    func testDisplayNameFallsBackToTruncatedFirstLine() {
+        let script = SessionScript(
+            name: "  ",
+            body: "source \t .venv/bin/activate && export PATH=$HOME/.local/bin:$PATH\necho ready"
+        )
+        // First line only, whitespace collapsed, truncated with an ellipsis.
+        XCTAssertEqual(
+            script.displayName,
+            "source .venv/bin/activate && export…"
+        )
+
+        let short = SessionScript(name: "", body: "nvm use 20")
+        XCTAssertEqual(short.displayName, "nvm use 20")
+
+        let empty = SessionScript(name: "", body: "")
+        XCTAssertEqual(empty.displayName, "Script")
+    }
+
+    func testNormalizedDropsBodylessRowsAndKeepsIDs() {
+        let keep = SessionScript(name: "keep", body: "  make dev  ")
+        let nameOnly = SessionScript(name: "named but empty", body: "   ")
+        let duplicateID = SessionScript(id: keep.id, name: "dupe", body: "echo hi")
+
+        let normalized = SessionScript.normalized([keep, nameOnly, duplicateID])
+
+        // A script with nothing to type is not a script, whatever its name;
+        // ids stay unique and are never reminted (the remembered-selection
+        // memory points at them).
+        XCTAssertEqual(normalized.map(\.id), [keep.id])
+        XCTAssertEqual(normalized.first?.body, "make dev")
+    }
+
+    func testDecodeToleratesMissingFieldsAndLegacyHostRecords() throws {
+        // A record from a peer running a different schema must not drop the
+        // host list: every script field is optional on decode.
+        let bare = try JSONDecoder().decode(SessionScript.self, from: Data("{}".utf8))
+        XCTAssertEqual(bare.name, "")
+        XCTAssertEqual(bare.body, "")
+
+        let legacyHost = Data(
+            #"{"name": "devbox", "hostname": "devbox.example.com", "username": "dev"}"#.utf8
+        )
+        let host = try JSONDecoder().decode(Host.self, from: legacyHost)
+        XCTAssertEqual(host.sessionScripts, [])
+    }
+
+    func testHostRoundTripsScriptsAndNormalizesOnDecode() throws {
+        var host = Host(name: "devbox", hostname: "devbox.example.com", username: "dev")
+        host.sessionScripts = [
+            SessionScript(name: "venv", body: "source .venv/bin/activate"),
+            SessionScript(name: "ghost", body: "   "),
+        ]
+
+        let decoded = try JSONDecoder().decode(
+            Host.self, from: JSONEncoder().encode(host)
+        )
+
+        // The bodyless row written by this (hypothetically buggy) encoder
+        // pass is dropped by the decode-side normalization.
+        XCTAssertEqual(decoded.sessionScripts.map(\.name), ["venv"])
+        XCTAssertEqual(decoded.sessionScripts, [host.sessionScripts[0]])
+    }
+
+    func testScriptEditsDoNotChangeConnectionModelIdentity() {
+        var host = Host(name: "devbox", hostname: "devbox.example.com", username: "dev")
+        var edited = host
+        edited.sessionScripts = [SessionScript(name: "venv", body: "source .venv/bin/activate")]
+        host.updatedAt = .now
+
+        // Adding or editing scripts must not tear down the probe connection.
+        XCTAssertTrue(host.hasSameConnectionModelConfiguration(as: edited))
+    }
+}

--- a/MultiplexTests/TmuxProbeTests.swift
+++ b/MultiplexTests/TmuxProbeTests.swift
@@ -399,6 +399,29 @@ final class TmuxProbeTests: XCTestCase {
         XCTAssertTrue(command.contains("tmux send-keys -t \"${i%% *}\" Enter"))
     }
 
+    func testNewSessionCommandTypesSetupScriptBeforeLaunch() {
+        let command = TmuxProbe.newSessionCommand(
+            name: "claude", sourceSessionName: nil,
+            script: "source .venv/bin/activate\nexport A=1", launch: "claude")
+        // The script types first — same shell, so what it exports/activates
+        // is live for the launch line — and typing is sequential, never
+        // gated on the script's exit status. Interior newlines ride inside
+        // the one literal send-keys argument.
+        XCTAssertTrue(command.contains(
+            "tmux send-keys -t \"${i%% *}\" -l -- 'source .venv/bin/activate\nexport A=1'; "
+                + "tmux send-keys -t \"${i%% *}\" Enter; "
+                + "tmux send-keys -t \"${i%% *}\" -l -- 'claude'"))
+    }
+
+    func testNewSessionCommandTypesSetupScriptForPlainShellSessions() {
+        let command = TmuxProbe.newSessionCommand(
+            name: "main", sourceSessionName: nil, script: "nvm use 20", launch: nil)
+        XCTAssertTrue(command.contains(
+            "tmux send-keys -t \"${i%% *}\" -l -- 'nvm use 20'; "
+                + "tmux send-keys -t \"${i%% *}\" Enter"))
+        XCTAssertTrue(command.contains("MULTIPLEX_NEW"))
+    }
+
     func testNewSessionCommandWithoutSourceOrLaunch() {
         let command = TmuxProbe.newSessionCommand(
             name: "main", sourceSessionName: nil, launch: nil)


### PR DESCRIPTION
## What

Hosts can define named **setup scripts** (Host Settings → *Session setup scripts*, below working dirs — sortable, reorder/delete/add). When a new session is created, the chosen script is typed into the fresh shell **before** the optional agent launch line — same shell, so its exports/activations (nvm, virtualenvs, sourced secrets) are live for whatever runs next.

- **One hook point**: creation only, shell-only sessions included; attaching to an existing session never types anything. The legacy restored `.create` route is untouched (nothing rides on `TerminalRoute`).
- **Sequential, never gated**: a failing script leaves its error visible above a launch that still runs. Multi-line bodies ride one `send-keys -l` literal; the custom-command sanitize applies (controls stripped, interior newlines/tabs kept). Known, documented footgun: a script that reads stdin consumes the launch line.
- **Selection, not policy**: list order is presentation only — a script never runs merely because it exists or sits first. The New Session sheet picks one via the Starts-in Menu grammar (`TallyChoiceBar` is fixed equal-width segments; user lists are unbounded).
- **One REMEMBER opt-in** now also stores the script choice per host (`NewSessionPreferences`, device-local host-UUID → script-id map; deleted ids fail soft to NONE). While it's on, the pickerless creation paths — **+ TAB** and the **widget/Shortcuts router** — inherit the remembered script the way + TAB inherits the pane cwd.
- **Storage**: scripts ride the synced `Host` record (Keychain mirror, `updatedAt` bump), are zeroed out of `connectionModelConfiguration` so edits don't drop the probe connection, and never enter the widget projection. Script ids are load-bearing, so the editor preserves them across edits (UUID-resolved bindings, per the Command Setup crash lesson).
- **Free tier** — host plumbing, not an agent-helper surface; no store-metadata changes.

## Verification

- 414 unit tests pass (new: `SessionScriptTests`, script variants in `TmuxProbeTests`, per-host memory in `NewSessionPreferencesTests`); visionOS + iPad builds green.
- **End-to-end against the dev harness**: seeded `devbox` with a two-line script (`export MPX_SETUP=proven` / `echo SETUP-RAN`), armed REMEMBER, fired the `debug.newtab` hook. The + TAB session ran both lines before the prompt settled, and a subsequently typed `echo "inherit=$MPX_SETUP"` printed `inherit=proven` — the env an agent launch would inherit. The deck tile showed the script output in its live miniature.
- The DEBUG seed (`MULTIPLEX_SEED_HOST`) now accepts a `sessionScripts` array so these paths stay headlessly checkable.

One thing not screenshot-verified: the Host Settings scripts section sits below the fold of the visionOS sheet, which headless capture can't scroll — it's the same components as the working-dirs section above it; worth a one-second eyeball.