### PR TITLE
Swap the key rail's keyboard key for dictation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,21 @@ path (disposable tmux sessions only), and
 `… -p app.multiplexterm.multiplex.debug.keybar` runs the focused terminal's
 iPad key-bar proof sequence — the four symbol keys plus a latched CTRL
 consumed by a typed `c`, so a shell prompt capture shows `~|/-^C`, and
+`… -p app.multiplexterm.multiplex.debug.dictation` presses the rail's
+dictation key (the slot the hardware keyboard swaps in, which the simulator
+always shows). Grant both permissions first or the press parks on a system
+alert: `xcrun simctl privacy <UDID> grant microphone
+app.multiplexterm.multiplex` covers the mic, but simctl has no
+speech-recognition service — with the device **shut down**, insert
+`kTCCServiceSpeechRecognition` into
+`~/Library/Developer/CoreSimulator/Devices/<UDID>/data/Library/TCC/TCC.db`
+(a write while it is booted is ignored by the running tccd). Point the
+simulator at a real input under Device → Audio Input to transcribe; with
+silence the walk still proves the whole path — LISTENING appears, the 30 s
+silence timeout ends it (or press the hook a second time, which is STOP), and
+`tmux capture-pane` shows nothing typed. The on-device
+verdict is logged (subsystem `app.multiplexterm.multiplex`, category
+`dictation`, debug level — `log stream`, not `log show`), and
 `… -p app.multiplexterm.multiplex.keycluster` runs the visionOS ornament
 key cluster's proof — ESC and TAB through its send path plus a latched CTRL
 consumed by a typed `c` (a raw-mode `dd bs=1 count=3 | od -c` in the pane
@@ -497,9 +512,10 @@ views.
 - **The iPad key rail is app-owned chrome, never an `inputAccessoryView`**:
   `TerminalKeyBar` is a TALLY rail (ESC / latching CTRL / TAB, the shell
   symbols `~ | / -`, DECCKM-aware autorepeat arrows, an iPad-only RET
-  immediately to their right, and the keyboard toggle —
-  `TerminalFocusArbiter.toggle`, the app's only keyboard show/hide control
-  since the KBD chips were retired) installed as a normal sibling beneath
+  immediately to their right, and one slot that is either the keyboard toggle
+  — `TerminalFocusArbiter.toggle`, the app's only keyboard show/hide control
+  since the KBD chips were retired — or, while a physical keyboard is
+  attached, the dictation key described below) installed as a normal sibling beneath
   `TerminalView`. A physical-iPad A/B proved that even
   assigning the custom rail to `inputAccessoryView` makes TextInputUI rehost it
   while a Stage Manager window moves, repeatedly reactivating the floating
@@ -515,7 +531,8 @@ views.
   Its popover opens downward; while it is presented, the focus arbiter
   temporarily resigns the terminal so a docked software keyboard cannot clip
   the fixed command grid, then restores input only if that tab still owns it.
-  ESC/CTRL/TAB, all four arrows, and the keyboard toggle never leave the rail;
+  ESC/CTRL/TAB, all four arrows, and the keyboard/dictation slot never leave
+  the rail;
   RET likewise stays present on iPad, while iPhone omits it to preserve the
   phone-width ladder. Every key sends through `TerminalView.send` → delegate →
   the controller's ordered pump (never a side channel); CTRL rides SwiftTerm's public
@@ -556,6 +573,38 @@ views.
   `commitTextInput` prefers that (invisible) accessory's `controlModifier`
   over the view-level one — `SwiftTermView` nils `inputAccessoryView` there
   so the cluster's latch is authoritative; don't remove that.
+- **A physical keyboard turns the rail's keyboard toggle into a dictation
+  key** (`HardwareKeyboardMonitor`, `DictationSession`, `DictationText` —
+  pure + tested; the pane's `DictationBar`). iOS suppresses the software
+  keyboard outright while a hardware keyboard is attached, so the toggle has
+  nothing left to toggle; the slot spends itself on the one affordance the
+  hardware keyboard lacks — the mic key the software keyboard would have
+  carried. Detection is `GCKeyboard.coalesced` plus its connect/disconnect
+  notifications: **UIKit cannot answer this question**, because keyboard-frame
+  notifications describe only the software keyboard, whose absence is exactly
+  what a hardware keyboard causes. iOS also exposes no way to *trigger* system
+  dictation, so the key runs recognition itself (Speech + AVAudioEngine),
+  requesting `requiresOnDeviceRecognition` wherever the locale supports it —
+  a terminal's input is the most sensitive text in the app, and the recognizer
+  is the one place it would otherwise leave the device outside the user's own
+  SSH connection. Three rules the implementation holds to: **nothing is typed
+  until the dictation finishes** (the recognizer rewrites earlier words as it
+  refines its hypothesis and a terminal cannot take a byte back — the live
+  partial is bar-only); the finished text is typed through `TerminalView.send`
+  → delegate → ordered pump like every other rail key, sanitized to one line
+  with no control bytes (`DictationText`) and **never submitted**, the same
+  discipline as a dropped file's path; and **LISTENING means the microphone is
+  open**, never merely that the key was pressed — the first press waits behind
+  two system permission alerts, so the rail key latches on the press while the
+  bar waits for `AVAudioEngine.start()`. Recognition stops itself after 30 s
+  of quiet (5 min hard cap) — deliberately far longer than system dictation's
+  pause, because what gets dictated here is an agent prompt and a mid-sentence
+  think must not end the take. One session holds the
+  mic app-wide: a second tab starting takes it rather than failing. Free rail
+  plumbing, not an agent-helper surface. ⚠ In the simulator DeviceHub always
+  bridges the Mac keyboard as *hardware*, so the mic key — not the keyboard
+  key — is what every screenshot run captures; the no-hardware-keyboard branch
+  can only be seen on a device with no keyboard attached.
 - **Copy Mode is an app-owned interaction state over tmux's remote mode**:
   the shortcut still sends stock `Ctrl-B [` through SwiftTerm and the ordered
   pump, then `TerminalSessionController` temporarily disables SwiftTerm mouse

--- a/Multiplex/Info.plist
+++ b/Multiplex/Info.plist
@@ -39,6 +39,10 @@
 	<string>Multiplex unlocks with Face ID when the optional App Lock setting is turned on.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Multiplex connects to SSH hosts on your local network.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Multiplex listens only while you hold a dictation going from the terminal key bar.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Multiplex transcribes your dictation so the words can be typed into the terminal session you are attached to. Recognition stays on device wherever your language supports it.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Multiplex/Models/DictationText.swift
+++ b/Multiplex/Models/DictationText.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Dictated speech is composer input, not a command: it is typed into the
+/// pane exactly like a dropped file's path and never submitted (see
+/// `DropText`). The recognizer hands back prose, so the only work here is
+/// making it safe to hand to a shell that may be sitting at a prompt.
+///
+/// Nothing is quoted or escaped — unlike a generated path, this text is the
+/// user's own words, and a shell-quoted sentence would be useless in an
+/// agent composer. What *is* removed is anything that would act rather than
+/// read: control bytes (an ESC would start an escape sequence, a CR would
+/// submit the line the user is still dictating into) and the line breaks a
+/// spoken "new line" can produce.
+enum DictationText {
+    /// The bytes to type for one finished dictation, or nil if the
+    /// recognizer heard nothing worth sending.
+    static func typed(_ raw: String) -> String? {
+        var words: [String] = []
+        var current = ""
+        for scalar in raw.unicodeScalars {
+            // Control characters and every line/paragraph separator collapse
+            // to a word break rather than being dropped outright, so
+            // "line one\nline two" cannot become "line oneline two".
+            if scalar.properties.generalCategory == .control
+                || scalar.properties.generalCategory == .lineSeparator
+                || scalar.properties.generalCategory == .paragraphSeparator
+                || CharacterSet.whitespacesAndNewlines.contains(scalar) {
+                if !current.isEmpty {
+                    words.append(current)
+                    current = ""
+                }
+                continue
+            }
+            current.unicodeScalars.append(scalar)
+        }
+        if !current.isEmpty { words.append(current) }
+        let text = words.joined(separator: " ")
+        return text.isEmpty ? nil : text
+    }
+
+    /// The live partial shown in the dictation bar. Same sanitizing, but a
+    /// long dictation must not push the bar past the window, so the tail is
+    /// kept — that is the part still being refined.
+    static func preview(_ raw: String, limit: Int = 60) -> String {
+        guard let text = typed(raw) else { return "" }
+        guard text.count > limit else { return text }
+        return "…" + String(text.suffix(limit))
+    }
+}

--- a/Multiplex/Services/DictationSession.swift
+++ b/Multiplex/Services/DictationSession.swift
@@ -1,0 +1,292 @@
+#if !os(visionOS)
+import AVFoundation
+import Foundation
+import Speech
+import os
+
+/// One live dictation: microphone → Speech framework → a finished string the
+/// pane types into its session.
+///
+/// iOS exposes no way to *trigger* the system keyboard's dictation, and with
+/// a hardware keyboard attached that keyboard (and its mic key) never appears
+/// at all — so the rail's dictation key runs recognition itself. On-device
+/// recognition is requested whenever the locale supports it: a terminal's
+/// input is the most sensitive text in the app, and the recognizer is the one
+/// place it would otherwise leave the device outside the user's own SSH
+/// connection.
+///
+/// Only one session may hold the microphone at a time, so starting a new one
+/// cancels whatever was listening — a second terminal tab takes the mic, it
+/// does not fail.
+///
+/// Nothing is typed until the dictation finishes. Partial results are shown
+/// in the pane's dictation bar only: the recognizer rewrites earlier words as
+/// it refines its hypothesis, and a terminal has no way to take a byte back.
+@MainActor
+final class DictationSession {
+    enum Outcome {
+        /// Everything the recognizer heard, unsanitized.
+        case text(String)
+        case cancelled
+        case failure(String)
+    }
+
+    /// The session currently holding the microphone, if any.
+    private static weak var active: DictationSession?
+
+    private static let logger = Logger(
+        subsystem: "app.multiplexterm.multiplex",
+        category: "dictation"
+    )
+
+    /// Recognition stops itself after this much quiet. Deliberately far
+    /// longer than system dictation's pause: what gets dictated here is a
+    /// prompt for a CLI agent, and thinking mid-sentence must not end the
+    /// take and type half a thought into the pane. STOP is the normal way
+    /// to finish; this is the backstop for walking away.
+    private static let silenceTimeout: Duration = .seconds(30)
+    /// Runaway stop: a forgotten open mic is a battery and privacy problem.
+    private static let maximumDuration: Duration = .seconds(5 * 60)
+    /// How long to wait for the recognizer's final result after the audio
+    /// ends. The tail of a sentence usually lands within a few hundred ms.
+    private static let finalResultTimeout: Duration = .seconds(2)
+
+    private let engine = AVAudioEngine()
+    private var recognizer: SFSpeechRecognizer?
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+    private var onStart: (() -> Void)?
+    private var onPartial: ((String) -> Void)?
+    private var onFinish: ((Outcome) -> Void)?
+    private var transcript = ""
+    private var silenceTask: Task<Void, Never>?
+    private var capTask: Task<Void, Never>?
+    private var finalResultTask: Task<Void, Never>?
+    private var finishing = false
+
+    private(set) var isListening = false
+
+    /// Ask for microphone + speech access, open the mic, and start
+    /// recognizing.
+    ///
+    /// `onStart` fires only once the microphone is genuinely open — the first
+    /// press can sit behind two system permission alerts, and a pane that
+    /// claims to be LISTENING while one is on screen is lying about a live
+    /// microphone. `onFinish` is called exactly once per start, including
+    /// when authorization is refused or another session takes the mic away.
+    func start(
+        onStart: @escaping () -> Void,
+        onPartial: @escaping (String) -> Void,
+        onFinish: @escaping (Outcome) -> Void
+    ) {
+        guard !isListening else { return }
+        Self.active?.cancel()
+        self.onStart = onStart
+        self.onPartial = onPartial
+        self.onFinish = onFinish
+        Task { await authorizeAndBegin() }
+    }
+
+    /// Finish normally: stop the audio, wait briefly for the recognizer's
+    /// final pass, then deliver everything it heard.
+    func stop() {
+        guard isListening, !finishing else { return }
+        finishing = true
+        silenceTask?.cancel()
+        capTask?.cancel()
+        stopAudio()
+        request?.endAudio()
+        finalResultTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.finalResultTimeout)
+            guard !Task.isCancelled, let self else { return }
+            deliver(.text(transcript))
+        }
+    }
+
+    /// Abandon the dictation without typing anything. Deliberately not gated
+    /// on `isListening`: a cancel can land while authorization is still
+    /// outstanding, and that must stop the microphone from ever opening.
+    func cancel() {
+        guard onFinish != nil else { return }
+        deliver(.cancelled)
+    }
+
+    // MARK: Authorization
+
+    private func authorizeAndBegin() async {
+        guard await Self.requestSpeechAuthorization() else {
+            deliver(.failure("Speech recognition access is off in Settings"))
+            return
+        }
+        guard await Self.requestMicrophoneAccess() else {
+            deliver(.failure("Microphone access is off in Settings"))
+            return
+        }
+        begin()
+    }
+
+    private static func requestSpeechAuthorization() async -> Bool {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized: return true
+        case .denied, .restricted: return false
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization { status in
+                    continuation.resume(returning: status == .authorized)
+                }
+            }
+        @unknown default: return false
+        }
+    }
+
+    private static func requestMicrophoneAccess() async -> Bool {
+        switch AVAudioApplication.shared.recordPermission {
+        case .granted: return true
+        case .denied: return false
+        case .undetermined:
+            return await withCheckedContinuation { continuation in
+                AVAudioApplication.requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        @unknown default: return false
+        }
+    }
+
+    // MARK: Recognition
+
+    private func begin() {
+        // A cancel that landed while authorization was outstanding already
+        // delivered its outcome; do not open the microphone behind it.
+        guard onFinish != nil, !isListening else { return }
+
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            deliver(.failure("Dictation isn't available for this language"))
+            return
+        }
+        self.recognizer = recognizer
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        // Keep the words on the device wherever the locale allows it. Where
+        // it does not, Apple's service does the transcription — the same
+        // boundary the system keyboard's own dictation key has.
+        request.requiresOnDeviceRecognition = recognizer.supportsOnDeviceRecognition
+        self.request = request
+
+        do {
+            let audio = AVAudioSession.sharedInstance()
+            try audio.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try audio.setActive(true, options: .notifyOthersOnDeactivation)
+            let input = engine.inputNode
+            input.removeTap(onBus: 0)
+            input.installTap(
+                onBus: 0,
+                bufferSize: 1024,
+                format: input.outputFormat(forBus: 0)
+            ) { buffer, _ in
+                request.append(buffer)
+            }
+            engine.prepare()
+            try engine.start()
+        } catch {
+            Self.logger.error("dictation-audio-failed \(error.localizedDescription, privacy: .public)")
+            stopAudio()
+            self.request = nil
+            deliver(.failure("The microphone couldn't be opened"))
+            return
+        }
+
+        isListening = true
+        Self.active = self
+        transcript = ""
+        Self.logger.debug(
+            "dictation-start onDevice=\(request.requiresOnDeviceRecognition, privacy: .public)"
+        )
+        onStart?()
+        onStart = nil
+
+        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            Task { @MainActor [weak self] in
+                self?.handle(result: result, error: error)
+            }
+        }
+        armSilenceTimer()
+        capTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.maximumDuration)
+            guard !Task.isCancelled else { return }
+            self?.stop()
+        }
+    }
+
+    private func handle(result: SFSpeechRecognitionResult?, error: Error?) {
+        guard isListening else { return }
+        if let result {
+            transcript = result.bestTranscription.formattedString
+            onPartial?(transcript)
+            if result.isFinal {
+                deliver(.text(transcript))
+                return
+            }
+            armSilenceTimer()
+        }
+        guard let error else { return }
+        // After `endAudio()` the recognizer reports the shutdown as an error
+        // even though the transcript is good — this is the normal finish.
+        if finishing {
+            deliver(.text(transcript))
+            return
+        }
+        Self.logger.error("dictation-failed \(error.localizedDescription, privacy: .public)")
+        deliver(transcript.isEmpty
+            ? .failure("Dictation stopped unexpectedly")
+            : .text(transcript))
+    }
+
+    private func armSilenceTimer() {
+        guard !finishing else { return }
+        silenceTask?.cancel()
+        silenceTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.silenceTimeout)
+            guard !Task.isCancelled else { return }
+            self?.stop()
+        }
+    }
+
+    // MARK: Teardown
+
+    private func deliver(_ outcome: Outcome) {
+        let finish = onFinish
+        onStart = nil
+        onPartial = nil
+        onFinish = nil
+        silenceTask?.cancel()
+        capTask?.cancel()
+        finalResultTask?.cancel()
+        silenceTask = nil
+        capTask = nil
+        finalResultTask = nil
+        stopAudio()
+        task?.cancel()
+        task = nil
+        request = nil
+        recognizer = nil
+        isListening = false
+        finishing = false
+        if Self.active === self { Self.active = nil }
+        finish?(outcome)
+    }
+
+    private func stopAudio() {
+        if engine.isRunning { engine.stop() }
+        engine.inputNode.removeTap(onBus: 0)
+        // Handing the session back can block briefly; the pane has already
+        // moved on by the time it completes.
+        Task.detached {
+            try? AVAudioSession.sharedInstance().setActive(
+                false, options: .notifyOthersOnDeactivation
+            )
+        }
+    }
+}
+#endif

--- a/Multiplex/Services/HardwareKeyboardMonitor.swift
+++ b/Multiplex/Services/HardwareKeyboardMonitor.swift
@@ -1,0 +1,68 @@
+#if !os(visionOS)
+import Foundation
+import GameController
+
+/// Whether a physical keyboard is attached to this device right now.
+///
+/// GameController is the only public API that answers the question directly.
+/// UIKit cannot: keyboard-frame notifications describe the *software*
+/// keyboard, and a hardware keyboard suppresses that entirely — so "no
+/// frames" is indistinguishable from "the user dismissed it". `GCKeyboard`
+/// reports at the HID layer instead, which covers every iPad case alike
+/// (Magic Keyboard, Smart Keyboard Folio, Bluetooth), and is the same layer
+/// SwiftTerm's iOS-on-Mac control-key bridge already listens on.
+///
+/// The key rail uses this to decide what its rightmost key does. With a
+/// hardware keyboard attached the software keyboard cannot be summoned at
+/// all, so the keyboard toggle has nothing to toggle; the rail offers
+/// dictation there instead — the one input affordance the hardware keyboard
+/// itself does not carry.
+///
+/// ⚠ Simulator: Xcode's DeviceHub always bridges the Mac keyboard as a
+/// *hardware* keyboard (CoreDevice HID), so this reads true in every
+/// simulator run. That is correct — it is genuinely a hardware keyboard —
+/// but it means the mic key, not the keyboard key, is what screenshot runs
+/// capture.
+@Observable
+@MainActor
+final class HardwareKeyboardMonitor {
+    static let shared = HardwareKeyboardMonitor()
+
+    private(set) var isConnected = false
+    private var observing = false
+
+    private init() {}
+
+    /// Idempotent: every key rail calls this, only the first one installs.
+    func startIfNeeded() {
+        guard !observing else { return }
+        observing = true
+        isConnected = GCKeyboard.coalesced != nil
+        for name in [Notification.Name.GCKeyboardDidConnect,
+                     Notification.Name.GCKeyboardDidDisconnect] {
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.refresh() }
+            }
+        }
+    }
+
+    private func refresh() {
+        apply(GCKeyboard.coalesced != nil)
+        // The disconnect notification can arrive before GameController has
+        // rebuilt `coalesced`, and a second keyboard may still be attached.
+        // Settle on the next turn so the rail never latches a stale answer.
+        DispatchQueue.main.async { [weak self] in
+            self?.apply(GCKeyboard.coalesced != nil)
+        }
+    }
+
+    private func apply(_ connected: Bool) {
+        guard isConnected != connected else { return }
+        isConnected = connected
+    }
+}
+#endif

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -158,6 +158,24 @@ final class TerminalSessionController {
     /// output, so the destination is shown first (see `TerminalLink`).
     private(set) var pendingLink: TerminalLink?
 
+    #if !os(visionOS)
+    /// The rail's dictation key, from the pane's side: LISTENING while the
+    /// microphone is open (the bar shows the live hypothesis), or a short
+    /// failure the user can act on.
+    enum DictationState: Equatable {
+        case listening(String)
+        case failed(String)
+    }
+    private(set) var dictation: DictationState?
+    private var dictationSession: DictationSession?
+    private var dictationClearTask: Task<Void, Never>?
+    /// The key has been pressed and a dictation is in flight — which starts
+    /// before `dictation` does, because the first press waits on the system's
+    /// microphone and speech-recognition alerts. The rail's key latches on
+    /// this; the pane's LISTENING bar waits for the microphone itself.
+    private var dictationRequested = false
+    #endif
+
     init(route: TerminalRoute, host: Host, attention: AttentionCenter? = nil) {
         self.route = route
         self.host = host
@@ -792,6 +810,88 @@ final class TerminalSessionController {
         terminalView.send(EscapeSequences.cmdEsc)
     }
 
+    #if !os(visionOS)
+    /// What the rail's key shows: engaged from the press, not from the mic,
+    /// so a permission alert never leaves the key looking untouched.
+    var isDictating: Bool { dictationRequested }
+
+    /// The rail's dictation key. It replaces the keyboard toggle only while a
+    /// hardware keyboard is attached, so this is always the key the user
+    /// pressed rather than a second way to reach the software keyboard.
+    func toggleDictation() {
+        if dictationRequested {
+            stopDictation()
+        } else {
+            startDictation()
+        }
+    }
+
+    /// Finish and type what was heard. The recognizer gets a moment to make
+    /// its final pass first, so the tail of a sentence is not lost. A press
+    /// that has not reached the microphone yet has nothing to type, so it
+    /// simply abandons the attempt.
+    func stopDictation() {
+        guard let dictationSession else { return }
+        if dictationSession.isListening {
+            dictationSession.stop()
+        } else {
+            dictationSession.cancel()
+        }
+    }
+
+    /// Leave without typing anything.
+    func cancelDictation() {
+        dictationSession?.cancel()
+    }
+
+    private func startDictation() {
+        guard status == .live else { return }
+        // The jump search owns the pane's input while it pages the remote
+        // transcript; dictated text would interleave with its PgUp stream.
+        if case .finding = historyJump { return }
+        dictationClearTask?.cancel()
+        dictation = nil
+        dictationRequested = true
+        let session = dictationSession ?? DictationSession()
+        dictationSession = session
+        session.start(
+            onStart: { [weak self] in
+                guard let self, dictationRequested else { return }
+                dictation = .listening("")
+            },
+            onPartial: { [weak self] partial in
+                guard let self, dictationRequested else { return }
+                dictation = .listening(DictationText.preview(partial))
+            },
+            onFinish: { [weak self] outcome in
+                self?.finishDictation(outcome)
+            }
+        )
+    }
+
+    private func finishDictation(_ outcome: DictationSession.Outcome) {
+        dictationRequested = false
+        dictation = nil
+        switch outcome {
+        case .text(let raw):
+            // Typed exactly like a rail key or a dropped file's path —
+            // through SwiftTerm and the ordered input pump, never submitted.
+            guard let text = DictationText.typed(raw), let terminalView else { return }
+            terminalView.send(txt: text)
+        case .cancelled:
+            break
+        case .failure(let message):
+            dictation = .failed(message)
+            dictationClearTask?.cancel()
+            dictationClearTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(4))
+                guard !Task.isCancelled else { return }
+                if case .failed = self?.dictation { self?.dictation = nil }
+            }
+        }
+    }
+    #endif
+
     private func setTmuxCopyModeUIActive(_ active: Bool) {
         guard tmuxCopyModeUIActive != active else { return }
         tmuxCopyModeUIActive = active
@@ -1342,6 +1442,15 @@ final class TerminalSessionController {
     /// handshake ends mosh-server, which HUPs its tmux client.)
     func detach() {
         cancelPendingResume()
+        #if !os(visionOS)
+        // The tab is going away — release the microphone rather than typing
+        // into a session that no longer exists.
+        dictationClearTask?.cancel()
+        dictationSession?.cancel()
+        dictationSession = nil
+        dictationRequested = false
+        dictation = nil
+        #endif
         dropTask?.cancel()
         dropTask = nil
         dropClearTask?.cancel()

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -110,6 +110,7 @@ struct SwiftTermView: UIViewRepresentable {
         let container = KeyboardAvoidingContainer()
         let keyBar = TerminalKeyBar(
             terminal: view,
+            controller: controller,
             performTmuxShortcut: { [weak controller] shortcut in
                 controller?.performTmuxShortcut(shortcut)
             },

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -37,6 +37,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     }
 
     private weak var terminal: TerminalView?
+    private weak var controller: TerminalSessionController?
     private let performTmuxShortcut: (TmuxShortcut) -> Void
     private let finishTmuxCopyMode: () -> Void
     private let showsTmuxShortcuts: Bool
@@ -46,19 +47,27 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
 
     init(
         terminal: TerminalView,
+        controller: TerminalSessionController?,
         performTmuxShortcut: @escaping (TmuxShortcut) -> Void,
         finishTmuxCopyMode: @escaping () -> Void,
         showsTmuxShortcuts: Bool
     ) {
         self.terminal = terminal
+        self.controller = controller
         self.performTmuxShortcut = performTmuxShortcut
         self.finishTmuxCopyMode = finishTmuxCopyMode
         self.showsTmuxShortcuts = showsTmuxShortcuts
         super.init(frame: .zero)
         model.ctrlLatched = terminal.controlModifier
+        // The rightmost key depends on whether a physical keyboard is
+        // attached, which can change at any moment (a Magic Keyboard is
+        // detached mid-session all the time).
+        HardwareKeyboardMonitor.shared.startIfNeeded()
 
         let host = UIHostingController(rootView: KeyBarRow(
             model: model,
+            controller: controller,
+            hardwareKeyboard: HardwareKeyboardMonitor.shared,
             showsTmuxShortcuts: showsTmuxShortcuts,
             showsReturnKey: UIDevice.current.userInterfaceIdiom == .pad,
             press: { [weak self] key in self?.press(key) }
@@ -136,6 +145,8 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
             terminal.send(EscapeSequences.cmdPageDown)
         case .keyboard:
             TerminalFocusArbiter.toggle(terminal)
+        case .dictation:
+            controller?.toggleDictation()
         case .showTmuxShortcuts:
             showTmuxShortcuts()
         case .tmux(let shortcut):
@@ -248,6 +259,16 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         press(.tmux(shortcut))
     }
 
+    /// Presses the rail's dictation key without touching the screen. The
+    /// simulator can be pointed at the Mac's microphone (Device → Audio
+    /// Input), so this drives the whole authorization → mic → recognizer →
+    /// ordered-pump path; the attached session's `tmux capture-pane` shows
+    /// the transcribed words typed at the prompt.
+    func debugToggleDictation() {
+        guard let terminal, TerminalFocusArbiter.current === terminal else { return }
+        press(.dictation)
+    }
+
     /// Headless proof sequence: the four symbol keys through the bar's own
     /// send path, then a latched CTRL consumed by a software-keyboard 'c' —
     /// at a shell prompt `tmux capture-pane` shows `~|/-^C`.
@@ -283,6 +304,7 @@ private enum TerminalKey {
     case up, down, left, right
     case pageUp, pageDown
     case keyboard
+    case dictation
     case showTmuxShortcuts
     case tmux(TmuxShortcut)
 }
@@ -296,6 +318,10 @@ private enum TerminalKey {
 /// available, and the iPhone shell moves the shortcut to its top-right bar.
 private struct KeyBarRow: View {
     var model: TerminalKeyBar.Model
+    /// Only for the dictation key's live state; every key still sends
+    /// through the bar's own `TerminalView` path.
+    var controller: TerminalSessionController?
+    var hardwareKeyboard: HardwareKeyboardMonitor
     var showsTmuxShortcuts: Bool
     var showsReturnKey: Bool
     var press: (TerminalKey) -> Void
@@ -389,14 +415,32 @@ private struct KeyBarRow: View {
             if showsReturnKey {
                 capsKey("RET", .returnKey, "Return", metric: metric)
             }
-            Key(
-                action: { press(.keyboard) },
-                width: metric.keyWidth,
-                faceHorizontalInset: metric.faceHorizontalInset,
-                accessibilityText: "Show or hide keyboard"
-            ) {
-                Image(systemName: "keyboard")
-                    .font(.ui(13, weight: .semibold))
+            // A physical keyboard suppresses the software one outright, so
+            // the toggle has nothing left to toggle. Spend the slot on the
+            // affordance the hardware keyboard genuinely lacks instead —
+            // the mic key the software keyboard would have carried.
+            if hardwareKeyboard.isConnected {
+                let listening = controller?.isDictating == true
+                Key(
+                    action: { press(.dictation) },
+                    width: metric.keyWidth,
+                    faceHorizontalInset: metric.faceHorizontalInset,
+                    latched: listening,
+                    accessibilityText: listening ? "Stop dictation" : "Dictate"
+                ) {
+                    Image(systemName: listening ? "mic.fill" : "mic")
+                        .font(.ui(13, weight: .semibold))
+                }
+            } else {
+                Key(
+                    action: { press(.keyboard) },
+                    width: metric.keyWidth,
+                    faceHorizontalInset: metric.faceHorizontalInset,
+                    accessibilityText: "Show or hide keyboard"
+                ) {
+                    Image(systemName: "keyboard")
+                        .font(.ui(13, weight: .semibold))
+                }
             }
             if showsTmux {
                 // Keep the tmux dropdown at the rail's trailing edge until
@@ -607,6 +651,17 @@ enum KeyBarDebugHook {
             else { return }
             bar.debugExercise()
         }
+
+        var dictationToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.dictation", &dictationToken, .main
+        ) { _ in
+            guard let view = TerminalFocusArbiter.current,
+                  let bar = view.superview?.subviews
+                    .compactMap({ $0 as? TerminalKeyBar }).first
+            else { return }
+            bar.debugToggleDictation()
+        }
     }
 }
 #endif
@@ -615,6 +670,8 @@ enum KeyBarDebugHook {
 #Preview("iPad Key Bar") {
     KeyBarRow(
         model: TerminalKeyBar.Model(),
+        controller: nil,
+        hardwareKeyboard: HardwareKeyboardMonitor.shared,
         showsTmuxShortcuts: true,
         showsReturnKey: true,
         press: { _ in }
@@ -625,6 +682,8 @@ enum KeyBarDebugHook {
 #Preview("Compact Key Bar") {
     KeyBarRow(
         model: TerminalKeyBar.Model(),
+        controller: nil,
+        hardwareKeyboard: HardwareKeyboardMonitor.shared,
         showsTmuxShortcuts: true,
         showsReturnKey: false,
         press: { _ in }

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -1305,13 +1305,7 @@ private struct TerminalPane: View {
                 DropTargetVeil()
             }
         }
-        .overlay(alignment: .top) {
-            if isActive, let controller, controller.tmuxCopyModeUIActive {
-                TmuxCopyModeBar(done: controller.finishTmuxCopyMode)
-                    .padding(.horizontal, 12)
-                    .padding(.top, 12)
-            }
-        }
+        .overlay(alignment: .top) { topContextualBar }
         // Trailing, not centered: the find loop stops on the page where the
         // message entered from the top, so the jumped-to line is usually the
         // FIRST row — a centered bar would sit right on it.
@@ -1338,6 +1332,40 @@ private struct TerminalPane: View {
             }
             .padding(.bottom, 12)
         }
+    }
+
+    /// The pane's app-owned interaction states share one slot at the top —
+    /// they are alternatives, never simultaneous (copy mode freezes the
+    /// pane; dictation is refused while the jump search holds it).
+    @ViewBuilder
+    private var topContextualBar: some View {
+        if isActive, let controller {
+            if controller.tmuxCopyModeUIActive {
+                TmuxCopyModeBar(done: controller.finishTmuxCopyMode)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 12)
+            } else {
+                dictationBar(for: controller)
+            }
+        }
+    }
+
+    /// Dictation is app-owned recognition, so the pane says what it is
+    /// hearing: nothing reaches the session until the dictation finishes,
+    /// and the live hypothesis is the only feedback until then.
+    @ViewBuilder
+    private func dictationBar(for controller: TerminalSessionController) -> some View {
+        #if !os(visionOS)
+        if let state = controller.dictation {
+            DictationBar(
+                state: state,
+                stop: controller.stopDictation,
+                cancel: controller.cancelDictation
+            )
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+        }
+        #endif
     }
 
     @ViewBuilder
@@ -1433,6 +1461,55 @@ private struct TmuxCopyModeBar: View {
         .accessibilityElement(children: .contain)
     }
 }
+
+#if !os(visionOS)
+/// The dictation counterpart of `TmuxCopyModeBar`: an open microphone is
+/// live state, so it gets a captioned tally lamp and the running hypothesis
+/// beside it. STOP types what was heard; CANCEL throws it away — recognition
+/// also stops itself after a pause, exactly like system dictation.
+private struct DictationBar: View {
+    let state: TerminalSessionController.DictationState
+    var stop: () -> Void
+    var cancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 18) {
+            switch state {
+            case .listening(let heard):
+                TallyLamp(caption: "LISTENING")
+                if !heard.isEmpty {
+                    Text(heard)
+                        .font(.mono(12))
+                        .foregroundStyle(Theme.signal2)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                        .frame(maxWidth: 320, alignment: .leading)
+                }
+                ChassisChip("CANCEL", action: cancel)
+                ChassisChip("STOP", prominent: true, action: stop)
+            case .failed(let message):
+                TallyLamp(caption: "DICTATION", color: Theme.caution)
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(Theme.signal2)
+                    .lineLimit(2)
+                    .frame(maxWidth: 320, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            Theme.bezel,
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(Theme.bezelHi, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+    }
+}
+#endif
 
 /// Jump-to-message state over the terminal: FINDING while the remote script
 /// pages the transcript (input is locked, the veil below explains why), and

--- a/MultiplexTests/DictationTextTests.swift
+++ b/MultiplexTests/DictationTextTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Multiplex
+
+final class DictationTextTests: XCTestCase {
+    // MARK: Typed text
+
+    func testOrdinarySpeechIsTypedVerbatim() {
+        XCTAssertEqual(
+            DictationText.typed("run the tests again"),
+            "run the tests again"
+        )
+    }
+
+    func testNothingHeardTypesNothing() {
+        XCTAssertNil(DictationText.typed(""))
+        XCTAssertNil(DictationText.typed("   \n\t "))
+    }
+
+    func testSurroundingAndRepeatedWhitespaceCollapses() {
+        XCTAssertEqual(DictationText.typed("  hello   world  "), "hello world")
+    }
+
+    /// A spoken "new line" must never become a submit in a shell prompt or
+    /// an agent composer — it is a word break like any other.
+    func testLineBreaksBecomeWordBreaks() {
+        let typed = DictationText.typed("line one\nline two")
+        XCTAssertEqual(typed, "line one line two")
+        XCTAssertEqual(typed?.contains("\n"), false)
+        XCTAssertEqual(typed?.contains("\r"), false)
+    }
+
+    func testControlBytesCanNeverReachThePane() {
+        XCTAssertEqual(DictationText.typed("before\u{1B}[Aafter"), "before [Aafter")
+        XCTAssertEqual(DictationText.typed("a\u{0D}b"), "a b")
+        XCTAssertEqual(DictationText.typed("a\u{02}b"), "a b")
+    }
+
+    /// Dictated text is the user's own words, not a generated path — quoting
+    /// it the way `DropText` quotes a filename would make it useless.
+    func testPunctuationShellCharactersAndNonASCIISurvive() {
+        XCTAssertEqual(
+            DictationText.typed("git commit -m \"fix: retry\""),
+            "git commit -m \"fix: retry\""
+        )
+        XCTAssertEqual(DictationText.typed("重新執行測試"), "重新執行測試")
+        XCTAssertEqual(DictationText.typed("rm -rf $HOME/tmp"), "rm -rf $HOME/tmp")
+    }
+
+    // MARK: Bar preview
+
+    func testPreviewKeepsTheTailStillBeingRefined() {
+        let long = String(repeating: "word ", count: 40)
+        let preview = DictationText.preview(long, limit: 20)
+        XCTAssertTrue(preview.hasPrefix("…"))
+        XCTAssertEqual(preview.count, 21)
+        XCTAssertEqual(DictationText.preview("short one", limit: 20), "short one")
+        XCTAssertEqual(DictationText.preview("  ", limit: 20), "")
+    }
+}

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -20,8 +20,8 @@ behavior, or App Review flow changes.
 | Target release model | Free download with one non-consumable Pro unlock; confirm the base-app price manually |
 | Primary category | Developer Tools |
 | Secondary category | Utilities |
-| Privacy declaration | Target: Data Not Collected; selected files/photos and camera captures go directly to the user's SSH host; set/confirm manually in App Store Connect |
-| Runtime permissions | Camera only after FILE → Camera on iPad/iPhone; Local Network only for LAN hosts; Notifications only for enabled agent alerts; Face ID/Optic ID only when the optional App Lock setting is enabled (device passcode fallback). Photos/Files use system pickers. |
+| Privacy declaration | Target: Data Not Collected; selected files/photos and camera captures go directly to the user's SSH host; dictation audio is transcribed by Apple's Speech framework (on device wherever the locale supports it) and the resulting text is typed into the user's own session — Multiplex stores and transmits neither; set/confirm manually in App Store Connect |
+| Runtime permissions | Camera only after FILE → Camera on iPad/iPhone; Microphone + Speech Recognition only after the key rail's dictation key, which appears only while a physical keyboard is attached; Local Network only for LAN hosts; Notifications only for enabled agent alerts; Face ID/Optic ID only when the optional App Lock setting is enabled (device passcode fallback). Photos/Files use system pickers. |
 | Age rating | Target: all questionnaire answers None → 4+; complete/confirm manually |
 | Base-app price | Free; confirm in App Store Connect before submission |
 | Storefronts | Confirm intended coverage in App Store Connect; France needs the encryption step in the release playbook |

--- a/fastlane/metadata/review_information/notes.txt
+++ b/fastlane/metadata/review_information/notes.txt
@@ -11,6 +11,7 @@ CORE FLOW
 - Tap a tile to attach: the session opens in its own window wearing a red LIVE lamp. Attach a second session and place the windows side by side (each terminal is its own spatial window on Vision Pro; on iPad use Stage Manager).
 - MERGE in a terminal's bottom bar pulls another window's session in as a tab; a tab's context menu moves it back out into its own window. The shell stays connected while it moves.
 - TMUX in the Vision Pro bottom bar or iPad/iPhone key bar opens the shortcut menu (on narrow iPhones it moves to the top-right). Pick New Window, Split, or Copy Mode to send its displayed default Ctrl-B binding. In Copy Mode, swipe history, hold to select/copy, and press Done to exit.
+- The key bar's rightmost keyboard key becomes a dictation (microphone) key whenever a physical keyboard is attached — including a review device with a hardware keyboard, and always in the Simulator. Press it, speak, and the transcribed words are typed into the session; it stops itself after a pause, and STOP/CANCEL are on the bar it shows.
 - FILE attaches Photos/Files (and Camera on iPad), uploads into the active pane's working directory, and types the remote path without Return. Drops use the same pipeline.
 - DETACH closes the window; tmux keeps the session running, so its tile stays on the wall.
 
@@ -25,6 +26,7 @@ MOSH (Pro)
 
 PERMISSIONS
 - Camera: only after FILE → Camera on iPad; capture goes directly to the SSH host. Photos/Files need no library access.
+- Microphone and Speech Recognition: only after the key bar's dictation key. That key replaces the show/hide-keyboard key while a physical keyboard is attached, because iOS suppresses the software keyboard (and its mic key) in that state. Transcription uses Apple's Speech framework, on device wherever the language supports it, and the finished text is typed into the session without Return — Multiplex neither stores nor transmits the audio or the text.
 - Local Network: requested only when a host address is on the local network. The demo host is on the public internet, so you may never see this prompt.
 - Notifications: agent alerts, as above.
 

--- a/project.yml
+++ b/project.yml
@@ -80,6 +80,11 @@ targets:
         # Also covers Optic ID on visionOS (there is no separate key).
         NSFaceIDUsageDescription: Multiplex unlocks with Face ID when the optional App Lock setting is turned on.
         NSLocalNetworkUsageDescription: Multiplex connects to SSH hosts on your local network.
+        # The key rail's dictation key, offered in place of the software
+        # keyboard toggle while a hardware keyboard is attached. Both are
+        # requested only on the first press of that key.
+        NSMicrophoneUsageDescription: Multiplex listens only while you hold a dictation going from the terminal key bar.
+        NSSpeechRecognitionUsageDescription: Multiplex transcribes your dictation so the words can be typed into the terminal session you are attached to. Recognition stays on device wherever your language supports it.
         # multiplex://open?host=…&action=shell|agent — widget taps and
         # automation deep links (parsed by ExternalActionURL).
         CFBundleURLTypes:


### PR DESCRIPTION
With a physical keyboard attached, iOS suppresses the software keyboard outright — so the key rail's keyboard toggle has nothing left to toggle. That slot now carries the affordance the hardware keyboard genuinely lacks: the mic key the software keyboard would have provided.

## Detection

`HardwareKeyboardMonitor` — `GCKeyboard.coalesced` plus its connect/disconnect notifications. **UIKit cannot answer this question**: keyboard-frame notifications describe only the *software* keyboard, whose absence is exactly what a hardware keyboard causes. GameController reads the HID layer, the same one SwiftTerm's iOS-on-Mac Ctrl bridge already uses.

## Dictation

iOS exposes no way to *trigger* system dictation, so the key runs recognition itself (`DictationSession`, Speech + AVAudioEngine), requesting `requiresOnDeviceRecognition` wherever the locale supports it — a terminal's input is the most sensitive text in the app, and the recognizer is the one place it would otherwise leave the device outside the user's own SSH connection.

Three rules held to:

- **Nothing is typed until the dictation finishes.** The recognizer rewrites earlier words as it refines its hypothesis and a terminal cannot take a byte back, so the live partial is bar-only.
- **The finished text is typed, never submitted** — through `TerminalView.send` → delegate → ordered pump like every other rail key, sanitized to one line with no control bytes (`DictationText`, pure + unit-tested). Same discipline as a dropped file's path.
- **LISTENING means the microphone is open**, not that the key was pressed. The first press waits behind two system permission alerts, so the key latches on the press while the bar waits for `AVAudioEngine.start()`.

Stops itself after 30 s of quiet (5 min hard cap) — deliberately far longer than system dictation's pause, because what gets dictated here is an agent prompt and a mid-sentence think must not end the take. STOP is the normal finish. One session holds the mic app-wide; a second tab starting takes it rather than failing.

Free rail plumbing, not an agent-helper surface.

## Verified

On the iPad simulator, through the new `debug.dictation` hook:

- Mic key rendered in place of the keyboard key; permission alert showed the new usage string.
- With TCC pre-granted: LISTENING bar up, key latched, `dictation-start onDevice=true` in the log.
- 12 s of silence — still listening. ~36 s — stopped, key unlatched, host-side `tmux capture-pane` shows nothing typed.
- Second press stops it promptly.

Full unit suite passes; iPad and visionOS both build.

**Not verified:** the no-hardware-keyboard branch (the simulator always bridges the Mac keyboard as hardware, so that branch only appears on a device with nothing attached — it is the previously shipped key, unchanged), and real transcription, since the sim had no driven audio input.

## Claim surface

`docs/store-metadata.md`, the App Review notes, and the Info.plist usage strings are updated in lockstep. The landing site's privacy policy is a companion PR in `multiplex-home`.
