### PR TITLE
Document the apex landing domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1091,9 +1091,8 @@ The **landing site** (the listing's marketing URL + the privacy policy) is
 part of the same claim surface but lives in its own repo, **multiplex-home**
 (`github.com/jhen0409/multiplex-home` — Astro on Cloudflare Workers; deploys
 are manual `npm run deploy`, decoupled from git). It serves
-`preview.multiplexterm.dev` today; the apex `multiplexterm.dev` is reserved
-for the release cutover (a one-line route change in its `wrangler.json`).
-Landing changes go through PRs, never straight to a default branch. When
+`multiplexterm.dev`; `preview.multiplexterm.dev` remains routed to the same
+Worker. Landing changes go through PRs, never straight to a default branch. When
 features, pricing, platforms, or privacy behavior change, update that site in
 the same change as the metadata above. The design bake-off record and the
 unchosen candidates stay here under `docs/landing/`.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ lamp when it's attached — before you ever attach.
 that produced it: [docs/design-bakeoff.md](docs/design-bakeoff.md). The
 product site — the App Store listing's marketing URL and privacy policy — is
 maintained in [multiplex-home](https://github.com/jhen0409/multiplex-home)
-and served at [preview.multiplexterm.dev](https://preview.multiplexterm.dev)
-until release (final home: multiplexterm.dev); its own design bake-off is
-recorded in [docs/landing/](docs/landing/).*
+and served at [multiplexterm.dev](https://multiplexterm.dev), with
+[preview.multiplexterm.dev](https://preview.multiplexterm.dev) retained as an
+alternate endpoint; its own design bake-off is recorded in
+[docs/landing/](docs/landing/).*
 
 ![The deck: a live monitor wall of tmux sessions](docs/visionos-deck.png)
 


### PR DESCRIPTION
## Summary
- point the README at `multiplexterm.dev` as the primary landing site
- document that the preview subdomain remains available

## Verification
- documentation-only change