### PR TITLE
visionOS: merge the key cluster into the UMD console row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,23 +474,34 @@ views.
   `TerminalKeyCluster` — ESC / latching CTRL / TAB, the DECCKM-aware
   autorepeat arrows, RET, and the keyboard toggle (first responder is the
   visibility authority on visionOS, which posts no keyboard show/hide
-  notifications) — is a chassis slab
-  stacked directly below the UMD row in the terminal window's bottom
-  ornament, riding the same send path and latch mechanism. That ornament
+  notifications) — flanks the UMD row on ONE console line in the terminal
+  window's bottom ornament (ESC/CTRL/TAB slab left, navigation-key slab
+  right, both matching the UMD's 44 pt height), riding the same send path
+  and latch mechanism; one cluster instance owns the latch state and the
+  DEBUG proof hook in both layouts. The row stays ONE line at every width:
+  ViewThatFits compacts the key faces first (tiers engage because the
+  window clamps the ornament content's width), and when even compact
+  cannot fit, a `fixedSize` floor keeps the row at its ideal width and
+  lets it overflow the window edges symmetrically — the shipped unclamped
+  UMD's own narrow-window behavior. Never re-add a keys-under-UMD
+  restack fallback and never let the UMD compress: the system CLIPS
+  ornament content hanging far below the anchor at compact window widths
+  (a restacked key row rendered as an unusable sliver), and a squeezed
+  UMD truncates its title (both simulator-verified 2026-07). The ornament
   is positioned by an `alignmentGuide(VerticalAlignment.center)` override
   with state-dependent constants (40 with an agent strip, 24 without):
-  with an agent detected the strip/UMD boundary sits on the anchor, so the
-  agent bar rides ON the tmux status row just inside the window edge —
-  the store-capture geometry (fastlane/…/visionos-09-keys.png) — with the
-  UMD and key rows hanging below; without one the UMD straddles the edge.
-  Neither plain anchor works: a true centered stack rises as it grows and
-  lifted the agent bar off the edge onto the screen content, and a
-  below-edge anchor (`contentAlignment: .top`) parked the keys and the
+  with an agent detected the strip/console-row boundary sits on the
+  anchor, so the agent bar rides ON the tmux status row just inside the
+  window edge — the store-capture geometry
+  (fastlane/…/visionos-09-keys.png, which predates the one-line merge) —
+  with the console row hanging below; without one that row straddles the
+  edge. Neither plain anchor works: a true centered stack rises as it
+  grows and lifted the agent bar off the edge onto the screen content, and
+  a below-edge anchor (`contentAlignment: .top`) parked the keys and the
   window bar exactly where the floating keyboard summons (both
-  user-reported; re-verify against that capture when touching the
-  constants). DECK and the text-size chips live in the UMD title row
-  (the keyboard toggle stays on the key cluster), so neither bottom row
-  runs long. ⚠ SwiftTerm still *builds* its stock accessory on visionOS, and
+  user-reported; re-verify visually when touching the constants). DECK and
+  the text-size chips live in the UMD title row (every key stays the
+  cluster's), so the title row never grows its own keys. ⚠ SwiftTerm still *builds* its stock accessory on visionOS, and
   `commitTextInput` prefers that (invisible) accessory's `controlModifier`
   over the view-level one — `SwiftTermView` nils `inputAccessoryView` there
   so the cluster's latch is authoritative; don't remove that.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,7 +478,7 @@ views.
   stacked directly below the UMD row in the terminal window's bottom
   ornament, riding the same send path and latch mechanism. That ornament
   is positioned by an `alignmentGuide(VerticalAlignment.center)` override
-  with state-dependent constants (48 with an agent strip, 24 without):
+  with state-dependent constants (40 with an agent strip, 24 without):
   with an agent detected the strip/UMD boundary sits on the anchor, so the
   agent bar rides ON the tmux status row just inside the window edge —
   the store-capture geometry (fastlane/…/visionos-09-keys.png) — with the

--- a/Multiplex/Views/Terminal/AgentHelperStrip.swift
+++ b/Multiplex/Views/Terminal/AgentHelperStrip.swift
@@ -64,9 +64,11 @@ struct AgentHelperStrip: View {
     var body: some View {
         Group {
             if floating {
+                // Chips keep their 22 pt faces; the slab hugs them so the
+                // ornament stack stays low over the tmux status row.
                 row
                     .padding(.horizontal, 16)
-                    .padding(.vertical, 9)
+                    .padding(.vertical, 5)
                     .frame(maxWidth: floatingMaximumWidth ?? 760)
                     .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                     .overlay(

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -642,41 +642,45 @@ import notify
 #endif
 
 /// The visionOS terminal's key cluster — ESC, a latching CTRL, TAB, the
-/// DECCKM-aware autorepeat arrows, RET, and the keyboard toggle on a chassis
-/// slab in the window's bottom ornament. The floating visionOS keyboard has
+/// DECCKM-aware autorepeat arrows, RET, and the keyboard toggle as chassis
+/// slabs in the window's bottom ornament. The floating visionOS keyboard has
 /// none of these keys and SwiftTerm plumbs no input accessory on visionOS,
 /// so the window's chrome carries them instead; arrows + RET are how a CLI
 /// agent's option picker is driven without summoning the keyboard at all.
+///
+/// Two layouts, one instance either way (the latch state and the DEBUG
+/// proof hook must have a single owner per window): standalone, the
+/// original single slab (the shell overlay's key row), or flanking a
+/// `center` row — the classic window's UMD — with ESC/CTRL/TAB on its left
+/// and the navigation keys on its right, so the ornament spends one console
+/// line on keys and window controls together.
 ///
 /// Same guarantees as the iPad key rail: every key sends through
 /// `TerminalView.send` → the view delegate → the controller's ordered input
 /// pump, and CTRL rides SwiftTerm's `controlModifier`, consumed by the next
 /// character the keyboard types — the cluster observes the reset
 /// notification to release the latch visual.
-struct TerminalKeyCluster: View {
+struct TerminalKeyCluster<Center: View>: View {
     var controller: TerminalSessionController?
+
+    /// The row the keys flank (the classic window's UMD); nil renders the
+    /// original standalone slab.
+    private let center: Center?
 
     @State private var ctrlLatched = false
 
     private var terminal: TerminalView? { controller?.terminalView }
 
+    init(
+        controller: TerminalSessionController?,
+        @ViewBuilder center: () -> Center
+    ) {
+        self.controller = controller
+        self.center = center()
+    }
+
     var body: some View {
-        // Ornaments propose unbounded width, so a classic window always gets
-        // the regular tier; the tiers exist for the (debug-forced) shell,
-        // whose pane can be phone-narrow. Faces compact before any key
-        // leaves the cluster; the floor keeps the original trio plus RET
-        // and the keyboard toggle — the window's only keyboard control.
-        ViewThatFits(in: .horizontal) {
-            row(.regular)
-            row(.compact)
-            row(.compact, minimal: true)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Theme.bezelHi, lineWidth: 1))
+        layout
         // SwiftTerm consumes the modifier on the next typed character.
         .onReceive(NotificationCenter.default.publisher(
             for: .terminalViewControlModifierReset
@@ -700,56 +704,149 @@ struct TerminalKeyCluster: View {
         #endif
     }
 
-    private struct Metric {
-        let keyWidth: CGFloat
-        let spacing: CGFloat
-        let groupGap: CGFloat
+    private typealias Metric = KeyClusterMetric
 
-        static let regular = Metric(keyWidth: 46, spacing: 6, groupGap: 12)
-        static let compact = Metric(keyWidth: 36, spacing: 4, groupGap: 8)
+    @ViewBuilder
+    private var layout: some View {
+        if let center {
+            // One console row at EVERY width: key faces compact first, and
+            // when even compact overflows the caller's clamp the row keeps
+            // its ideal width and spills past the window edges symmetrically
+            // — the shipped unclamped UMD's own narrow-window behavior.
+            // ViewThatFits compares each tier's IDEAL width against the
+            // proposal, so the fixedSize floor is only reached when compact
+            // genuinely cannot fit; without fixedSize the last tier would
+            // instead compress the UMD (title truncated to "AGEN…").
+            // A restacked keys-under-UMD fallback was tried and rejected:
+            // ornament content hanging ~100 pt below the anchor is clipped
+            // by the system at compact window widths — the key row rendered
+            // as an unusable sliver (2026-07, simulator-verified).
+            ViewThatFits(in: .horizontal) {
+                consoleRow(center, metric: .regular)
+                consoleRow(center, metric: .compact)
+                consoleRow(center, metric: .compact)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+        } else {
+            standaloneSlab
+        }
+    }
+
+    /// ESC/CTRL/TAB ride one slab left of the center row, the navigation
+    /// keys another on its right. Slab padding (9) around the 26 pt key
+    /// faces matches the UMD's height, so the three slabs read as one
+    /// console line.
+    private func consoleRow(_ center: Center, metric: Metric) -> some View {
+        HStack(spacing: 10) {
+            slab {
+                HStack(spacing: metric.spacing) {
+                    escKey(metric)
+                    ctrlKey(metric)
+                    tabKey(metric)
+                }
+            }
+            center
+            slab {
+                HStack(spacing: metric.groupGap) {
+                    arrowGroup(metric)
+                    retKey(metric)
+                    keyboardToggleKey(metric)
+                }
+            }
+        }
+    }
+
+    private var standaloneSlab: some View {
+        slab {
+            // Ornaments propose unbounded width, so a classic window always
+            // gets the regular tier; the tiers exist for the (debug-forced)
+            // shell, whose pane can be phone-narrow. Faces compact before
+            // any key leaves the cluster; the floor keeps the original trio
+            // plus RET and the keyboard toggle — the window's only keyboard
+            // control.
+            ViewThatFits(in: .horizontal) {
+                row(.regular)
+                row(.compact)
+                row(.compact, minimal: true)
+            }
+        }
+    }
+
+    private func slab(@ViewBuilder _ content: () -> some View) -> some View {
+        content()
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(Theme.bezelHi, lineWidth: 1))
     }
 
     private func row(_ metric: Metric, minimal: Bool = false) -> some View {
         HStack(spacing: metric.groupGap) {
             HStack(spacing: metric.spacing) {
-                capsKey("ESC", "Escape", metric: metric) {
-                    $0.send(EscapeSequences.cmdEsc)
-                }
-                capsKey("CTRL", "Control", latched: ctrlLatched, metric: metric) { terminal in
-                    let latched = !terminal.controlModifier
-                    terminal.controlModifier = latched
-                    ctrlLatched = latched
-                }
-                capsKey("TAB", "Tab", metric: metric) { $0.send([0x09]) }
+                escKey(metric)
+                ctrlKey(metric)
+                tabKey(metric)
             }
             if !minimal {
-                HStack(spacing: metric.spacing) {
-                    arrowKey(
-                        "arrow.left", "Arrow left", metric: metric,
-                        app: EscapeSequences.moveLeftApp,
-                        normal: EscapeSequences.moveLeftNormal)
-                    arrowKey(
-                        "arrow.up", "Arrow up", metric: metric,
-                        app: EscapeSequences.moveUpApp,
-                        normal: EscapeSequences.moveUpNormal)
-                    arrowKey(
-                        "arrow.down", "Arrow down", metric: metric,
-                        app: EscapeSequences.moveDownApp,
-                        normal: EscapeSequences.moveDownNormal)
-                    arrowKey(
-                        "arrow.right", "Arrow right", metric: metric,
-                        app: EscapeSequences.moveRightApp,
-                        normal: EscapeSequences.moveRightNormal)
-                }
+                arrowGroup(metric)
             }
-            capsKey("RET", "Return", metric: metric) { $0.send([0x0D]) }
-            TerminalClusterKey(
-                face: .icon("keyboard"),
-                accessibility: "Show or hide keyboard",
-                width: metric.keyWidth,
-                action: { controller?.toggleKeyboard() }
-            )
+            retKey(metric)
+            keyboardToggleKey(metric)
         }
+    }
+
+    private func escKey(_ metric: Metric) -> some View {
+        capsKey("ESC", "Escape", metric: metric) {
+            $0.send(EscapeSequences.cmdEsc)
+        }
+    }
+
+    private func ctrlKey(_ metric: Metric) -> some View {
+        capsKey("CTRL", "Control", latched: ctrlLatched, metric: metric) { terminal in
+            let latched = !terminal.controlModifier
+            terminal.controlModifier = latched
+            ctrlLatched = latched
+        }
+    }
+
+    private func tabKey(_ metric: Metric) -> some View {
+        capsKey("TAB", "Tab", metric: metric) { $0.send([0x09]) }
+    }
+
+    private func arrowGroup(_ metric: Metric) -> some View {
+        HStack(spacing: metric.spacing) {
+            arrowKey(
+                "arrow.left", "Arrow left", metric: metric,
+                app: EscapeSequences.moveLeftApp,
+                normal: EscapeSequences.moveLeftNormal)
+            arrowKey(
+                "arrow.up", "Arrow up", metric: metric,
+                app: EscapeSequences.moveUpApp,
+                normal: EscapeSequences.moveUpNormal)
+            arrowKey(
+                "arrow.down", "Arrow down", metric: metric,
+                app: EscapeSequences.moveDownApp,
+                normal: EscapeSequences.moveDownNormal)
+            arrowKey(
+                "arrow.right", "Arrow right", metric: metric,
+                app: EscapeSequences.moveRightApp,
+                normal: EscapeSequences.moveRightNormal)
+        }
+    }
+
+    private func retKey(_ metric: Metric) -> some View {
+        capsKey("RET", "Return", metric: metric) { $0.send([0x0D]) }
+    }
+
+    private func keyboardToggleKey(_ metric: Metric) -> some View {
+        TerminalClusterKey(
+            face: .icon("keyboard"),
+            accessibility: "Show or hide keyboard",
+            width: metric.keyWidth,
+            action: { controller?.toggleKeyboard() }
+        )
     }
 
     #if DEBUG
@@ -798,6 +895,25 @@ struct TerminalKeyCluster: View {
             guard let terminal else { return }
             terminal.send(terminal.getTerminal().applicationCursor ? app : normal)
         }
+    }
+}
+
+/// Key sizing tiers, hoisted out of the generic cluster (generic types
+/// cannot hold static stored properties).
+private struct KeyClusterMetric {
+    let keyWidth: CGFloat
+    let spacing: CGFloat
+    let groupGap: CGFloat
+
+    static let regular = KeyClusterMetric(keyWidth: 46, spacing: 6, groupGap: 12)
+    static let compact = KeyClusterMetric(keyWidth: 36, spacing: 4, groupGap: 8)
+}
+
+/// The standalone slab — the shell overlay's key row, with no UMD to flank.
+extension TerminalKeyCluster where Center == EmptyView {
+    init(controller: TerminalSessionController?) {
+        self.controller = controller
+        self.center = nil
     }
 }
 

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -597,36 +597,53 @@ struct TerminalWindowRoot: View {
                                 )
                             )
                         )
-                        UMDBar(
-                            controller: activeController,
-                            title: umdTitle,
-                            mergeSources: mergeSources,
-                            showDeck: showDeck,
-                            fontDown: { fontSize = max(9, fontSize - 1) },
-                            fontUp: { fontSize = min(32, fontSize + 1) },
-                            newSession: { openNewTab(launching: $0) },
-                            merge: { merge($0) },
-                            detach: { detachActiveTab() },
-                            closeSession: activeTabHasSession
-                                ? { confirmingCloseActiveSession = true } : nil,
-                            keychainTip: activeTabKeychainNotice != nil
-                                ? { presentKeychainTip() } : nil,
-                            showsTmuxShortcuts: activeTab?.sessionName != nil
-                        )
                         // The floating visionOS keyboard has no ESC/CTRL/TAB,
                         // arrows, or RET; the chrome carries them (same send
-                        // path as typing) plus the keyboard toggle.
-                        TerminalKeyCluster(controller: activeController)
+                        // path as typing) plus the keyboard toggle. The keys
+                        // flank the UMD on one console row — ESC/CTRL/TAB
+                        // left, navigation keys right. The width clamp is
+                        // what lets its ViewThatFits compact the key faces —
+                        // and it must be OrnamentWidthClamp, never
+                        // `.frame(maxWidth:)`: an ornament clips to its
+                        // REPORTED bounds, and a frame caps the report, so
+                        // the too-narrow floor tier rendered with both key
+                        // slabs and DECK sliced off at the window edges.
+                        OrnamentWidthClamp(
+                            maxWidth: max(1, geometry.size.width - 24)
+                        ) {
+                            TerminalKeyCluster(controller: activeController) {
+                                UMDBar(
+                                    controller: activeController,
+                                    title: umdTitle,
+                                    mergeSources: mergeSources,
+                                    showDeck: showDeck,
+                                    fontDown: { fontSize = max(9, fontSize - 1) },
+                                    fontUp: { fontSize = min(32, fontSize + 1) },
+                                    newSession: { openNewTab(launching: $0) },
+                                    merge: { merge($0) },
+                                    detach: { detachActiveTab() },
+                                    closeSession: activeTabHasSession
+                                        ? { confirmingCloseActiveSession = true } : nil,
+                                    keychainTip: activeTabKeychainNotice != nil
+                                        ? { presentKeychainTip() } : nil,
+                                    showsTmuxShortcuts: activeTab?.sessionName != nil
+                                )
+                            }
+                        }
                     }
                     // "Center" resolves through this guide. With an agent
-                    // detected, the strip/UMD boundary sits on the anchor:
-                    // the agent bar rides ON the status row just inside the
-                    // window edge — the store-capture geometry
-                    // (fastlane/…/visionos-09-keys.png) — and the session
-                    // rows hang below. Without one, the UMD straddles the
-                    // edge. Constants are empirical against the system's
-                    // ornament standoff; re-verify against that capture
-                    // when touching them.
+                    // detected, the strip/console-row boundary sits on the
+                    // anchor: the agent bar rides ON the status row just
+                    // inside the window edge — the store-capture geometry
+                    // (fastlane/…/visionos-09-keys.png, pre-merge rows) —
+                    // and the console row (keys flanking the UMD) hangs
+                    // below. Without one, that row straddles the edge.
+                    // Empirical against the system's ornament standoff;
+                    // re-verify visually when touching them. Content must
+                    // never hang much deeper than this row does: the system
+                    // clips ornament content far below the anchor at
+                    // compact window widths (a third stacked row rendered
+                    // as a sliver).
                     .alignmentGuide(VerticalAlignment.center) { _ in
                         showsAgentHelper ? 40 : 24
                     }
@@ -1437,6 +1454,45 @@ private struct HistoryNoticePill: View {
         .accessibilityElement(children: .combine)
     }
 }
+
+#if os(visionOS)
+/// Proposes at most `maxWidth` to its content but reports the content's
+/// ACTUAL size. An ornament clips to its reported bounds, so the ordinary
+/// `.frame(maxWidth:)` — which caps the report — sliced the console row's
+/// key slabs off at the window edges whenever the fixedSize floor tier
+/// overflowed the clamp. This keeps the clamp's tier-driving proposal
+/// (bounded even when the ornament proposes nothing) while letting the
+/// ornament grow to whatever the chosen tier really needs.
+private struct OrnamentWidthClamp: Layout {
+    var maxWidth: CGFloat
+
+    private func clamped(_ proposal: ProposedViewSize) -> ProposedViewSize {
+        ProposedViewSize(
+            width: min(proposal.width ?? maxWidth, maxWidth),
+            height: proposal.height
+        )
+    }
+
+    func sizeThatFits(
+        proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+    ) -> CGSize {
+        guard let content = subviews.first else { return .zero }
+        return content.sizeThatFits(clamped(proposal))
+    }
+
+    func placeSubviews(
+        in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews,
+        cache: inout ()
+    ) {
+        guard let content = subviews.first else { return }
+        content.place(
+            at: CGPoint(x: bounds.midX, y: bounds.midY),
+            anchor: .center,
+            proposal: clamped(proposal)
+        )
+    }
+}
+#endif
 
 #if DEBUG
 #Preview("Copy mode bar") {

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -628,7 +628,7 @@ struct TerminalWindowRoot: View {
                     // ornament standoff; re-verify against that capture
                     // when touching them.
                     .alignmentGuide(VerticalAlignment.center) { _ in
-                        showsAgentHelper ? 48 : 24
+                        showsAgentHelper ? 40 : 24
                     }
                 }
         }

--- a/Multiplex/Views/Terminal/UMDBar.swift
+++ b/Multiplex/Views/Terminal/UMDBar.swift
@@ -6,9 +6,9 @@ import SwiftUI
 struct UMDBar: View {
     enum Style {
         /// The visionOS classic window's title row: DECK, source label,
-        /// text size, and the session controls. The keyboard toggle lives
-        /// on the key cluster below, which keeps this row short enough to
-        /// stack under the monitor.
+        /// text size, and the session controls. The key cluster flanks it
+        /// on the same console row (every key stays TerminalKeyCluster's;
+        /// this row never grows its own).
         case regular
         /// The single-window shell's slim full-width row — it keeps DECK
         /// and the font chips because the shell has no other chrome; the


### PR DESCRIPTION
## What

The classic terminal window's bottom ornament spent three rows (agent strip / UMD / key cluster). `TerminalKeyCluster` now flanks the UMD on **one console line** — ESC/CTRL/TAB slab left, arrows/RET/keyboard-toggle slab right, all slabs sharing the UMD's 44 pt height — so the ornament is two rows with an agent detected and one without. The shell overlay keeps the standalone slab through a `Center == EmptyView` convenience init, and one cluster instance owns the CTRL latch state and the `debug.keycluster` proof hook in both layouts.

## Width behavior

One line at every window width:
- `ViewThatFits` picks regular key faces when they fit, compact next.
- A `fixedSize` floor then keeps the row at its ideal width, overflowing the window edges symmetrically — the same narrow-window behavior the shipped unclamped UMD already had.
- The tier-driving clamp is `OrnamentWidthClamp`, a custom `Layout` that proposes at most the window width but **reports the content's actual size**. An ornament clips to its *reported* bounds, so a plain `.frame(maxWidth:)` sliced both key slabs off at the window edges whenever the floor tier overflowed (user-reported at compact widths).

Two rejected fallbacks are recorded in AGENTS.md so they don't come back:
- Restacking the keys beneath the UMD: the system clips ornament content that hangs far below the anchor at compact window widths — the key row rendered as an unusable sliver.
- Letting the last tier compress: the UMD title truncated ("AGEN…").

## Verification (visionOS simulator + dev-sshd harness)

- 560 / 700 / 1120 / 1400 pt windows, with and without a detected agent: full row renders at each width, agent strip still rides the tmux status row (guide 40), no-agent row straddles the edge (guide 24).
- `debug.keycluster` proof: ESC/TAB/latched CTRL+`c` delivered through the ordered pump (the `^C` SIGINT'd the harness pane's `cat`).
- iPad build unaffected (all changes `#if os(visionOS)` except a UMDBar doc comment).

## Note

`fastlane/…/visionos-09-keys.png` (store capture) predates this geometry and needs re-capture if this ships.