### PR TITLE
Open web links found in terminal output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,12 @@ terminal's Command Setup editor for layout capture, and
 `… -p app.multiplexterm.multiplex.debug.msghistory` opens the focused
 terminal's agent HISTORY panel (session-file prompt list) for layout
 capture, and
+`… -p app.multiplexterm.multiplex.debug.link` activates the first link on
+the focused pane's visible screen through the same resolve → policy →
+confirmation path a long press takes (a screen of only filesystem paths
+must present nothing — that's the decline working), with
+`….debug.linkopen` running the sheet's OPEN action so the system log shows
+the URL reaching SurfBoard, and
 `… -p app.multiplexterm.multiplex.debug.msgjump` / `….debug.msgjumpback`
 jumps the focused Claude Code terminal to its oldest session-file prompt
 and runs BACK TO LIVE — host-side `tmux capture-pane` proves both (the old
@@ -388,8 +394,19 @@ views.
     keystrokes reach the UIKit pipeline but never the HID layer, so neither
     that rewrite nor the Ctrl bridge can be driven headlessly. Upstream
     1.15.0 encodes UIKit taps as xterm button 0
-    (primary/left), so that former Multiplex patch was retired. Sample apps
-    trimmed.
+    (primary/left), so that former Multiplex patch was retired. And link
+    activation is reachable by touch and answerable by the app:
+    `linkActivationIgnoresHighlight` lifts the pointer-only gate (every
+    upstream mode needs `linkHighlightRange`, which only
+    UIPointerInteraction/UIHoverGestureRecognizer set — touch and visionOS
+    gaze set neither, so an implicit URL could never be activated at all),
+    `linkActivationHandler` lets the app decline a match so a press over a
+    filesystem path still opens the selection menu, and both gestures route
+    through one `activateLink`: `singleTap` now skips the link check while
+    the remote wants the tap (upstream resolved links first, so URL-shaped
+    text swallowed tmux pane switches and vim cursor placement), while
+    `longPress` — local at every mouse mode — resolves one before its
+    context menu. Sample apps trimmed.
   - When bumping either, re-apply the patches and diff before trusting it.
 - **Citadel pinned to exactly 0.12.0**: 0.12.1 moved its swift-nio-ssh dep to an
   unaudited personal fork. Don't bump without review — this is the transport.
@@ -533,6 +550,35 @@ views.
   a keyboard Escape clears the state there too. Always restore mouse reporting
   when the mode ends or the transport closes, or normal tmux touch interaction
   silently stops.
+- **A terminal link is confirmed, never followed** (`TerminalLink`, pure +
+  tested; `TerminalLinkSheet`): SwiftTerm resolves the match (explicit OSC 8,
+  else ghostty-derived implicit detection, wrapped rows reassembled), the
+  patched gestures hand it to `TerminalSessionController.activateLink`, and
+  the pane presents the target rather than opening it. **Long press is the
+  activation route on every platform** — it is local at any mouse mode, while
+  a tap belongs to the remote whenever the client asked for tracking (tmux
+  `mouse on` is the default); tap activates only when it doesn't. Three
+  rules the model enforces, all load-bearing: the scheme allowlist is
+  `http`/`https`/`mailto` and nothing else — notably **not `multiplex:`,
+  which `ExternalActionRouter` would accept as a widget-grade
+  `open?host=…&action=agent&prompt=…`**, so pane output can't launch an
+  agent on another host; implicit detection matches **filesystem paths**
+  (`./x`, `/etc/hosts`, `~/x`) as readily as URLs, so those resolve to nil
+  and the press falls through to selection; and interior whitespace
+  disqualifies a target, because prose carrying a colon (`warning: unused
+  variable`) otherwise classifies as a `warning:` link. The sheet renders
+  the **resolved target** with the host on its own line — an OSC 8 label is
+  chosen independently of its destination, and that line is also what
+  exposes `https://github.com@evil.example/x`. Blocked and malformed
+  targets still get a sheet with COPY: an explanation beats a press that
+  does nothing. ⚠ **OSC 8 does not survive a tmux attach today** — tmux
+  3.6a stores hyperlinks (`capture-pane -e` proves it) but only emits them
+  to a client whose terminal advertises `Hls`, and the app requests
+  `TERM=xterm-256color`, which has none. So implicit detection is the live
+  path in tmux tabs; explicit links reach only direct `.shell` tabs. Don't
+  "fix" it with a server-scoped `terminal-features` default (the same leak
+  the per-host new-session conf documents). Full record + the verified
+  experiment table: `local-plan/terminal-links.md`.
 - **"Back to deck" reuses the one deck scene**: the data-driven `WindowGroup`
   always opens `DeckWindowRoute.main`, so `openWindow(id:value:)` raises the
   matching deck instead of minting another; `DeckScene` also destroys a second

--- a/Multiplex/Models/TerminalLink.swift
+++ b/Multiplex/Models/TerminalLink.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// A link resolved from terminal content — either an explicit OSC 8 hyperlink
+/// target or a URL SwiftTerm detected in the rendered text.
+///
+/// Terminal bytes are attacker-controlled in the ordinary case, not just the
+/// adversarial one: an SSH host's MOTD, a build log, a `cat`-ed README, or a
+/// CLI agent's tool output all print whatever they like, and an OSC 8
+/// hyperlink's visible label is independent of its target. Two consequences
+/// shape this type:
+///
+/// - **The allowlist is the gate.** Only schemes the system can open
+///   harmlessly resolve to `.openable`. Everything else is reported, not
+///   opened — including `multiplex:`, which `ExternalActionRouter` would
+///   otherwise accept as a widget-grade command (`open?host=…&action=agent&
+///   prompt=…`), letting pane output launch an agent on another host.
+/// - **The target is what gets shown.** The confirmation surface renders
+///   `raw` and `host` from this model, never the text the user tapped, so a
+///   label that reads `docs.example.com` cannot hide a different destination.
+struct TerminalLink: Equatable, Identifiable {
+    enum Kind: Equatable {
+        /// An allowlisted scheme that parsed into a URL the system can open.
+        case openable(URL)
+        /// A well-formed link whose scheme Multiplex will not hand to the
+        /// system. Carries the lowercased scheme so the sheet can name it.
+        case blockedScheme(String)
+        /// An allowlisted scheme that did not survive parsing — no host on an
+        /// http(s) URL, no address on a `mailto:`, or characters no encoding
+        /// rescues. Offered for copy, never opened.
+        case malformed
+    }
+
+    /// The resolved target, trimmed. This is the string the user is shown.
+    let raw: String
+    let kind: Kind
+
+    var id: String { raw }
+
+    /// The authority an `.openable` link actually resolves to. Shown on its
+    /// own line because userinfo hides the real destination inside an
+    /// otherwise ordinary-looking URL: `https://github.com@evil.example/x`
+    /// reads as GitHub until the host is spelled out separately.
+    var host: String? {
+        guard case .openable(let url) = kind else { return nil }
+        return url.host()
+    }
+
+    var openableURL: URL? {
+        guard case .openable(let url) = kind else { return nil }
+        return url
+    }
+}
+
+extension TerminalLink {
+    /// Schemes Multiplex hands to the system. Deliberately short: every
+    /// addition is a new way for remote output to reach another app. `file:`
+    /// and `ssh:` are excluded because a link naming a *local* resource, from
+    /// a *remote* host, is meaningless at best; `tel:` because a tap that
+    /// starts dialling from a build log is not a trade worth making.
+    static let allowedSchemes: Set<String> = ["http", "https", "mailto"]
+
+    /// Longer than any URL worth confirming, and a bound on what the sheet
+    /// has to render. Real targets sit far below it.
+    static let maxLength = 2048
+
+    /// Classifies a raw activation target. Returns nil when the match is not
+    /// a link Multiplex should say anything about — a filesystem path, a bare
+    /// word, or bytes that cannot be a URL. `SwiftTermView` declines those, so
+    /// the gesture falls through to normal selection handling.
+    ///
+    /// Pure: no URL is opened here and nothing is logged.
+    static func resolve(_ target: String) -> TerminalLink? {
+        let trimmed = target.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, trimmed.count <= maxLength else { return nil }
+        // Controls and line breaks are never part of a legitimate target, and
+        // a target that embeds them is trying to change how it renders. OSC 8
+        // payloads reach us as raw remote bytes, so this is the entry check.
+        guard !trimmed.unicodeScalars.contains(where: {
+            CharacterSet.controlCharacters.contains($0)
+                || CharacterSet.newlines.contains($0)
+        }) else { return nil }
+        // A URI has no raw spaces, and interior whitespace is what separates
+        // an actual target from ordinary prose that happens to carry a colon:
+        // `warning: unused variable` otherwise classifies as a `warning:`
+        // link. Implicit detection's path branches do match spaces, but those
+        // have no scheme and are declined below anyway.
+        guard !trimmed.contains(where: \.isWhitespace) else { return nil }
+
+        // No scheme means implicit detection matched a path branch
+        // (`./src/main.swift`, `/etc/hosts`, `~/notes`) or a bare token.
+        // Those are ordinary terminal output, not links.
+        guard let scheme = scheme(of: trimmed) else { return nil }
+        guard allowedSchemes.contains(scheme) else {
+            return TerminalLink(raw: trimmed, kind: .blockedScheme(scheme))
+        }
+        guard let url = url(from: trimmed, scheme: scheme) else {
+            return TerminalLink(raw: trimmed, kind: .malformed)
+        }
+        return TerminalLink(raw: trimmed, kind: .openable(url))
+    }
+
+    /// RFC 3986 scheme: an ASCII letter followed by letters, digits, `+`,
+    /// `-`, or `.`, up to the first colon. Hand-parsed rather than asking
+    /// `URL` — classification must not depend on how lenient the parser feels
+    /// about the rest of the string.
+    private static func scheme(of text: String) -> String? {
+        guard let colon = text.firstIndex(of: ":") else { return nil }
+        let candidate = text[text.startIndex..<colon]
+        guard let first = candidate.first, first.isASCII, first.isLetter else {
+            return nil
+        }
+        guard candidate.allSatisfy({
+            $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "+" || $0 == "-" || $0 == ".")
+        }) else {
+            return nil
+        }
+        return candidate.lowercased()
+    }
+
+    private static func url(from text: String, scheme: String) -> URL? {
+        // iOS 17 made `URL(string:)` reject invalid characters outright;
+        // encoding them keeps a URL with a stray brace or a non-ASCII path
+        // usable while still failing on genuine nonsense.
+        guard let url = URL(string: text, encodingInvalidCharacters: true) else {
+            return nil
+        }
+        switch scheme {
+        case "http", "https":
+            // A hostless http URL cannot be opened and is a strong sign the
+            // text was never a link (`http://` alone, `https:///path`).
+            guard let host = url.host(), !host.isEmpty else { return nil }
+            return url
+        case "mailto":
+            // Everything after the scheme is the address list; empty means
+            // there is nothing to mail.
+            let address = text.dropFirst(scheme.count + 1)
+            guard !address.isEmpty else { return nil }
+            return url
+        default:
+            return url
+        }
+    }
+}

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -153,6 +153,10 @@ final class TerminalSessionController {
     private(set) var dropState: DropState?
     private var dropTask: Task<Void, Never>?
     private var dropClearTask: Task<Void, Never>?
+    /// A link the user activated in this pane, awaiting confirmation. The
+    /// pane never opens one straight from the gesture: the target is remote
+    /// output, so the destination is shown first (see `TerminalLink`).
+    private(set) var pendingLink: TerminalLink?
 
     init(route: TerminalRoute, host: Host, attention: AttentionCenter? = nil) {
         self.route = route
@@ -175,6 +179,13 @@ final class TerminalSessionController {
         terminalView = view
         view.allowMouseReporting = !tmuxCopyModeUIActive
         view.forceRemoteCursorScroll = tmuxCopyModeUIActive
+        // Touch never hovers, so SwiftTerm's pointer-gated activation can
+        // never fire here; this pane decides instead. The view owns the
+        // closure and this controller owns the view — capture weakly.
+        view.linkActivationIgnoresHighlight = true
+        view.linkActivationHandler = { [weak self] target, _ in
+            self?.activateLink(target) ?? false
+        }
         if !pendingOutput.isEmpty {
             view.feed(byteArray: pendingOutput[...])
             pendingOutput.removeAll()
@@ -1286,6 +1297,42 @@ final class TerminalSessionController {
             typedPrefix: nil,
             prepareGitIgnoredDirectory: false
         )
+    }
+
+    // MARK: Links
+
+    /// A link the terminal resolved under a tap or long press. Returns
+    /// whether this pane claims the gesture — declining lets it fall through
+    /// to selection, which is what a filesystem path (implicit detection
+    /// matches those too) must keep doing.
+    func activateLink(_ target: String) -> Bool {
+        // The jump search owns the pane's input while it pages and its veil
+        // covers the text being pressed — same rule as a drop.
+        if case .finding = historyJump { return false }
+        guard let link = TerminalLink.resolve(target) else { return false }
+        pendingLink = link
+        return true
+    }
+
+    /// Hands the confirmed target to the system. Only an allowlisted scheme
+    /// ever reaches here — `TerminalLink` decided that, and the sheet only
+    /// offers OPEN for `.openable`.
+    func openPendingLink() {
+        guard let url = pendingLink?.openableURL else { return }
+        pendingLink = nil
+        UIApplication.shared.open(url)
+    }
+
+    /// Copy is the answer for everything Multiplex will not open: a blocked
+    /// scheme, a malformed target, or a link the user wants elsewhere.
+    func copyPendingLink() {
+        guard let link = pendingLink else { return }
+        UIPasteboard.general.string = link.raw
+        pendingLink = nil
+    }
+
+    func dismissPendingLink() {
+        pendingLink = nil
     }
 
     // MARK: Actions

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -609,7 +609,13 @@ struct SwiftTermView: UIViewRepresentable {
 
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
         func scrolled(source: TerminalView, position: Double) {}
-        func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+        /// Only reached if the view's `linkActivationHandler` is ever absent —
+        /// `bind` installs one. Kept wired so the two routes can't disagree.
+        func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {
+            MainActor.assumeIsolated {
+                _ = controller.activateLink(link)
+            }
+        }
 
         func bell(source: TerminalView) {
             MainActor.assumeIsolated {

--- a/Multiplex/Views/Terminal/TerminalLinkSheet.swift
+++ b/Multiplex/Views/Terminal/TerminalLinkSheet.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+/// Confirmation for a link activated in a terminal pane.
+///
+/// The pane never opens a link straight from the gesture, and this sheet is
+/// why: the target is remote output. An OSC 8 hyperlink's label is chosen
+/// independently of its destination, so the text the user pressed proves
+/// nothing — this surface renders the *resolved target* and names the host on
+/// its own line, which is what defeats both a mislabelled hyperlink and a
+/// userinfo-padded authority (`https://github.com@evil.example/x`).
+///
+/// Blocked and malformed targets still get here. Saying "Multiplex won't open
+/// a `file:` link" and offering COPY is a better answer than a press that
+/// appears to do nothing.
+struct TerminalLinkSheet: View {
+    let link: TerminalLink
+    let onOpen: () -> Void
+    let onCopy: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 18) {
+                    TallyFormSection(sectionTitle, detail: detail) {
+                        TallyFormRow {
+                            VStack(alignment: .leading, spacing: 12) {
+                                if let host = link.host {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        ChassisLabel("HOST", size: 9, color: Theme.signal3)
+                                        Text(host)
+                                            .font(.mono(13, weight: .semibold))
+                                            .foregroundStyle(Theme.signal)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                }
+                                VStack(alignment: .leading, spacing: 4) {
+                                    ChassisLabel("TARGET", size: 9, color: Theme.signal3)
+                                    Text(link.raw)
+                                        .font(.mono(11))
+                                        .foregroundStyle(Theme.signal2)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .textSelection(.enabled)
+                                }
+                                .padding(10)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Theme.screen)
+                                .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+
+                                HStack(spacing: 10) {
+                                    if link.openableURL != nil {
+                                        ChassisChip(
+                                            "OPEN",
+                                            systemImage: "arrow.up.forward.app",
+                                            prominent: true
+                                        ) {
+                                            onOpen()
+                                            dismiss()
+                                        }
+                                    }
+                                    ChassisChip("COPY", systemImage: "doc.on.doc") {
+                                        onCopy()
+                                        dismiss()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: 560)
+                .padding(18)
+                .frame(maxWidth: .infinity)
+            }
+            .chassisSheetGround()
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ChassisSheetTitle(navigationTitle)
+                ToolbarItem(placement: .cancellationAction) {
+                    ChassisBarButton("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var navigationTitle: String {
+        link.openableURL == nil ? "Can't open link" : "Open link"
+    }
+
+    private var sectionTitle: String {
+        switch link.kind {
+        case .openable: "Leaves Multiplex"
+        case .blockedScheme(let scheme): "\(scheme.uppercased()) links stay here"
+        case .malformed: "Not a usable address"
+        }
+    }
+
+    private var detail: String {
+        switch link.kind {
+        case .openable:
+            "This address came from the host, and a hyperlink's visible text "
+                + "can differ from where it points — check the host above "
+                + "before opening it outside Multiplex."
+        case .blockedScheme(let scheme):
+            "Multiplex opens web and mail links only. A \(scheme): link from a "
+                + "remote pane would act on this device, so it is shown rather "
+                + "than followed — copy it if you want it elsewhere."
+        case .malformed:
+            "The text looked like a link but has no address Multiplex can "
+                + "open. Copy it if it's still useful."
+        }
+    }
+}
+
+extension View {
+    /// Presents `controller`'s pending link confirmation. Packaged as one
+    /// modifier because `TerminalWindowRoot`'s body is already at the Swift
+    /// type-checker's ceiling — an inline `.sheet(item:)` with its binding and
+    /// action closures tips the whole chain over.
+    func terminalLinkConfirmation(
+        for controller: TerminalSessionController?
+    ) -> some View {
+        let binding = Binding<TerminalLink?>(
+            get: { controller?.pendingLink },
+            set: { if $0 == nil { controller?.dismissPendingLink() } }
+        )
+        return sheet(item: binding) { link in
+            TerminalLinkSheet(
+                link: link,
+                onOpen: { controller?.openPendingLink() },
+                onCopy: { controller?.copyPendingLink() }
+            )
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Openable") {
+    TerminalLinkSheet(
+        link: TerminalLink.resolve("https://multiplexterm.dev/docs/tmux")!,
+        onOpen: {},
+        onCopy: {}
+    )
+    .frame(width: 720, height: 640)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Blocked") {
+    TerminalLinkSheet(
+        link: TerminalLink.resolve("file:///etc/shadow")!,
+        onOpen: {},
+        onCopy: {}
+    )
+    .frame(width: 720, height: 640)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 #if DEBUG
 import notify
+import SwiftTerm
 #endif
 
 /// Root of one terminal window scene: the window's tabs (each one SSH
@@ -104,6 +105,14 @@ struct TerminalWindowRoot: View {
     }
     private var terminalFocusAllowed: Bool {
         shell?.terminalFocusAllowed ?? true
+    }
+    /// Kept out of the body's modifier chain, which sits at the Swift
+    /// type-checker's ceiling: an inline binding here fails to type-check.
+    private var newTabFailedAlertBinding: Binding<Bool> {
+        Binding(
+            get: { newTabFailedHost != nil },
+            set: { if !$0 { newTabFailedHost = nil } }
+        )
     }
     /// Only the in-scene shell spends the side safe areas on its panes; a
     /// classic terminal scene is laid out inside them already.
@@ -248,12 +257,10 @@ struct TerminalWindowRoot: View {
                     sessionNames: tip.sessionNames
                 )
             }
+            .terminalLinkConfirmation(for: activeController)
             .alert(
                 "Couldn't Create Session",
-                isPresented: Binding(
-                    get: { newTabFailedHost != nil },
-                    set: { if !$0 { newTabFailedHost = nil } }
-                )
+                isPresented: newTabFailedAlertBinding
             ) {
                 Button("OK", role: .cancel) {}
             } message: {
@@ -298,6 +305,16 @@ struct TerminalWindowRoot: View {
                 else { return }
                 controller.finishHistoryJump()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugLink)) { _ in
+                debugActivateFirstLink()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugLinkOpen)) { _ in
+                guard let controller = activeController,
+                      let view = controller.terminalView,
+                      view === TerminalFocusArbiter.current
+                else { return }
+                controller.openPendingLink()
+            }
             #endif
     }
 
@@ -324,6 +341,7 @@ struct TerminalWindowRoot: View {
         AgentChipDebugHook.install()
         NewTabDebugHook.install()
         MessageJumpDebugHook.install()
+        TerminalLinkDebugHook.install()
         #endif
         guard let hostID = activeTab?.hostID, let host = store.host(id: hostID) else { return }
         let model = hub.model(for: host)
@@ -463,6 +481,36 @@ struct TerminalWindowRoot: View {
               ).first(where: { $0.label.hasPrefix("/") })
         else { return }
         send(command, via: controller)
+    }
+
+    /// Headless link proof: scan the focused pane's visible screen for the
+    /// first resolvable link and run it through the same
+    /// `activateLink` policy a long press uses, so the confirmation sheet
+    /// that appears is the real one. Screen coordinates keep the scan on
+    /// what is actually rendered rather than the whole scrollback.
+    private func debugActivateFirstLink() {
+        guard let controller = activeController,
+              let view = controller.terminalView,
+              view === TerminalFocusArbiter.current
+        else { return }
+        let terminal = view.getTerminal()
+        for row in 0..<terminal.rows {
+            var col = 0
+            while col < terminal.cols {
+                guard let target = terminal.link(
+                    at: .screen(Position(col: col, row: row)),
+                    mode: .explicitAndImplicit
+                ) else {
+                    col += 1
+                    continue
+                }
+                if controller.activateLink(target) { return }
+                // A declined match (a filesystem path) must not stall the
+                // scan on its own cells — step past the whole match's worth
+                // of columns rather than re-resolving each one.
+                col += max(1, target.count)
+            }
+        }
     }
 
     /// Run the + TAB dropdown's New Session action for the focused window
@@ -1537,6 +1585,35 @@ extension Notification.Name {
     static let multiplexDebugMessageJumpBack = Notification.Name(
         "MultiplexDebugMessageJumpBack"
     )
+    static let multiplexDebugLink = Notification.Name("MultiplexDebugLink")
+    static let multiplexDebugLinkOpen = Notification.Name("MultiplexDebugLinkOpen")
+}
+
+/// `….debug.link` activates the first link on the focused terminal's visible
+/// screen — the same resolve → policy → confirmation path a long press takes,
+/// which is the only way to drive it headlessly (no sim tap injection exists,
+/// and ornament/gesture input can't be synthesized). `….debug.linkopen` then
+/// runs the sheet's OPEN action, so a screenshot shows Safari with the target.
+@MainActor
+enum TerminalLinkDebugHook {
+    private static var installed = false
+
+    static func install() {
+        guard !installed else { return }
+        installed = true
+        var findToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.link", &findToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugLink, object: nil)
+        }
+        var openToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.linkopen", &openToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugLinkOpen, object: nil)
+        }
+    }
 }
 
 /// Headless-verification hook, same shape as `AgentChipDebugHook`:

--- a/MultiplexTests/TerminalLinkTests.swift
+++ b/MultiplexTests/TerminalLinkTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import Multiplex
+
+final class TerminalLinkTests: XCTestCase {
+    // MARK: Openable
+
+    func testResolvesWebLinks() {
+        for target in [
+            "https://multiplexterm.dev",
+            "http://localhost:5173/",
+            "https://github.com/jhen0409/multiplex-home/pull/3#issue-1",
+            "https://[2001:db8::1]:8080/status",
+        ] {
+            guard case .openable(let url)? = TerminalLink.resolve(target)?.kind else {
+                return XCTFail("expected \(target) to be openable")
+            }
+            XCTAssertEqual(url.absoluteString, target)
+        }
+    }
+
+    func testResolvesMailto() {
+        guard case .openable? = TerminalLink.resolve("mailto:dev@example.com")?.kind else {
+            return XCTFail("expected a mailto link")
+        }
+    }
+
+    func testSchemeMatchingIsCaseInsensitive() {
+        guard case .openable? = TerminalLink.resolve("HTTPS://Example.com/A")?.kind else {
+            return XCTFail("expected an uppercase scheme to resolve")
+        }
+    }
+
+    func testTrimsSurroundingWhitespace() {
+        // Implicit detection can carry the trailing spaces of an end-of-line
+        // match into the target.
+        XCTAssertEqual(
+            TerminalLink.resolve("  https://example.com/x  ")?.raw,
+            "https://example.com/x"
+        )
+    }
+
+    // MARK: The host line
+
+    func testHostIsTheRealAuthorityNotTheUserinfo() {
+        // The defence against `https://github.com@evil.example/x` reading as
+        // GitHub: the sheet shows this host on its own line.
+        XCTAssertEqual(
+            TerminalLink.resolve("https://github.com@evil.example/x")?.host,
+            "evil.example"
+        )
+    }
+
+    func testHostIsNilForEverythingNotOpenable() {
+        XCTAssertNil(TerminalLink.resolve("ssh://box.example")?.host)
+    }
+
+    // MARK: Blocked schemes
+
+    func testAppSchemeIsNeverOpenable() {
+        // ExternalActionRouter accepts this as a widget-grade command, so pane
+        // output must never be able to launch an agent on another host.
+        guard case .blockedScheme("multiplex")? = TerminalLink.resolve(
+            "multiplex://open?host=prod&action=agent&prompt=rm%20-rf"
+        )?.kind else {
+            return XCTFail("expected the app's own scheme to be blocked")
+        }
+    }
+
+    func testNonWebSchemesAreReportedNotOpened() {
+        for (target, scheme) in [
+            ("file:///etc/shadow", "file"),
+            ("ssh://root@box.example", "ssh"),
+            ("tel:+15550100", "tel"),
+            ("javascript:alert(1)", "javascript"),
+            ("shortcuts://run-shortcut?name=Wipe", "shortcuts"),
+        ] {
+            guard case .blockedScheme(let found)? = TerminalLink.resolve(target)?.kind else {
+                return XCTFail("expected \(target) to be blocked")
+            }
+            XCTAssertEqual(found, scheme)
+        }
+    }
+
+    // MARK: Declined — not links at all
+
+    func testFilesystemPathsAreDeclined() {
+        // Implicit detection matches these as readily as URLs, and they are
+        // everywhere in terminal output. Declining lets the long press fall
+        // through to the selection menu.
+        for target in [
+            "./src/main.swift",
+            "../Vendor/SwiftTerm",
+            "/etc/hosts",
+            "~/notes/todo.md",
+            "Sources/Multiplex/Theme.swift",
+        ] {
+            XCTAssertNil(TerminalLink.resolve(target), "expected \(target) to be declined")
+        }
+    }
+
+    func testEmptyAndOversizedTargetsAreDeclined() {
+        XCTAssertNil(TerminalLink.resolve(""))
+        XCTAssertNil(TerminalLink.resolve("   "))
+        XCTAssertNil(
+            TerminalLink.resolve("https://example.com/" + String(repeating: "a", count: 4096))
+        )
+    }
+
+    func testControlCharactersAreDeclined() {
+        // OSC 8 payloads arrive as raw remote bytes; a target that embeds a
+        // newline or an escape is trying to change how it renders.
+        XCTAssertNil(TerminalLink.resolve("https://example.com/a\nb"))
+        XCTAssertNil(TerminalLink.resolve("https://example.com/\u{1B}[31m"))
+        XCTAssertNil(TerminalLink.resolve("https://exam\u{7}ple.com"))
+    }
+
+    func testSchemeLikePrefixesThatAreNotSchemesAreDeclined() {
+        // A leading digit is not a legal scheme, and prose that happens to
+        // carry a colon is not a link — an OSC 8 payload is arbitrary remote
+        // text, so both reach `resolve` even though implicit detection would
+        // never match them.
+        XCTAssertNil(TerminalLink.resolve("12:34:56"))
+        XCTAssertNil(TerminalLink.resolve("warning: unused variable"))
+        XCTAssertNil(TerminalLink.resolve("note: see the docs"))
+        XCTAssertNil(TerminalLink.resolve("https://example.com/a b"))
+    }
+
+    // MARK: Malformed
+
+    func testHostlessWebLinksAreMalformed() {
+        for target in ["https://", "http:///path"] {
+            guard case .malformed? = TerminalLink.resolve(target)?.kind else {
+                return XCTFail("expected \(target) to be malformed")
+            }
+        }
+    }
+
+    func testEmptyMailtoIsMalformed() {
+        guard case .malformed? = TerminalLink.resolve("mailto:")?.kind else {
+            return XCTFail("expected an addressless mailto to be malformed")
+        }
+    }
+
+    func testMalformedAndBlockedLinksExposeNoURL() {
+        XCTAssertNil(TerminalLink.resolve("mailto:")?.openableURL)
+        XCTAssertNil(TerminalLink.resolve("file:///tmp/x")?.openableURL)
+    }
+
+    // MARK: Identity
+
+    func testIdentityIsTheResolvedTarget() {
+        // `.sheet(item:)` re-presents when this changes, so two activations of
+        // the same link must not thrash the sheet.
+        XCTAssertEqual(
+            TerminalLink.resolve("https://example.com/a")?.id,
+            TerminalLink.resolve("https://example.com/a  ")?.id
+        )
+        XCTAssertNotEqual(
+            TerminalLink.resolve("https://example.com/a")?.id,
+            TerminalLink.resolve("https://example.com/b")?.id
+        )
+    }
+}

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -925,6 +925,17 @@ extension TerminalView {
 
     func linkVisibleForClick(match: Terminal.LinkMatch, hasCommandModifier: Bool) -> Bool
     {
+        // Multiplex patch: every activation mode below is gated on state only a
+        // pointer can produce — `.hover*` needs `linkHighlightRange`, which is
+        // populated exclusively by UIPointerInteraction/UIHoverGestureRecognizer,
+        // and `.always*` resolves explicit OSC 8 payloads only. Touch produces
+        // neither, so on a phone, an iPad without a trackpad, or Vision Pro
+        // driven by gaze + pinch, an implicitly detected URL could never be
+        // activated at all. When this is set the match itself is enough and the
+        // delegate decides what activation means.
+        if linkActivationIgnoresHighlight {
+            return true
+        }
         switch linkHighlightMode {
         case .always:
             return match.isExplicit

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -901,6 +901,11 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
 
     var linkHighlightRange: [Terminal.LinkMatch.RowRange]?
 
+    /// Multiplex patch: shared with the iOS view so `linkVisibleForClick` in
+    /// AppleTerminalView compiles on both platforms. macOS has a real pointer,
+    /// so nothing in Multiplex sets this here — Command-hover stays the rule.
+    public var linkActivationIgnoresHighlight = false
+
     /**
      * If set to true, this will call the TerminalViewDelegate's rangeChanged method
      * when there are changes that are being performed on the UI

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -196,6 +196,34 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         }
     }
 
+    /// Multiplex patch: allow a resolved link to be activated without the
+    /// pointer state `linkHighlightMode` demands. Touch never hovers, so a
+    /// touch-only device could otherwise activate explicit OSC 8 links at
+    /// best and implicit URLs never. This only affects activation — hover
+    /// underlining still follows `linkHighlightMode`.
+    public var linkActivationIgnoresHighlight = false
+
+    /// Multiplex patch: app-owned policy for an activated link. Implicit
+    /// detection matches filesystem paths (`./src/main.swift`, `/etc/hosts`)
+    /// as readily as URLs, and those are everywhere in terminal output — a
+    /// long press over one must still open the selection menu. Returning
+    /// false declines the match and lets the gesture continue as if no link
+    /// were there. Install with a weak capture: the view owns this closure.
+    ///
+    /// With no handler installed, upstream behavior stands: the delegate's
+    /// `requestOpenLink` is called and the gesture is consumed.
+    public var linkActivationHandler: ((_ link: String, _ params: [String: String]) -> Bool)?
+
+    /// Multiplex patch: shared activation path for tap and long press.
+    func activateLink(_ result: (link: String, params: [String: String])) -> Bool
+    {
+        if let linkActivationHandler {
+            return linkActivationHandler(result.link, result.params)
+        }
+        terminalDelegate?.requestOpenLink(source: self, link: result.link, params: result.params)
+        return true
+    }
+
     private var lastReportedLink: String?
     var commandActive = false
     private var activeCommandKeys: Set<UIKeyboardHIDUsage> = []
@@ -688,9 +716,20 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
              let _ = self.becomeFirstResponder()
              let tapLocation = gestureRecognizer.location(in: gestureRecognizer.view)
              let tapRegion = makeContextMenuRegionForTap (point: tapLocation)
-             
-             showContextMenu (forRegion: tapRegion,
-                              pos: calculateTapHit (gesture: gestureRecognizer).grid)
+             let hit = calculateTapHit (gesture: gestureRecognizer).grid
+
+             // Multiplex patch: a long press is a local gesture — no mouse
+             // report rides on it at any tracking mode — so it is the one
+             // activation route that always reaches the user's intent. A press
+             // over a link the app claims resolves it; a declined match (a
+             // filesystem path) or a press anywhere else opens the selection
+             // menu exactly as before.
+             if let result = linkForClick(at: hit, hasCommandModifier: commandActive),
+                activateLink(result) {
+                 return
+             }
+
+             showContextMenu (forRegion: tapRegion, pos: hit)
           }
     }
     
@@ -831,8 +870,18 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
 
         if isFirstResponder {
             let tapHit = calculateTapHit(gesture: gestureRecognizer).grid
-            if let result = linkForClick(at: tapHit, hasCommandModifier: commandActive) {
-                terminalDelegate?.requestOpenLink(source: self, link: result.link, params: result.params)
+            // Multiplex patch: a tap belongs to the remote whenever the client
+            // asked for mouse tracking. Upstream resolves links first, which
+            // means any URL-shaped text under the finger silently swallows the
+            // click — tmux `mouse on` (this app's default) stops switching
+            // panes there, and vim stops placing the cursor. Long press is the
+            // link route in that state; see `longPress`.
+            let remoteWantsTap = allowMouseReporting
+                && !shiftBypassesMouseReporting(for: gestureRecognizer)
+                && terminal.mouseMode.sendButtonPress()
+            if !remoteWantsTap,
+               let result = linkForClick(at: tapHit, hasCommandModifier: commandActive),
+               activateLink(result) {
                 return
             }
 

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -110,7 +110,11 @@ Current product split:
   tmux's server-scoped values remain server-wide, built-in terminal themes
   and a separate theme selection per appearance (light adds Tally Frost/Paper/Ivory),
   free file attachment on SSH-backed tmux tabs from Files/Photos (plus camera
-  on iPad) and drag-and-drop through the same SSH upload path, a most-used tmux
+  on iPad) and drag-and-drop through the same SSH upload path, opening web and
+  mail links found in terminal output (long press, or tap where the remote is
+  not tracking the mouse; the confirmation shows the resolved target and its
+  host, and other schemes are shown for copying rather than followed), a
+  most-used tmux
   shortcut dropdown on both platforms (including touch-native copy-mode
   selection and explicit exit), Home Screen widgets (per-host monitor +
   fleet wall; iPadOS 17+, visionOS 26+) and App Shortcuts ("Open Shell" /


### PR DESCRIPTION
Tap or long-press a URL in a pane and Multiplex offers to open it — after showing you where it actually goes.

## Why this wasn't just wiring up a delegate

The vendored SwiftTerm already resolves links (explicit OSC 8, else a ghostty-derived implicit regex, wrapped rows reassembled) and already calls `requestOpenLink`. The app implemented that method as `{}`. But every upstream activation mode is gated on `linkHighlightRange`, which only `UIPointerInteraction`/`UIHoverGestureRecognizer` populate — touch sets neither, and visionOS gaze isn't delivered to gesture recognizers. So an implicit URL could never be activated on a phone, a trackpad-less iPad, or Vision Pro.

## Three problems that shaped it

**Mouse reporting owns the tap.** Upstream resolved links *before* the mouse branch, so URL-shaped text under the finger silently swallowed the click — tmux `mouse on` (the default) stopped switching panes there, vim stopped placing the cursor. Long press is now the activation route on every platform (it's local at any tracking mode); tap activates only when the remote isn't tracking.

**A match is not always a URL.** The implicit regex matches filesystem paths (`./src/main.swift`, `/etc/hosts`) as readily as URLs, and those are everywhere in output. SwiftTerm now asks an app-owned handler whether the match is claimed; declining lets the press fall through to the selection menu.

**The bytes are attacker-controlled in the ordinary case** — a MOTD, a build log, an agent's tool output — and an OSC 8 label is chosen independently of its target. So the pane confirms rather than follows. The sheet shows the **resolved target** with the host on its own line, which also exposes `https://github.com@evil.example/x`. The allowlist is `http`/`https`/`mailto` and notably **not `multiplex:`**, which `ExternalActionRouter` would accept as a widget-grade `open?host=…&action=agent&prompt=…` — pane output must not be able to launch an agent on another host. Blocked and malformed targets still get a sheet with COPY.

## SwiftTerm patch (ninth group)

Three edits marked `Multiplex patch`: an additive `linkActivationIgnoresHighlight`, an app-owned `linkActivationHandler`, and both gestures routed through one `activateLink` (tap skips the check while the remote wants it; long press resolves before its context menu). Upstream behavior stands when no handler is installed.

## Verified

visionOS simulator against `Tools/dev-sshd/harness.sh`, via two new DEBUG hooks (`debug.link` / `debug.linkopen`) — no sim tap injection exists, so the hooks run the real resolve → policy → confirmation path.

| Case | Result |
| --- | --- |
| `docs: https://multiplexterm.dev/guide` | sheet: HOST `multiplexterm.dev`, TARGET the full URL |
| OPEN | SurfBoard logged the URL; MobileSafari launched |
| screen of only `./Sources/…`, `/tmp/…`, `~/.tmux.conf` | no sheet — declined |
| OSC 8 labelled "Click here for the docs" → `https://evil.example/pwned` | sheet: HOST `evil.example` |
| OSC 8 → `multiplex://open?host=prod&action=agent&prompt=wipe` | "CAN'T OPEN LINK", COPY only |

505 unit tests pass (`TerminalLink` is pure and covered — its whitespace rule came from a failing test, where `warning: unused variable` classified as a `warning:` link). visionOS + iPad Debug and visionOS Release all build.

## Finding worth knowing

**OSC 8 does not survive a tmux attach today.** tmux 3.6a stores hyperlinks (`capture-pane -e` proves it) but only emits them to a client advertising the `Hls` terminfo capability, and the app requests `TERM=xterm-256color`, which has none. Confirmed by flipping `set -as terminal-features ",xterm-256color:hyperlinks"` on and watching the spoofed link resolve (reverted after). So implicit detection is the live path in tmux tabs; explicit links reach only direct `.shell` tabs. Not defaulted, because `terminal-features` is server-scoped — the same leak the per-host new-session conf documents. Changing `TERM` is the other lever and a larger decision.

## Note

`docs/store-metadata.md`'s Free list is updated. Release notes are untouched — 1.0.1's are already written, so which version this lands in is your call.

Full record: `local-plan/terminal-links.md`.
