### PR TITLE
Keep held backspace repeating on the software keyboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,7 +355,7 @@ views.
   - `swift-nio-ssh` — Citadel 0.12.0's resolved fork (`Joannis` 0.3.5), patched
     to declare the `NIO` product it imports (Xcode 27's module resolution
     rejects the undeclared import). Also freezes the SSH transport supply chain.
-  - `SwiftTerm` — 1.15.0 (rev `dd2fb8a`), patched in eight behavior groups
+  - `SwiftTerm` — 1.15.0 (rev `dd2fb8a`), patched in nine behavior groups
     (marked `Multiplex patch`; the obscured-tab display guards share the marker
     on their owning state):
     `keyboardType` is settable (upstream is get-only), and Multiplex keeps it
@@ -376,7 +376,13 @@ views.
     `selection.active`**: a long press opens PASTE / SELECT / SELECT ALL
     without selecting anything, so guarding on the selection alone left that
     menu stuck on screen — cancellable only by pressing SELECT first, which is
-    what finally made the guard true (user-reported); UIKit marked text stays
+    what finally made the guard true (user-reported); **`hasText` always
+    answers true**, because a terminal's document is the remote screen and
+    never the local `textInputStorage` mirror — text typed before the attach,
+    sent by another client, or left in a composer is on screen and deletable
+    while that mirror is empty, so reporting the mirror answered about the
+    wrong document (⚠ this does NOT fix held-backspace auto-repeat — see the
+    open item below); UIKit marked text stays
     local in a caret-anchored overlay until
     commit, with honest candidate-window geometry and cleanup across reset,
     deletion, detach, and font/caret changes — this is merged with 1.15.0's
@@ -1320,3 +1326,30 @@ unchosen candidates stay here under `docs/landing/`.
   Citadel's `.custom` validator is the ship-blocker TODO.
 - csh/fish remote shells may need tmux on the default PATH (probe prepends common
   Homebrew/local paths but assumes POSIX-ish login shells).
+- **Held-backspace auto-repeat rides an input filler and is NOT verified**
+  (`inputFillerLength` / `inputFillerCharacter`, `seedInputFillerIfNeeded` /
+  `clearInputFiller`). iOS accelerates a held delete into word-wise deletion and
+  reads the `UITextInput` document's real characters to find boundaries, but
+  `textInputStorage` only mirrors what was typed through this view — empty for
+  text typed before the attach, sent by another client, or echoed by the remote,
+  so the repeat starved and every backspace was a separate tap (user-reported).
+  Upstream SwiftTerm #271 ("will not auto-repeat if it encounters a space") is
+  the milder form of the same mismatch, open since 2023. `hasText` returning
+  true and reporting the delete to `inputDelegate` were both tried first and
+  neither moved it. The buffer is now stocked with filler when it holds nothing
+  real, and each consumed filler character becomes one backspace byte. The
+  load-bearing invariant: **filler exists only while there is no real text** —
+  `commitTextInput`, `setMarkedText`, and `replace` clear it before reading the
+  buffer. That keeps it away from typed text (a word-wise delete spanning the
+  boundary would over-count backspaces) and away from the `.last` / `.suffix()`
+  / caret-at-end reads behind auto-period and Korean resyllabification;
+  filler deletions are also barred from opening a resyllabification
+  transaction. Restocking happens *after* `endTextInputEdit` on purpose, so the
+  keyboard is told the shortened document this delete produced and still finds
+  a full buffer on its next read. Geometry is unaffected (`caretRect` /
+  `firstRect` answer from the terminal caret, not buffer offsets).
+  ⚠ No headless route exists to drive a held software key (see the simulator
+  tap-injection note), so this shipped on device testing alone. If IME
+  regresses, suspect a mutation path that reads the buffer without clearing
+  filler first. Both constants are tuning knobs: the length bounds how many
+  backspaces one word-wise delete can emit in a tick.

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -2066,8 +2066,89 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         true
     }
     
+    /// Multiplex patch: a terminal's document is the remote screen, not this
+    /// view's local input mirror, so this always answers true.
+    ///
+    /// `textInputStorage` holds only what was typed through *this* view's text
+    /// input session. Text that arrived any other way — typed before the
+    /// attach, sent by another client, echoed by the remote, or left in a
+    /// composer when the app reattaches — is on screen and deletable while the
+    /// mirror is still empty, so reporting that mirror answered a question
+    /// about the wrong document. Backspace is unconditionally meaningful here:
+    /// `deleteBackward` sends 0x7f (or the kitty backspace event) and the remote
+    /// alone decides what that does. Nothing in SwiftTerm reads this property —
+    /// real editing addresses `textInputStorage` through ranges — so it is
+    /// advisory to UIKit only.
+    ///
+    /// ⚠ This does NOT restore held-backspace auto-repeat (tested: no change).
+    /// Once iOS accelerates a held delete it deletes word-wise, which reads the
+    /// document's actual characters to find boundaries — an empty mirror
+    /// starves that regardless of what this property claims. Same root cause as
+    /// upstream SwiftTerm #271 ("will not auto-repeat if it encounters a
+    /// space"), still open and undiagnosed there. Fixing it needs the document
+    /// stocked with real filler characters, which lands on the buffer that also
+    /// carries marked text and the Korean resyllabification transaction.
     public var hasText: Bool {
-        return !textInputStorage.isEmpty
+        return true
+    }
+
+    // MARK: - Input filler (held-backspace auto-repeat)
+    //
+    // Multiplex patch: iOS accelerates a held delete key into word-wise
+    // deletion, and to find a word boundary it reads the real characters of the
+    // `UITextInput` document. `textInputStorage` only ever mirrors what was
+    // typed through this view, so for text that came from anywhere else — typed
+    // before the attach, sent by another client, echoed by the remote — the
+    // document is empty and the repeat starves immediately: every backspace
+    // becomes a separate tap. (Upstream SwiftTerm #271 is the milder form,
+    // where the repeat dies at a space.) Neither `hasText` nor reporting the
+    // delete to `inputDelegate` fixes it; the keyboard wants characters it can
+    // consume.
+    //
+    // So when the buffer holds nothing real, it is stocked with filler, and
+    // each filler character the keyboard consumes is converted into one
+    // backspace byte for the remote. The load-bearing invariant is that filler
+    // exists ONLY while there is no real text: any actual input clears it
+    // first. That keeps filler from ever sitting next to typed text (where a
+    // word-wise delete spanning the boundary would over-count backspaces) and
+    // keeps it away from `.last`/`.suffix()` and the caret-at-end guards that
+    // the auto-period and Korean resyllabification paths read.
+    //
+    // Both constants are tuning knobs. The length bounds how many backspaces a
+    // single word-wise delete can emit in one tick; the character must not be a
+    // space (spaces are what upstream #271 trips over, and the auto-period path
+    // keys on a trailing space) and must not be Hangul (`tryComposeKoreanFinal`
+    // inspects the last character).
+    static let inputFillerLength = 16
+    static let inputFillerCharacter: Character = "x"
+
+    /// Count of filler characters at the head of `textInputStorage`. Non-zero
+    /// only while the buffer is *entirely* filler — see the invariant above.
+    var inputFillerCount = 0
+
+    /// Stocks the buffer with filler when it holds nothing real, so a held
+    /// delete key always has characters to consume. No-op during composition.
+    func seedInputFillerIfNeeded () {
+        guard _markedTextRange == nil else { return }
+        // Only when there is no real text: either empty, or already all filler.
+        guard textInputStorage.count == inputFillerCount,
+              inputFillerCount < TerminalView.inputFillerLength else { return }
+        textInputStorage = String(repeating: TerminalView.inputFillerCharacter,
+                                  count: TerminalView.inputFillerLength)
+        inputFillerCount = TerminalView.inputFillerLength
+        let end = TextPosition(offset: textInputStorage.textInputUTF16Count)
+        _selectedTextRange = TextRange(from: end, to: end)
+    }
+
+    /// Drops the filler before any real input touches the buffer, restoring the
+    /// empty-document state the text input paths were written against.
+    func clearInputFiller () {
+        guard inputFillerCount > 0 else { return }
+        inputFillerCount = 0
+        textInputStorage = ""
+        let start = TextPosition(offset: 0)
+        _selectedTextRange = TextRange(from: start, to: start)
+        _markedTextRange = nil
     }
 
     func isAutoPeriodReplacement(_ text: String) -> Bool {
@@ -2130,6 +2211,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     }
 
     private func commitTextInput(_ text: String, applyModifiers: Bool) {
+        // Multiplex patch: real input never coexists with the backspace filler —
+        // drop it before anything reads the buffer, so every path below sees the
+        // empty document it was written against.
+        clearInputFiller()
         // Multiplex patch: on iOS-app-on-Mac the Cocoa text system owns
         // hardware Return — Shift+Return never reaches pressesBegan with its
         // modifier and arrives here as a bare "\n". The physical shift state
@@ -2730,7 +2815,11 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     }
 
     private func trackKoreanResyllabificationDeletion(_ deletedText: Substring, range: TextRange) {
+        // Multiplex patch: deleted filler is not text the user composed, so it
+        // must never open a resyllabification transaction — the buffer is all
+        // filler whenever the count is non-zero.
         guard isKoreanTextInput,
+              inputFillerCount == 0,
               _markedTextRange == nil,
               range.endPosition.offset == textInputStorage.textInputUTF16Count else {
             resetKoreanResyllabificationTransaction()
@@ -2755,6 +2844,10 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     
     open func deleteBackward() {
         uitiLog("deleteBackward() \(textInputStateDescription())")
+
+        // Multiplex patch: make sure a held delete key has something to consume
+        // before the ranges below are read. See the input filler section.
+        seedInputFillerIfNeeded()
 
         // after backward deletion, marked range is always cleared, and length of selected range is always zero
         let rangeToDelete = _markedTextRange ?? _selectedTextRange
@@ -2813,6 +2906,20 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         _selectedTextRange = TextRange(from: rangeStartPosition, to: rangeStartPosition)
 
         endTextInputEdit()
+
+        // Multiplex patch: re-stock the filler for the next repeat tick. The
+        // buffer is all filler whenever the count is non-zero, so what survived
+        // the delete is simply what is left. Restocking happens *after*
+        // `endTextInputEdit` on purpose: the keyboard is told the shortened
+        // document this delete produced — it has to see the delete do something
+        // — and finds a full buffer again on its next read, so a held key never
+        // runs the document dry. Deleting the last of the user's own typed text
+        // lands here too, which is what lets a hold continue past it into text
+        // the remote owns.
+        if inputFillerCount > 0 {
+            inputFillerCount = textInputStorage.count
+        }
+        seedInputFillerIfNeeded()
     }
 
     enum SendData {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTextInput.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTextInput.swift
@@ -142,6 +142,10 @@ extension TerminalView: UITextInput {
     }
     
     public func replace(_ range: UITextRange, withText text: String) {
+        // Multiplex patch: an incoming range addresses the real document, so the
+        // backspace filler must be cleared before it is coerced against the
+        // buffer. Ranges the caller derived from filler are dropped with it.
+        clearInputFiller()
         guard let r = coerceTextRange(range) else { return }
 
         guard _markedTextRange == nil else { return }
@@ -251,6 +255,9 @@ extension TerminalView: UITextInput {
 
     public func setMarkedText(_ markedText: String?, selectedRange: NSRange) {
         uitiLog("setMarkedText(\(markedText?.debugDescription ?? "nil"), selectedRange:\(selectedRange)) \(textInputStateDescription())")
+        // Multiplex patch: composition is real input — the backspace filler must
+        // be gone before any marked range is computed against the buffer.
+        clearInputFiller()
         resetKoreanResyllabificationTransaction()
 
         let rangeToReplace = _markedTextRange ?? _selectedTextRange
@@ -348,6 +355,8 @@ extension TerminalView: UITextInput {
         beginTextInputEdit()
         pendingAutoPeriodDeleteWasSpace = false
         resetKoreanResyllabificationTransaction()
+        // Multiplex patch: the filler lives in this buffer, so it resets with it.
+        inputFillerCount = 0
         textInputStorage = ""
         _selectedTextRange = TextRange (from: TextPosition(offset: 0), to: TextPosition(offset: 0))
         _markedTextRange = nil


### PR DESCRIPTION
## The bug

Attach to a session that already has text at the prompt, then hold backspace: nothing repeats. Every delete is a separate tap. Text typed in the app *does* delete on a hold, which is what made this look intermittent rather than conditional.

## Why

iOS doesn't run a dumb timer for a held delete key. Once it accelerates it deletes **word-wise**, and to find a word boundary it reads the real characters of the `UITextInput` document. SwiftTerm's document — `textInputStorage` — only ever mirrors what was typed through that view. For text that came from anywhere else (typed before the attach, sent by another client, echoed by the remote) the document is empty, so the repeat starves immediately.

Upstream [SwiftTerm #271](https://github.com/migueldeicaza/SwiftTerm/issues/271), *"Backspace button will not auto-repeat if it encounters a space"*, is the milder form of the same mismatch — open and undiagnosed since 2023.

## What's here

The buffer is stocked with filler whenever it holds nothing real, and each filler character the keyboard consumes becomes one backspace byte.

The load-bearing invariant is that **filler exists only while there is no real text** — `commitTextInput`, `setMarkedText`, and `replace` clear it before reading the buffer. That keeps filler from ever sitting beside typed text, where a word-wise delete spanning the boundary would over-count backspaces, and away from the `.last` / `.suffix()` / caret-at-end reads behind auto-period and Korean resyllabification. Filler deletions are also barred from opening a resyllabification transaction.

Restocking runs *after* `endTextInputEdit` deliberately: the keyboard is told the shortened document this delete produced — it has to see the delete do something — and finds a full buffer again on its next read. Deleting the last of your own typed text lands there too, which is what lets a hold continue past it into text the remote owns. Geometry is untouched (`caretRect`/`firstRect` answer from the terminal caret, not buffer offsets).

## Two dead ends, recorded so they aren't retried

Both were tried first and neither moved the symptom:

- `hasText` returning `true` — says *whether* text exists, not what can be consumed.
- Reporting the delete to `inputDelegate` — says something *changed*.

The `hasText` correction is kept regardless, since a terminal's document is the remote screen and reporting the local mirror answered about the wrong one, but its comment now states plainly that it does not fix the repeat. The `inputDelegate` change is reverted — unproven churn in a vendored patch set that has to be re-applied on every SwiftTerm bump.

## ⚠ Not verified

There is no headless way to hold a software key: Xcode 27 simulators have no touch injection, and the delete key's repeat comes from the keyboard rather than the app. This rests on reading iOS behaviour and needs a device pass. The mechanism is the reading that fits the symptom, #271, and both failed attempts — it is **not** confirmed at the UIKit level.

Worth checking on device:

- **Japanese/Korean input** — composition, candidates, commit. This is the real risk; a regression would be a mutation path reading the buffer without clearing filler first.
- **Over-deletion** — hold backspace on a line you typed and confirm it doesn't run past it faster than it should. `inputFillerLength` (16) bounds the per-tick burst.
- **Nothing typing `x`** — filler never leaves the local buffer, but that's the immediate tell if this is wrong.

iPad and visionOS build; 507 unit tests pass (none cover this path).