### PR TITLE
Let agent launches carry a model, picked from per-host configured lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -833,7 +833,12 @@ views.
   widget's Model setting (same choices in the widget process — the lists
   ride the App Group projection as `WidgetHostState.agentModels`, names
   only, and the tap's `&model=` is validated app-side), and the ASK-mode
-  prompt sheet (seeded, editable, same menu). Like scripts/conf, the lists
+  prompt sheet (seeded, editable, same menu). Both option providers lead
+  with an "Agent Default" row (empty-string value — rejected by the token
+  gate and skipped by the link builder, i.e. "no model") and are NEVER
+  empty: a zero-item options query makes the widget-config picker open and
+  immediately dismiss (user-reported), the same reason the setup-script
+  provider always returns its Default/None rows. Like scripts/conf, the lists
   ride the synced Host record, are zeroed out of
   `connectionModelConfiguration` (edits keep the probe link), and a model
   is never applied because it exists — no choice means the agent's own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,10 @@ vars to drive the real SSH→PTY→tmux→SwiftTerm path headlessly:
   one of them probing when you meant to test a quiet wall. Prefer
   terminate + relaunch over reinstall, or expect the duplicate and
   attribute log traffic accordingly.
-  Optional `workingDirs` / `sessionScripts` / `newSessionTmuxConf` keys feed
-  headless checks of the New Session pickers and the setup-script and
-  tmux-conf creation paths. `"enabled": false` starts the launch with the
+  Optional `workingDirs` / `sessionScripts` / `newSessionTmuxConf` /
+  `agentLaunchModels` (agent rawValue → model-id list) keys feed
+  headless checks of the New Session pickers and the setup-script,
+  tmux-conf, and launch-model paths. `"enabled": false` starts the launch with the
   host switched off, so the never-dials-it promise can be checked against a
   silent `Tools/dev-sshd/state/sshd.log`.
 - `MULTIPLEX_AUTO_ATTACH=main,scratch` — opens a terminal per comma entry via
@@ -89,6 +90,13 @@ vars to drive the real SSH→PTY→tmux→SwiftTerm path headlessly:
 - `MULTIPLEX_AUTO_DROP=<local path>` — after auto-attach, drops that file
   into the first tab (the simulator shares the Mac's filesystem): SFTP
   upload + typed path, the same path a real drag takes.
+- `MULTIPLEX_AUTO_ACTION_URL=multiplex://open?…` — submits the parsed URL
+  through the exact `onOpenURL` → router seam once per process: the headless
+  stand-in for a widget tap when `simctl openurl`'s one-time "Open in
+  Multiplex?" confirmation can't be clicked (fresh install on a headless
+  run; idb HID taps died with Xcode 27's SimulatorKit removal). E.g.
+  `…open?host=devbox&action=agent&agent=pi&model=x` proves the launch line
+  types `pi --model 'x'` — capture-pane the newly minted session host-side.
 - `MULTIPLEX_PRO_LOCKED=1` — DEBUG-only free-tier mode for headless gate and
   daily-meter verification. Unlike the Settings toggle it does not persist;
   combine it with `MULTIPLEX_AUTO_ATTACH=agent` and the `debug.agentchip`
@@ -104,9 +112,12 @@ vars to drive the real SSH→PTY→tmux→SwiftTerm path headlessly:
   editor for the same treatment.
 - `MULTIPLEX_AUTO_FAQ=1` — opens the deck's FAQ sheet (the wall's FAQ chip)
   for headless layout capture.
-- `MULTIPLEX_AUTO_HOST_SETTINGS=1` — opens the first host's edit sheet to
-  regression-check the Observation environment across the shell/scene sheet
-  boundary (a missing HostStore is a fatal error, not a recoverable blank).
+- `MULTIPLEX_AUTO_HOST_SETTINGS=1|models` — opens the first host's edit
+  sheet to regression-check the Observation environment across the
+  shell/scene sheet boundary (a missing HostStore is a fatal error, not a
+  recoverable blank); `models` also scrolls it to the Agent launch models
+  section for layout capture (the form outruns one frame and the sim can't
+  scroll).
 - `MULTIPLEX_KEYCHAIN_TIP=locked|unlocked|missing` — forces the keychain
   check's verdict for the deck's KEYCHAIN LOCKED tip. The sign-in-screen
   gate still applies: inject a real needle (e.g. `tmux send-keys -t
@@ -307,8 +318,8 @@ SwiftUI: classic Deck window + N Terminal windows, or one adaptive Shell
                      refreshAndWait → phase==.connected → focusTab/attach
                      most-recent (or exact ?session=) / createSession with
                      the resolved setup-script choice followed by agent
-                     launchCommand(initialPrompt:). Failures alert on the
-                     deck; the widget's ASK mode presents
+                     launchCommand(model:initialPrompt:). Failures alert on
+                     the deck; the widget's ASK mode presents
                      AgentPromptSheet, which resubmits. A scene without a
                      mounted deck raises the one deck scene to drain.
   SharedStateStore   secret-free App Group projection (widget-state.json,
@@ -797,6 +808,37 @@ views.
   drop the probe link, never enter the widget projection, and are free-tier
   host plumbing, not an agent-helper surface. The dev seed may carry a
   `sessionScripts` array for headless checks of these paths.
+- **An agent launch's model override is one verified flag, picked from
+  host-configured lists, and fail-soft**
+  (`AgentKind.launchCommand(model:initialPrompt:)` +
+  `normalizedLaunchModel`, pure + tested): every supported CLI spells it
+  `--model <value>` (verified 2026-07-27 against Claude Code 2.1.220, Codex
+  rust 0.145.0, Pi 0.81.1). Values are deliberately NOT app-curated — model
+  names churn faster than app releases — but only Claude Code has friendly
+  aliases, so full Codex/Pi ids are typed ONCE into
+  `Host.agentLaunchModels` (Host Settings → Agent launch models; keyed by
+  agent rawValue, host-scoped on purpose — Pi's available models genuinely
+  differ per machine with its configured providers) and every surface then
+  offers them as a picker with free text kept as the escape hatch. The
+  normalizer only enforces argv-token shape (no whitespace, no controls,
+  no leading `-`, ≤64 chars) and rejection means "agent default", never an
+  error; it also gates list entries at save, and preserves UNKNOWN agent
+  keys verbatim so an edit-save here can't drop a newer schema's list. The
+  composed value is always shell-quoted, which is load-bearing — Claude's
+  `sonnet[1m]` alias would otherwise glob in zsh. Surfaces: New Session
+  sheet (field + preset menu + live Command preview; REMEMBER stores the
+  choice per agent, device-local — + TAB's agent variants inherit it), the
+  Open Agent Shortcut's Model parameter (host+agent-dependent suggestions
+  via `AgentModelChoices`, value stays a String for variables), the Host
+  widget's Model setting (same choices in the widget process — the lists
+  ride the App Group projection as `WidgetHostState.agentModels`, names
+  only, and the tap's `&model=` is validated app-side), and the ASK-mode
+  prompt sheet (seeded, editable, same menu). Like scripts/conf, the lists
+  ride the synced Host record, are zeroed out of
+  `connectionModelConfiguration` (edits keep the probe link), and a model
+  is never applied because it exists — no choice means the agent's own
+  default; external actions never inherit the remembered model, so the
+  same widget behaves identically on every device.
 - **The per-host new-session tmux conf is Host-record text applied as
   targeted `set-option -t` calls — never a host file, never `-f`, never on
   the raced create** (`Host.newSessionTmuxConf`, Host Settings below the
@@ -1262,7 +1304,10 @@ views.
   variables still work; unset means the live host default and `"~"` means
   Home. The setup-script String is validated as DEFAULT/NONE/a UUID — unset
   preserves the remembered New Session choice, and arbitrary text never
-  reaches the remote shell. Intents/widget links and
+  reaches the remote shell. The Model String (Shortcut parameter and Host
+  widget setting alike) stays free text for the same variable reason and is
+  gated by `normalizedLaunchModel` before it can ride the launch line —
+  rejection means the agent's own default. Intents/widget links and
   `ExternalActionURL` formats are kept in lockstep by `SharedStateTests`
   (the widget target compiles only `Multiplex/Shared`, never the app model
   chain — don't import Host/Tmux/Agent types there). XcodeGen quirk: the

--- a/Multiplex/App/MultiplexApp.swift
+++ b/Multiplex/App/MultiplexApp.swift
@@ -46,7 +46,8 @@ struct MultiplexApp: App {
                             id: $0.id,
                             displayName: $0.displayName
                         )
-                    }
+                    },
+                    agentModels: $0.agentLaunchModels
                 )
             }
         }
@@ -175,6 +176,10 @@ private struct ExternalActionReceiver: ViewModifier {
     @Environment(\.openWindow) private var openWindow
     @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
 
+    /// One shot per process, like `MULTIPLEX_AUTO_ATTACH` — the modifier is
+    /// on every scene root, and the hook must not resubmit per scene.
+    @MainActor private static var autoActionFired = false
+
     func body(content: Content) -> some View {
         content
             .onOpenURL { url in
@@ -185,6 +190,25 @@ private struct ExternalActionReceiver: ViewModifier {
                 guard !router.hasContext, supportsMultipleWindows else { return }
                 openWindow(id: "deck", value: DeckWindowRoute.main)
             }
+            .task { submitAutoActionIfNeeded() }
+    }
+
+    /// DEBUG-only headless stand-in for a widget tap:
+    /// `MULTIPLEX_AUTO_ACTION_URL=multiplex://open?…` runs the same
+    /// parse-then-submit seam as `onOpenURL`. It exists because
+    /// `simctl openurl` parks a fresh install's FIRST open on a system
+    /// "Open in Multiplex?" confirmation that a headless run cannot click
+    /// (idb HID taps died with Xcode 27's SimulatorKit removal).
+    @MainActor private func submitAutoActionIfNeeded() {
+        #if DEBUG
+        guard !Self.autoActionFired,
+              let raw = ProcessInfo.processInfo.environment["MULTIPLEX_AUTO_ACTION_URL"],
+              let url = URL(string: raw),
+              let action = ExternalActionURL.action(from: url)
+        else { return }
+        Self.autoActionFired = true
+        router.submit(action)
+        #endif
     }
 }
 

--- a/Multiplex/AppIntents/OpenHostIntents.swift
+++ b/Multiplex/AppIntents/OpenHostIntents.swift
@@ -149,8 +149,11 @@ struct AgentModelOptionsProvider: DynamicOptionsProvider {
             hosts.first { $0.id == dependency.host.id }?
                 .agentModels[dependency.agent.rawValue]
         } ?? []
-        let items = AgentModelChoices.values(configured: configured)
-            .map { IntentItem($0) }
+        // Same never-empty rule as the widget's provider: the leading
+        // Agent Default row keeps the picker presentable with nothing
+        // configured, and its empty value normalizes to "no model".
+        let items = AgentModelChoices.choices(configured: configured)
+            .map { IntentItem($0.value, title: "\($0.title)") }
         return IntentItemCollection(
             promptLabel: "Choose a model",
             sections: [IntentItemSection(items: items)]

--- a/Multiplex/AppIntents/OpenHostIntents.swift
+++ b/Multiplex/AppIntents/OpenHostIntents.swift
@@ -54,12 +54,24 @@ struct OpenHostAgentIntent: AppIntent {
         description: "Runs before the agent. Leave empty for the setup script remembered in Multiplex.",
         optionsProvider: AgentSetupScriptOptionsProvider()
     ) var setupScript: String?
+    /// Suggestions come from the host's pre-configured launch models (Host
+    /// Settings) — full Codex/Pi ids are typed once there, then picked here.
+    /// The value stays a free String so Shortcuts variables and unlisted
+    /// models keep working; a value the launch grammar rejects (whitespace,
+    /// leading `-`) falls back to the agent default rather than reaching the
+    /// shell malformed.
+    @Parameter(
+        title: "Model",
+        description: "Launches the agent with --model set to this value. Configure choices in Multiplex's Host Settings; leave empty for the agent's default model.",
+        optionsProvider: AgentModelOptionsProvider()
+    ) var model: String?
     /// Optional so Shortcuts users can leave it off or set "Ask Each Time";
     /// sent as the agent's shell-quoted launch argument.
     @Parameter(title: "First Prompt") var prompt: String?
 
     static var parameterSummary: some ParameterSummary {
         Summary("Start \(\.$agent) on \(\.$host)") {
+            \.$model
             \.$directory
             \.$setupScript
             \.$prompt
@@ -74,13 +86,15 @@ struct OpenHostAgentIntent: AppIntent {
         let text = prompt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let path = directory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let script = ShortcutSetupScriptOptions.selection(for: setupScript)
+        let launchModel = model.flatMap(AgentKind.normalizedLaunchModel)
         router.submit(.openAgent(
             host: .id(host.id),
             agent: kind,
             prompt: text.isEmpty ? nil : text,
             askForPrompt: false,
             directory: path.isEmpty ? nil : path,
-            setupScript: script
+            setupScript: script,
+            model: launchModel
         ))
         return .result()
     }
@@ -119,6 +133,28 @@ enum ShortcutWorkingDirectoryOptions {
         }
         values.append("~")
         return values
+    }
+}
+
+/// The host's pre-configured launch models for the selected agent, as
+/// Shortcut suggestions. Same shared choice builder as the widget's Model
+/// setting, so both surfaces offer identical rows.
+struct AgentModelOptionsProvider: DynamicOptionsProvider {
+    @IntentParameterDependency<OpenHostAgentIntent>(\.$host, \.$agent)
+    private var intent
+
+    func results() async throws -> IntentItemCollection<String> {
+        let hosts = await HostEntityProvider.all()
+        let configured = intent.flatMap { dependency in
+            hosts.first { $0.id == dependency.host.id }?
+                .agentModels[dependency.agent.rawValue]
+        } ?? []
+        let items = AgentModelChoices.values(configured: configured)
+            .map { IntentItem($0) }
+        return IntentItemCollection(
+            promptLabel: "Choose a model",
+            sections: [IntentItemSection(items: items)]
+        )
     }
 }
 

--- a/Multiplex/Models/AgentSignature.swift
+++ b/Multiplex/Models/AgentSignature.swift
@@ -35,15 +35,46 @@ enum AgentKind: String, Hashable, Codable, CaseIterable {
         }
     }
 
-    /// The command typed into a fresh shell, optionally carrying the user's
-    /// first prompt as one safely quoted positional argument. Shell quoting
-    /// keeps prompt text inert; multiline prompts use printable `printf`
-    /// escapes so control bytes never reach the shell's line editor before
-    /// the final Enter.
-    func launchCommand(initialPrompt rawPrompt: String) -> String {
+    /// The command typed into a fresh shell, optionally carrying a model
+    /// override and the user's first prompt as one safely quoted positional
+    /// argument. Every supported CLI spells the override `--model <value>`
+    /// (verified 2026-07-27: Claude Code 2.1.220, Codex rust 0.145.0, Pi
+    /// 0.81.1 — Pi values may be `provider/id` with a `:<thinking>` suffix).
+    /// Shell quoting keeps prompt text inert; the model value is quoted too,
+    /// which is load-bearing beyond hygiene — Claude aliases like
+    /// `sonnet[1m]` would otherwise glob in zsh. Multiline prompts use
+    /// printable `printf` escapes so control bytes never reach the shell's
+    /// line editor before the final Enter.
+    func launchCommand(model rawModel: String?, initialPrompt rawPrompt: String) -> String {
+        var command = launchCommand
+        if let model = rawModel.flatMap(Self.normalizedLaunchModel) {
+            command += " --model \(model.shellQuoted)"
+        }
         let prompt = Self.normalizedInitialPrompt(rawPrompt)
-        guard !prompt.isEmpty else { return launchCommand }
-        return "\(launchCommand) \(Self.shellArgument(for: prompt))"
+        guard !prompt.isEmpty else { return command }
+        return "\(command) \(Self.shellArgument(for: prompt))"
+    }
+
+    /// A model identifier fit to ride `--model` as one argv token, or nil —
+    /// which every caller treats as "the agent's own default". Deliberately
+    /// not a curated list: model names churn far faster than app releases,
+    /// and a wrong value fails visibly in the agent's own UI (the chip
+    /// philosophy). The gate only enforces token shape: no whitespace (one
+    /// argument, never a smuggled second one), no control bytes, no leading
+    /// `-` (must never read as another flag), bounded length. Quoting at the
+    /// composition site keeps the surviving characters inert.
+    static func normalizedLaunchModel(_ raw: String) -> String? {
+        let safeScalars = raw.unicodeScalars.filter {
+            !CharacterSet.controlCharacters.contains($0)
+        }
+        let trimmed = String(String.UnicodeScalarView(safeScalars))
+            .trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty,
+              trimmed.count <= 64,
+              !trimmed.hasPrefix("-"),
+              !trimmed.contains(where: \.isWhitespace)
+        else { return nil }
+        return trimmed
     }
 
     private static func normalizedInitialPrompt(_ prompt: String) -> String {

--- a/Multiplex/Models/ExternalAction.swift
+++ b/Multiplex/Models/ExternalAction.swift
@@ -66,26 +66,33 @@ enum ExternalAction: Hashable {
     /// first prompt as its shell-quoted launch argument — then attach it.
     /// `askForPrompt` presents the in-app prompt sheet first (the widget's
     /// ASK mode); the sheet resubmits with the entered prompt, directory,
-    /// and setup-script choice. `directory` semantics: nil = the host's
-    /// default (first working dir), `"~"` = explicitly home (the quoting
-    /// layer expands it to `$HOME`), anything else = that path.
+    /// model, and setup-script choice. `directory` semantics: nil = the
+    /// host's default (first working dir), `"~"` = explicitly home (the
+    /// quoting layer expands it to `$HOME`), anything else = that path.
+    /// `model` rides the launch as `--model <value>`; nil — including any
+    /// value `AgentKind.normalizedLaunchModel` rejects — means the agent's
+    /// own default, never the New Session sheet's remembered choice (an
+    /// automation without a model must behave the same on every device).
     case openAgent(
         host: ExternalHostRef, agent: AgentKind, prompt: String?,
         askForPrompt: Bool, directory: String?,
-        setupScript: ExternalSetupScriptSelection)
+        setupScript: ExternalSetupScriptSelection, model: String?)
 
     var hostRef: ExternalHostRef {
         switch self {
         case .openShell(let host, _): host
-        case .openAgent(let host, _, _, _, _, _): host
+        case .openAgent(let host, _, _, _, _, _, _): host
         }
     }
 }
 
 /// `multiplex://open?host=<uuid|name>&action=shell|agent[&agent=<kind>]
-/// [&prompt=<text>][&ask=1][&dir=<path>][&script=<uuid|none>]` — built by
-/// widgets, parsed by `onOpenURL`. Omitting `script` uses the remembered New
-/// Session choice.
+/// [&prompt=<text>][&ask=1][&dir=<path>][&script=<uuid|none>][&model=<id>]`
+/// — built by widgets, parsed by `onOpenURL`. Omitting `script` uses the
+/// remembered New Session choice; omitting `model` uses the agent's own
+/// default (a malformed model token also parses as omitted — fail-soft, the
+/// setup-script id stays the one strict token because a wrong script runs
+/// arbitrary text).
 enum ExternalActionURL {
     static let scheme = "multiplex"
     static let authority = "open"
@@ -103,7 +110,7 @@ enum ExternalActionURL {
             }
         case .openAgent(
             _, let agent, let prompt, let askForPrompt, let directory,
-            let setupScript
+            let setupScript, let model
         ):
             items.append(URLQueryItem(name: "action", value: "agent"))
             items.append(URLQueryItem(name: "agent", value: agent.rawValue))
@@ -118,6 +125,9 @@ enum ExternalActionURL {
             }
             if let token = setupScript.token {
                 items.append(URLQueryItem(name: "script", value: token))
+            }
+            if let model, !model.isEmpty {
+                items.append(URLQueryItem(name: "model", value: model))
             }
         }
         components.queryItems = items
@@ -156,10 +166,11 @@ enum ExternalActionURL {
             } else {
                 setupScript = .remembered
             }
+            let model = value("model").flatMap(AgentKind.normalizedLaunchModel)
             return .openAgent(
                 host: hostRef, agent: agent, prompt: prompt,
                 askForPrompt: ask, directory: directory,
-                setupScript: setupScript)
+                setupScript: setupScript, model: model)
         default:
             return nil
         }
@@ -213,7 +224,7 @@ enum ExternalActionPlan {
 }
 
 /// The in-app "ask for the first prompt" sheet's payload (widget ASK mode).
-/// `directory` seeds the sheet's Starts-in picker with whatever the
+/// `directory` and `model` seed the sheet's fields with whatever the
 /// originating action carried (same nil/`"~"`/path semantics as the action).
 struct AgentPromptRequest: Identifiable {
     let id = UUID()
@@ -221,6 +232,7 @@ struct AgentPromptRequest: Identifiable {
     var agent: AgentKind
     var directory: String?
     var setupScript: ExternalSetupScriptSelection
+    var model: String?
 }
 
 /// What the deck's failure alert shows when an external action can't run.

--- a/Multiplex/Models/Host.swift
+++ b/Multiplex/Models/Host.swift
@@ -45,6 +45,18 @@ struct Host: Identifiable, Codable, Hashable {
     /// selected one is typed into a freshly created session's shell before
     /// the optional agent launch line.
     var sessionScripts: [SessionScript] = []
+    /// Pre-configured `--model` values per agent (keyed by
+    /// `AgentKind.rawValue`), in the user's order. Full model ids are typed
+    /// once here — Host Settings — and every launch surface (New Session
+    /// sheet, Open Agent Shortcut, Host widget setting) then offers them as
+    /// a picker; only Claude Code has human-friendly aliases, so free text
+    /// alone was a bad experience for Codex and Pi. Host-scoped on purpose,
+    /// not just for the sync ride: Pi's available models genuinely differ
+    /// per machine with its configured providers. A model is never applied
+    /// because it exists — launches without a choice use the agent's own
+    /// default. Unknown agent keys survive normalization so a record
+    /// written by a newer schema keeps its lists through an edit-save here.
+    var agentLaunchModels: [String: [String]] = [:]
     /// tmux options for sessions created from Multiplex — conf-style text
     /// stored in this record (never a file on the host), one option per
     /// line (`mouse on`, `focus-events on`). Each line is applied to the
@@ -75,6 +87,33 @@ struct Host: Identifiable, Codable, Hashable {
     var address: String {
         port == 22 ? "\(username)@\(hostname)" : "\(username)@\(hostname):\(port)"
     }
+
+    /// The configured launch models for one agent, picker-ready.
+    func launchModels(for agent: AgentKind) -> [String] {
+        agentLaunchModels[agent.rawValue] ?? []
+    }
+
+    /// Canonical form for persistence: known agents' lists pass the launch
+    /// grammar's token gate and dedupe in order (an invalid entry can never
+    /// ride a launch line, so storing it would only fabricate a dead picker
+    /// row); empty lists drop their key. Unknown agent keys pass through
+    /// verbatim — validating a newer schema's list against today's grammar
+    /// could destroy it.
+    static func normalizedLaunchModels(_ raw: [String: [String]]) -> [String: [String]] {
+        var result: [String: [String]] = [:]
+        for (agentRaw, models) in raw {
+            guard AgentKind(rawValue: agentRaw) != nil else {
+                if !models.isEmpty { result[agentRaw] = models }
+                continue
+            }
+            var seen = Set<String>()
+            let cleaned = models
+                .compactMap(AgentKind.normalizedLaunchModel)
+                .filter { seen.insert($0).inserted }
+            if !cleaned.isEmpty { result[agentRaw] = cleaned }
+        }
+        return result
+    }
 }
 
 // Decoding lives in an extension so the memberwise initializer survives.
@@ -99,6 +138,10 @@ extension Host {
         sessionScripts = SessionScript.normalized(
             try container.decodeIfPresent([SessionScript].self, forKey: .sessionScripts) ?? []
         )
+        agentLaunchModels = Host.normalizedLaunchModels(
+            try container.decodeIfPresent(
+                [String: [String]].self, forKey: .agentLaunchModels) ?? [:]
+        )
         newSessionTmuxConf = try container.decodeIfPresent(
             String.self, forKey: .newSessionTmuxConf
         ) ?? Host.defaultNewSessionTmuxConf
@@ -110,8 +153,8 @@ extension Host {
     }
 
     /// Hashable identity for the connection model and the wall feed that
-    /// drives it. Command-setup, setup-script, and new-session tmux conf
-    /// edits must not tear down the probe connection; every other
+    /// drives it. Command-setup, setup-script, launch-model, and new-session
+    /// tmux conf edits must not tear down the probe connection; every other
     /// current/future Host field remains part of the identity — `isEnabled`
     /// deliberately included, so a host switched off on another device
     /// restarts the wall feed here, which is where the live probe is dropped.
@@ -119,6 +162,7 @@ extension Host {
         var configuration = self
         configuration.agentCommandConfiguration = AgentCommandConfiguration()
         configuration.sessionScripts = []
+        configuration.agentLaunchModels = [:]
         configuration.newSessionTmuxConf = Host.defaultNewSessionTmuxConf
         configuration.updatedAt = .distantPast
         return configuration

--- a/Multiplex/Services/ExternalActionRouter.swift
+++ b/Multiplex/Services/ExternalActionRouter.swift
@@ -114,14 +114,15 @@ enum ExternalActionPerformer {
             await openShell(on: host, requestedSession: sessionName, context: context)
         case .openAgent(
             _, let agent, let prompt, let askForPrompt, let directory,
-            let setupScript
+            let setupScript, let model
         ):
             if askForPrompt {
                 context.presentAgentPrompt(AgentPromptRequest(
                     host: host,
                     agent: agent,
                     directory: directory,
-                    setupScript: setupScript
+                    setupScript: setupScript,
+                    model: model
                 ))
                 return
             }
@@ -130,6 +131,7 @@ enum ExternalActionPerformer {
                 prompt: prompt,
                 directory: directory,
                 setupScript: setupScript,
+                model: model,
                 on: host,
                 context: context
             )
@@ -185,6 +187,7 @@ enum ExternalActionPerformer {
         prompt: String?,
         directory: String?,
         setupScript: ExternalSetupScriptSelection,
+        model launchModel: String?,
         on host: Host,
         context: ExternalActionRouter.Context
     ) async {
@@ -192,7 +195,9 @@ enum ExternalActionPerformer {
         // nil = the host's default working dir; the sheet's explicit Home
         // choice arrives as "~", which the quoting layer expands to $HOME.
         // The Shortcut picker can select a stable script id, explicitly opt
-        // out, or preserve the remembered New Session choice.
+        // out, or preserve the remembered New Session choice. The launch
+        // model stays binary — carried or the agent's default — so the same
+        // widget/Shortcut behaves identically on every device.
         let script = ExternalActionPlan.setupScript(
             for: setupScript,
             available: host.sessionScripts,
@@ -204,7 +209,7 @@ enum ExternalActionPerformer {
             startingIn: directory ?? host.workingDirs.first,
             applying: host.newSessionTmuxConf,
             running: script?.normalizedBody,
-            typing: agent.launchCommand(initialPrompt: prompt ?? "")
+            typing: agent.launchCommand(model: launchModel, initialPrompt: prompt ?? "")
         ) else {
             presentCreateFailure(for: model, host: host, context: context)
             return

--- a/Multiplex/Services/HostStore.swift
+++ b/Multiplex/Services/HostStore.swift
@@ -315,6 +315,11 @@ final class HostStore {
         if let scripts = seed.sessionScripts {
             host.sessionScripts = SessionScript.normalized(scripts)
         }
+        // And for launch models — headless checks of the model pickers seed
+        // known per-agent lists; an absent key leaves the host's lists alone.
+        if let models = seed.agentLaunchModels {
+            host.agentLaunchModels = Host.normalizedLaunchModels(models)
+        }
         // And for the new-session tmux conf — headless checks seed option
         // lines and read them back host-side with show-options. An absent
         // key keeps the host's current conf (the default on first import);
@@ -369,6 +374,7 @@ final class HostStore {
         var workingDirs: [String]?
         var sessionScripts: [SessionScript]?
         var newSessionTmuxConf: String?
+        var agentLaunchModels: [String: [String]]?
     }
     #endif
 }

--- a/Multiplex/Services/NewSessionPreferences.swift
+++ b/Multiplex/Services/NewSessionPreferences.swift
@@ -6,14 +6,19 @@ import Foundation
 /// is deliberately never persisted.
 ///
 /// The same single opt-in also covers the setup-script choice — per host,
-/// because script ids are host-scoped. While it is on, the remembered script
-/// is what pickerless creation paths (+ TAB, widgets) and Open Agent's
-/// Shortcut default type into fresh sessions; off means those paths type
-/// nothing unless the Shortcut explicitly selects a script.
+/// because script ids are host-scoped — and the model override — per agent,
+/// because a model belongs to the agent, not the host. While it is on, the
+/// remembered script is what pickerless creation paths (+ TAB, widgets) and
+/// Open Agent's Shortcut default type into fresh sessions, and + TAB's agent
+/// variants inherit the remembered model; off means those paths type nothing
+/// unless the Shortcut explicitly selects a script. External actions never
+/// inherit the remembered model — an automation carries its own or gets the
+/// agent default.
 struct NewSessionPreferences {
     private static let remembersLastLaunchKey = "newSession.remembersLastLaunch"
     private static let lastAgentKey = "newSession.lastAgent"
     private static let lastScriptsKey = "newSession.lastScripts"
+    private static let lastModelsKey = "newSession.lastModels"
 
     private let defaults: UserDefaults
 
@@ -34,6 +39,20 @@ struct NewSessionPreferences {
         return AgentKind(rawValue: rawValue)
     }
 
+    /// The remembered `--model` override, per agent — models belong to the
+    /// agent, not the host, so one choice follows Claude Code (or Codex, or
+    /// Pi) across the fleet. Stored as typed; the launch grammar re-validates
+    /// at composition, so a stale value fails soft to the agent default while
+    /// staying visible in the sheet's field for the user to fix.
+    func rememberedModel(for agent: AgentKind) -> String? {
+        guard remembersLastLaunch,
+              let stored = defaults.dictionary(forKey: Self.lastModelsKey),
+              let model = stored[agent.rawValue] as? String,
+              !model.isEmpty
+        else { return nil }
+        return model
+    }
+
     /// The host's remembered setup script, resolved against its current
     /// list. `nil` means NONE — an absent entry and a remembered id whose
     /// script was since deleted or unsynced read the same way, silently.
@@ -47,7 +66,7 @@ struct NewSessionPreferences {
     }
 
     func save(
-        remembersLastLaunch: Bool, agent: AgentKind?,
+        remembersLastLaunch: Bool, agent: AgentKind?, model: String?,
         script: SessionScript?, hostID: UUID
     ) {
         defaults.set(remembersLastLaunch, forKey: Self.remembersLastLaunchKey)
@@ -74,6 +93,26 @@ struct NewSessionPreferences {
             defaults.removeObject(forKey: Self.lastScriptsKey)
         } else {
             defaults.set(scripts, forKey: Self.lastScriptsKey)
+        }
+
+        // And per agent for the model. A shell-only submit (agent nil) says
+        // nothing about models, so other agents' entries survive it; an
+        // agent submitted with an empty field explicitly forgets its entry.
+        var models = remembersLastLaunch
+            ? (defaults.dictionary(forKey: Self.lastModelsKey) as? [String: String]) ?? [:]
+            : [:]
+        if let agent {
+            let trimmed = model?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if remembersLastLaunch, !trimmed.isEmpty {
+                models[agent.rawValue] = trimmed
+            } else {
+                models.removeValue(forKey: agent.rawValue)
+            }
+        }
+        if models.isEmpty {
+            defaults.removeObject(forKey: Self.lastModelsKey)
+        } else {
+            defaults.set(models, forKey: Self.lastModelsKey)
         }
     }
 }

--- a/Multiplex/Services/WidgetStatePublisher.swift
+++ b/Multiplex/Services/WidgetStatePublisher.swift
@@ -71,7 +71,8 @@ enum WidgetStateBuilder {
             sessions: sessions.map {
                 sessionState($0, miniatureLines: miniatures[$0.name] ?? [])
             },
-            probedAt: probedAt
+            probedAt: probedAt,
+            agentModels: host.agentLaunchModels.isEmpty ? nil : host.agentLaunchModels
         )
     }
 

--- a/Multiplex/Shared/AgentChoice.swift
+++ b/Multiplex/Shared/AgentChoice.swift
@@ -23,6 +23,30 @@ enum AgentChoice: String, AppEnum {
 /// Presentation-only hygiene (trim, drop empties, dedupe in order); the
 /// launch grammar's token gate stays app-side where the value is consumed.
 enum AgentModelChoices {
+    struct Choice: Equatable {
+        var value: String
+        var title: String
+    }
+
+    /// The empty string is the "no model" sentinel every consumer already
+    /// honors: the widget link builder skips empty values and the Shortcut's
+    /// perform normalizes them to nil, so picking it launches the agent's
+    /// own default.
+    static let agentDefaultValue = ""
+
+    /// Always non-empty, like the setup-script provider's Default/None
+    /// rows: an options query that returns zero items makes the picker
+    /// sheet open and immediately dismiss (observed in widget config), so
+    /// "Agent Default" leads even when the host has nothing configured —
+    /// which is also the honest way to say where configuration lives.
+    static func choices(configured: [String]) -> [Choice] {
+        var choices = [Choice(value: agentDefaultValue, title: "Agent Default")]
+        choices += values(configured: configured).map {
+            Choice(value: $0, title: $0)
+        }
+        return choices
+    }
+
     static func values(configured: [String]) -> [String] {
         var seen = Set<String>()
         var values: [String] = []

--- a/Multiplex/Shared/AgentChoice.swift
+++ b/Multiplex/Shared/AgentChoice.swift
@@ -16,3 +16,21 @@ enum AgentChoice: String, AppEnum {
         .pi: "Pi",
     ]
 }
+
+/// Picker rows for a host's pre-configured launch models — shared by the
+/// Open Agent Shortcut's provider (app process) and the Host widget's
+/// configuration provider (widget process), so both offer the same list.
+/// Presentation-only hygiene (trim, drop empties, dedupe in order); the
+/// launch grammar's token gate stays app-side where the value is consumed.
+enum AgentModelChoices {
+    static func values(configured: [String]) -> [String] {
+        var seen = Set<String>()
+        var values: [String] = []
+        for raw in configured {
+            let model = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !model.isEmpty, seen.insert(model).inserted else { continue }
+            values.append(model)
+        }
+        return values
+    }
+}

--- a/Multiplex/Shared/HostEntity.swift
+++ b/Multiplex/Shared/HostEntity.swift
@@ -13,8 +13,10 @@ struct ShortcutSessionScript: Identifiable, Hashable, Sendable {
 /// The host as Shortcuts and widget configuration see it: id + labels, no
 /// secrets. The app-side query also carries configured working directories
 /// and setup-script labels so dependent Shortcut parameters can offer them;
-/// the widget fallback does not need or publish either. Both processes share
-/// this type and query.
+/// the widget fallback does not need or publish either. Launch-model lists
+/// ride BOTH sides — the widget's own Model setting needs a picker in the
+/// widget process, and model names are ordinary labels, not secrets. Both
+/// processes share this type and query.
 struct HostEntity: AppEntity, Identifiable, Hashable {
     static let typeDisplayRepresentation: TypeDisplayRepresentation = "Multiplex Host"
     static let defaultQuery = HostEntityQuery()
@@ -24,6 +26,9 @@ struct HostEntity: AppEntity, Identifiable, Hashable {
     var address: String
     var workingDirs: [String] = []
     var sessionScripts: [ShortcutSessionScript] = []
+    /// Pre-configured launch models per agent, keyed by the agent raw value
+    /// (`AgentChoice`/`AgentKind` mirror one-to-one, unit-tested).
+    var agentModels: [String: [String]] = [:]
 
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(title: "\(name)", subtitle: "\(address)")
@@ -40,7 +45,10 @@ enum HostEntityProvider {
     static func all() async -> [HostEntity] {
         if let entities = await liveEntities() { return entities }
         return (SharedStateStore.load()?.hosts ?? []).map {
-            HostEntity(id: $0.id, name: $0.name, address: $0.address)
+            HostEntity(
+                id: $0.id, name: $0.name, address: $0.address,
+                agentModels: $0.agentModels ?? [:]
+            )
         }
     }
 

--- a/Multiplex/Shared/SharedStateStore.swift
+++ b/Multiplex/Shared/SharedStateStore.swift
@@ -65,6 +65,11 @@ struct WidgetHostState: Codable, Hashable, Identifiable {
     var sessions: [WidgetSessionState] = []
     /// When the app last had a live probe result for this host; nil = never.
     var probedAt: Date? = nil
+    /// Pre-configured launch models per agent raw value — what the Host
+    /// widget's Model setting offers as picker rows in the widget process.
+    /// Names only, no secrets. Optional-typed so files written before the
+    /// field existed keep decoding (synthesized decoder; nil = none).
+    var agentModels: [String: [String]]? = nil
 
     /// The session the per-host widget features and a bare shell deep link
     /// attaches — newest by creation, name-ordered on a tie. Must mirror

--- a/Multiplex/Shared/WidgetLink.swift
+++ b/Multiplex/Shared/WidgetLink.swift
@@ -19,7 +19,12 @@ enum WidgetLink {
         return url(queryItems: items)
     }
 
-    static func agentURL(hostID: UUID, agentRaw: String, askForPrompt: Bool) -> URL {
+    /// `model` travels raw — the app-side parser owns validation (a value
+    /// the launch grammar rejects reads as "agent default"), so the widget
+    /// target never compiles the grammar it would need to pre-validate.
+    static func agentURL(
+        hostID: UUID, agentRaw: String, askForPrompt: Bool, model: String? = nil
+    ) -> URL {
         var items = [
             URLQueryItem(name: "host", value: hostID.uuidString),
             URLQueryItem(name: "action", value: "agent"),
@@ -27,6 +32,9 @@ enum WidgetLink {
         ]
         if askForPrompt {
             items.append(URLQueryItem(name: "ask", value: "1"))
+        }
+        if let model, !model.isEmpty {
+            items.append(URLQueryItem(name: "model", value: model))
         }
         return url(queryItems: items)
     }

--- a/Multiplex/Views/Deck/AddHostSheet.swift
+++ b/Multiplex/Views/Deck/AddHostSheet.swift
@@ -31,6 +31,10 @@ struct AddHostSheet: View {
     /// the first save, not invisible policy.
     @State private var newSessionTmuxConf = Host.defaultNewSessionTmuxConf
     @State private var scripts: [ScriptRow] = []
+    /// Launch-model lists as one-id-per-line text, one field per agent —
+    /// the tmux-conf field's compact grammar, not editable rows (model ids
+    /// are short single tokens; row chrome tripled the height).
+    @State private var modelText: [AgentKind: String] = [:]
     @State private var testState: TestState = .idle
     @State private var showingPaywall = false
 
@@ -77,6 +81,7 @@ struct AddHostSheet: View {
 
     var body: some View {
         NavigationStack {
+            ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: 18) {
                     hostSection
@@ -86,6 +91,8 @@ struct AddHostSheet: View {
                     workingDirsSection
                     tmuxConfSection
                     scriptsSection
+                    agentModelsSection
+                        .id("agent-models")
                     transportSection
                 }
                 .frame(maxWidth: 680)
@@ -96,6 +103,7 @@ struct AddHostSheet: View {
             // Fields, chips, and switches claim their own taps, so this only
             // fires on inert ground and never fights a control.
             .onTapGesture(perform: unfocusInputs)
+            .task { await scrollForVerificationIfRequested(proxy) }
             .chassisSheetGround()
             .navigationTitle(editing == nil ? "Add Host" : "Host Settings")
             .navigationBarTitleDisplayMode(.inline)
@@ -108,6 +116,7 @@ struct AddHostSheet: View {
                     ChassisBarButton("Save", action: save)
                         .disabled(!isValid)
                 }
+            }
             }
         }
         // This long form is easy to drag while scrolling. Require the
@@ -616,6 +625,66 @@ struct AddHostSheet: View {
             : "New Session offers these by name; the chosen one is typed into the fresh shell before the launch command."
     }
 
+    // MARK: Agent launch models
+
+    /// One compact field per agent, one model id per line — the tmux-conf
+    /// field's grammar. Model ids are short single tokens, so editable rows
+    /// with move/delete chrome only added height; line order IS the picker
+    /// order, and deleting a line deletes the model.
+    private var agentModelsSection: some View {
+        TallyFormSection("Agent launch models", detail: modelsDetail) {
+            ForEach(AgentKind.allCases, id: \.self) { agent in
+                TallyFormField(agent.displayName) {
+                    TextField(
+                        modelPlaceholder(for: agent),
+                        text: modelTextBinding(for: agent),
+                        axis: .vertical
+                    )
+                    .lineLimit(1...5)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .accessibilityLabel("\(agent.displayName) models, one per line")
+                }
+            }
+        }
+    }
+
+    private var modelsDetail: String {
+        "One model id per line, in picker order. New Session, the Open "
+            + "Agent shortcut, and the host widget offer them as choices, "
+            + "passed as --model; nothing is applied unless chosen at launch."
+    }
+
+    /// A hint only where the alias grammar is stable; Codex and Pi ids are
+    /// exactly what this feature saves the user from retyping, so those
+    /// fields never suggest one that would go stale.
+    private func modelPlaceholder(for agent: AgentKind) -> String {
+        switch agent {
+        case .claudeCode: "opus, sonnet, or a full model id"
+        case .codex: "model id per line"
+        case .pi: "provider/model-id per line"
+        }
+    }
+
+    private func modelTextBinding(for agent: AgentKind) -> Binding<String> {
+        Binding(
+            get: { modelText[agent] ?? "" },
+            set: { modelText[agent] = $0 }
+        )
+    }
+
+    /// Fields split back into lists, in editor order; the token gate and
+    /// dedupe happen in `Host.normalizedLaunchModels` at save.
+    private var resolvedLaunchModels: [String: [String]] {
+        var models: [String: [String]] = [:]
+        for agent in AgentKind.allCases {
+            models[agent.rawValue] = (modelText[agent] ?? "")
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+        }
+        return models
+    }
+
     /// Same late-write discipline as the working-dir rows: resolve through
     /// the row id, never a captured array index.
     private func scriptBinding(
@@ -706,6 +775,19 @@ struct AddHostSheet: View {
         }
     }
 
+    /// `MULTIPLEX_AUTO_HOST_SETTINGS=models` scrolls to the Agent launch
+    /// models section once the sheet settles — the form is taller than one
+    /// headless frame and the simulator cannot scroll (DEBUG capture only).
+    private func scrollForVerificationIfRequested(_ proxy: ScrollViewProxy) async {
+        #if DEBUG
+        guard ProcessInfo.processInfo.environment[
+            "MULTIPLEX_AUTO_HOST_SETTINGS"
+        ] == "models" else { return }
+        try? await Task.sleep(for: .milliseconds(700))
+        withAnimation(nil) { proxy.scrollTo("agent-models", anchor: .top) }
+        #endif
+    }
+
     /// Resigns whichever field currently holds the keyboard. Routed through
     /// the responder chain so it covers the SwiftUI fields and the
     /// UIKit-backed secret fields alike, without threading FocusState
@@ -731,6 +813,13 @@ struct AddHostSheet: View {
         workingDirs = host.workingDirs.map { WorkingDir(path: $0) }
         newSessionTmuxConf = host.newSessionTmuxConf
         scripts = host.sessionScripts.map(ScriptRow.init)
+        modelText = [:]
+        for agent in AgentKind.allCases {
+            let models = host.launchModels(for: agent)
+            if !models.isEmpty {
+                modelText[agent] = models.joined(separator: "\n")
+            }
+        }
         password = KeychainStore.get(for: host.id, kind: .password) ?? ""
         privateKey = KeychainStore.get(for: host.id, kind: .privateKey) ?? ""
         passphrase = KeychainStore.get(for: host.id, kind: .keyPassphrase) ?? ""
@@ -767,6 +856,16 @@ struct AddHostSheet: View {
         // Rows with nothing to type drop out; ids survive edits so the
         // remembered-selection memory keeps pointing at the same script.
         host.sessionScripts = SessionScript.normalized(scripts.map(\.script))
+        // Known agents' lists come from the editor; a newer schema's agent
+        // keys pass through from the live record so this save can't drop
+        // them. The normalizer applies the launch grammar's token gate.
+        var launchModels = host.agentLaunchModels.filter {
+            AgentKind(rawValue: $0.key) == nil
+        }
+        for (agentRaw, values) in resolvedLaunchModels {
+            launchModels[agentRaw] = values
+        }
+        host.agentLaunchModels = Host.normalizedLaunchModels(launchModels)
         return host
     }
 

--- a/Multiplex/Views/Deck/AgentPromptSheet.swift
+++ b/Multiplex/Views/Deck/AgentPromptSheet.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 /// The widget's ASK mode: an agent-open arrived asking for its first prompt,
-/// so collect it here — plus the starting directory, mirroring the New
-/// Session sheet's picker — and resubmit the same action with `askForPrompt`
-/// off while preserving its setup-script choice. Launching with an empty
-/// field opens the agent bare — the prompt is
+/// so collect it here — plus the starting directory and model, mirroring the
+/// New Session sheet's fields — and resubmit the same action with
+/// `askForPrompt` off while preserving its setup-script choice. Launching
+/// with an empty field opens the agent bare — the prompt is
 /// always optional, matching the New Session sheet.
 struct AgentPromptSheet: View {
     let request: AgentPromptRequest
@@ -17,12 +17,15 @@ struct AgentPromptSheet: View {
     /// explicit Home choice. Seeded with the originating action's directory,
     /// else the host's default (first working dir).
     @State private var directory: String?
+    /// Seeded with the widget setting's model; editable per launch.
+    @State private var model: String
     @FocusState private var promptFocused: Bool
 
     init(request: AgentPromptRequest) {
         self.request = request
         _directory = State(
             initialValue: request.directory ?? request.host.workingDirs.first)
+        _model = State(initialValue: request.model ?? "")
     }
 
     var body: some View {
@@ -41,6 +44,45 @@ struct AgentPromptSheet: View {
                             )
                             .lineLimit(3...8)
                             .focused($promptFocused)
+                        }
+                    }
+
+                    TallyFormSection(
+                        "Model",
+                        detail: modelDetail
+                    ) {
+                        TallyFormField("Model") {
+                            HStack(spacing: 8) {
+                                TextField("Agent default", text: $model)
+                                    .autocorrectionDisabled()
+                                    .textInputAutocapitalization(.never)
+                                    .accessibilityLabel(
+                                        "Optional model for \(request.agent.displayName)"
+                                    )
+                                let configured = request.host.launchModels(for: request.agent)
+                                if !configured.isEmpty {
+                                    Menu {
+                                        ForEach(configured, id: \.self) { candidate in
+                                            Button(candidate) { model = candidate }
+                                        }
+                                        Divider()
+                                        Button("Agent default") { model = "" }
+                                    } label: {
+                                        Image(systemName: "chevron.down")
+                                            .font(.ui(9, weight: .semibold))
+                                            .foregroundStyle(Theme.signal2)
+                                            .frame(width: 25, height: 25)
+                                            .background(Theme.chassis)
+                                            .overlay(Rectangle().strokeBorder(
+                                                Theme.bezelHi, lineWidth: 1))
+                                    }
+                                    .buttonStyle(.plain)
+                                    .chassisHover(2)
+                                    .accessibilityLabel(
+                                        "Configured models for \(request.agent.displayName)"
+                                    )
+                                }
+                            }
                         }
                     }
 
@@ -109,6 +151,14 @@ struct AgentPromptSheet: View {
         return directory
     }
 
+    private var modelDetail: String {
+        let trimmed = model.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            return "Uses \(request.agent.displayName)'s own default model."
+        }
+        return "Launches as \(request.agent.launchCommand(model: trimmed, initialPrompt: ""))."
+    }
+
     private var directoryDetail: String {
         guard !request.host.workingDirs.isEmpty else {
             return "Uses the host's login-shell home directory."
@@ -121,13 +171,15 @@ struct AgentPromptSheet: View {
 
     private func launch() {
         let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let launchModel = model.trimmingCharacters(in: .whitespaces)
         router.submit(.openAgent(
             host: .id(request.host.id),
             agent: request.agent,
             prompt: text.isEmpty ? nil : text,
             askForPrompt: false,
             directory: directory,
-            setupScript: request.setupScript
+            setupScript: request.setupScript,
+            model: launchModel.isEmpty ? nil : launchModel
         ))
         dismiss()
     }

--- a/Multiplex/Views/Deck/DeckWindow.swift
+++ b/Multiplex/Views/Deck/DeckWindow.swift
@@ -302,9 +302,12 @@ struct DeckWindow: View {
     /// deck's sheet boundary. A missing HostStore used to fatal as Host
     /// Settings opened from the compact shell.
     private func presentHostSettingsForVerificationIfRequested() async {
-        guard ProcessInfo.processInfo.environment[
+        // "models" also scrolls the sheet to the Agent launch models
+        // section (AddHostSheet reads the same variable) — the form is too
+        // tall for one headless frame and the sim cannot scroll.
+        guard ["1", "models"].contains(ProcessInfo.processInfo.environment[
             "MULTIPLEX_AUTO_HOST_SETTINGS"
-        ] == "1" else { return }
+        ]) else { return }
         for _ in 0..<50 {
             if let host = store.hosts.first {
                 editingHost = host

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -200,11 +200,12 @@ struct FleetWall: View {
             NewSessionSheet(
                 host: host,
                 existingNames: hub.model(for: host).tmux.sessions.map(\.name),
-                create: { name, agent, initialPrompt, directory, script in
+                create: { name, agent, model, initialPrompt, directory, script in
                     createSession(
                         on: host,
                         named: name,
                         launching: agent,
+                        model: model,
                         initialPrompt: initialPrompt,
                         startingIn: directory,
                         running: script
@@ -1308,8 +1309,8 @@ struct FleetWall: View {
     /// the problem.
     private func createSession(
         on host: Host, named rawName: String, launching agent: AgentKind?,
-        initialPrompt: String, startingIn directory: String?,
-        running script: SessionScript?
+        model launchModel: String?, initialPrompt: String,
+        startingIn directory: String?, running script: SessionScript?
     ) {
         let name = TmuxProbe.sanitizedSessionName(rawName)
         let model = hub.model(for: host)
@@ -1320,7 +1321,7 @@ struct FleetWall: View {
                 startingIn: directory,
                 applying: host.newSessionTmuxConf,
                 running: script?.normalizedBody,
-                typing: agent?.launchCommand(initialPrompt: initialPrompt)
+                typing: agent?.launchCommand(model: launchModel, initialPrompt: initialPrompt)
             ) else { return }
             open(TerminalRoute(hostID: host.id, mode: .attach(sessionName: created)))
         }
@@ -1373,15 +1374,18 @@ private struct SessionDropTarget: Equatable {
 /// name for the selection (main / claude / codex / pi, then
 /// -2, -3…) so Create is one tap; picking an agent re-prefills it unless
 /// the user already typed their own. Each agent can receive a one-shot first
-/// prompt as its CLI argument. An opt-in remembers only the submitted launch
-/// and setup-script choices for the next sheet. Hosts with working
+/// prompt as its CLI argument and an optional model override (free text —
+/// model names churn faster than app releases; the Command preview shows the
+/// exact line, and a value the launch grammar rejects reads as the agent
+/// default). An opt-in remembers only the submitted launch, model, and
+/// setup-script choices for the next sheet. Hosts with working
 /// directories also get a "Starts in" picker, defaulting to the first (the
 /// host's own default); hosts with setup scripts get a "Runs first" picker,
 /// defaulting to NONE unless one is remembered.
 private struct NewSessionSheet: View {
     let host: Host
     let existingNames: [String]
-    let create: (String, AgentKind?, String, String?, SessionScript?) -> Void
+    let create: (String, AgentKind?, String?, String, String?, SessionScript?) -> Void
 
     private let preferences: NewSessionPreferences
 
@@ -1395,6 +1399,7 @@ private struct NewSessionSheet: View {
     @State private var name: String
     @State private var launchMode: LaunchMode
     @State private var selectedAgent: AgentKind
+    @State private var model: String
     @State private var initialPrompt: String
     @State private var directory: String?
     @State private var script: SessionScript?
@@ -1403,13 +1408,14 @@ private struct NewSessionSheet: View {
 
     private enum InputField: Hashable {
         case name
+        case model
         case initialPrompt
     }
 
     init(
         host: Host,
         existingNames: [String],
-        create: @escaping (String, AgentKind?, String, String?, SessionScript?) -> Void,
+        create: @escaping (String, AgentKind?, String?, String, String?, SessionScript?) -> Void,
         preferences: NewSessionPreferences = NewSessionPreferences()
     ) {
         self.host = host
@@ -1421,6 +1427,7 @@ private struct NewSessionSheet: View {
         let agent = preferences.rememberedAgent
         _launchMode = State(initialValue: agent == nil ? .shell : .agents)
         _selectedAgent = State(initialValue: agent ?? .claudeCode)
+        _model = State(initialValue: agent.flatMap(preferences.rememberedModel) ?? "")
         _initialPrompt = State(initialValue: "")
         _directory = State(initialValue: host.workingDirs.first)
         _script = State(initialValue: preferences.rememberedScript(for: host))
@@ -1466,6 +1473,44 @@ private struct NewSessionSheet: View {
                             launchPicker
                         }
                         if let agent = agentToLaunch {
+                            TallyFormField("Model (optional)") {
+                                HStack(spacing: 8) {
+                                    TextField("Agent default", text: $model)
+                                        .focused($focusedField, equals: .model)
+                                        .autocorrectionDisabled()
+                                        .textInputAutocapitalization(.never)
+                                        .accessibilityLabel(
+                                            "Optional model for \(agent.displayName)"
+                                        )
+                                    // Host Settings' pre-configured list —
+                                    // the picker that spares retyping full
+                                    // Codex/Pi ids; the field stays the
+                                    // free-text escape hatch.
+                                    let configured = host.launchModels(for: agent)
+                                    if !configured.isEmpty {
+                                        Menu {
+                                            ForEach(configured, id: \.self) { candidate in
+                                                Button(candidate) { model = candidate }
+                                            }
+                                            Divider()
+                                            Button("Agent default") { model = "" }
+                                        } label: {
+                                            Image(systemName: "chevron.down")
+                                                .font(.ui(9, weight: .semibold))
+                                                .foregroundStyle(Theme.signal2)
+                                                .frame(width: 25, height: 25)
+                                                .background(Theme.chassis)
+                                                .overlay(Rectangle().strokeBorder(
+                                                    Theme.bezelHi, lineWidth: 1))
+                                        }
+                                        .buttonStyle(.plain)
+                                        .chassisHover(2)
+                                        .accessibilityLabel(
+                                            "Configured models for \(agent.displayName)"
+                                        )
+                                    }
+                                }
+                            }
                             TallyFormField("Initial prompt (optional)") {
                                 TextField(
                                     "What should \(agent.displayName) do?",
@@ -1490,9 +1535,14 @@ private struct NewSessionSheet: View {
                                 Spacer()
                                 VStack(alignment: .trailing, spacing: 3) {
                                     ChassisLabel("Command", size: 7, color: Theme.signal3)
-                                    Text(agentToLaunch?.launchCommand ?? "login shell")
+                                    // The live line minus the prompt — the
+                                    // honest surface for the model field: a
+                                    // rejected value visibly falls out.
+                                    Text(commandPreview)
                                         .font(.mono(9, weight: .medium))
                                         .foregroundStyle(Theme.signal2)
+                                        .lineLimit(1)
+                                        .truncationMode(.head)
                                 }
                             }
                         }
@@ -1585,10 +1635,11 @@ private struct NewSessionSheet: View {
                         preferences.save(
                             remembersLastLaunch: remembersLastLaunch,
                             agent: agentToLaunch,
+                            model: agentToLaunch == nil ? nil : model,
                             script: script,
                             hostID: host.id
                         )
-                        create(name, agentToLaunch, initialPrompt, directory, script)
+                        create(name, agentToLaunch, modelToLaunch, initialPrompt, directory, script)
                         dismiss()
                     }
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
@@ -1598,11 +1649,27 @@ private struct NewSessionSheet: View {
         .onChange(of: agentToLaunch) { previous, selected in
             let untouched = name == prefill(for: previous)
             if untouched { name = prefill(for: selected) }
+            // Same prefill contract for the model: an untouched field swaps
+            // to the newly selected agent's remembered model, a hand-typed
+            // one stays (its Command preview says what it will do).
+            let modelUntouched = model == modelPrefill(for: previous)
+            if modelUntouched { model = modelPrefill(for: selected) }
         }
     }
 
     private var agentToLaunch: AgentKind? {
         launchMode == .agents ? selectedAgent : nil
+    }
+
+    private var modelToLaunch: String? {
+        guard agentToLaunch != nil else { return nil }
+        let trimmed = model.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var commandPreview: String {
+        guard let agent = agentToLaunch else { return "login shell" }
+        return agent.launchCommand(model: modelToLaunch, initialPrompt: "")
     }
 
     private var launchPicker: some View {
@@ -1672,6 +1739,10 @@ private struct NewSessionSheet: View {
     private func prefill(for agent: AgentKind?) -> String {
         TmuxProbe.uniqueSessionName(
             base: agent?.launchCommand ?? "main", existing: existingNames)
+    }
+
+    private func modelPrefill(for agent: AgentKind?) -> String {
+        agent.flatMap(preferences.rememberedModel) ?? ""
     }
 
     private var launchDetail: String {
@@ -2099,7 +2170,7 @@ private enum FleetWallPreviewData {
     NewSessionSheet(
         host: FleetWallPreviewData.host,
         existingNames: ["main", "scratch"],
-        create: { _, _, _, _, _ in },
+        create: { _, _, _, _, _, _ in },
         preferences: NewSessionPreferences(
             defaults: UserDefaults(
                 suiteName: "app.multiplexterm.multiplex.preview.new-session"

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -555,9 +555,10 @@ struct TerminalWindowRoot: View {
     /// same host, same directory as its pane (an agent variant also types
     /// its launch command into the new shell) — and attach it as a new tab
     /// of this window. The session exists before the tab appears, so the
-    /// attach can't race it. The host's remembered setup script rides along
-    /// while the New Session sheet's REMEMBER opt-in is on — the quick path
-    /// inherits the choice made there, the way it inherits the pane's cwd.
+    /// attach can't race it. The host's remembered setup script — and, for
+    /// an agent variant, that agent's remembered model — rides along while
+    /// the New Session sheet's REMEMBER opt-in is on: the quick path
+    /// inherits the choices made there, the way it inherits the pane's cwd.
     private func openNewTab(launching agent: AgentKind?) {
         guard !creatingTab,
               let activeTab,
@@ -567,7 +568,8 @@ struct TerminalWindowRoot: View {
         // A plain shell tab has no pane to inherit a directory from —
         // the new session starts in $HOME, named after the host's habit.
         let source = activeTab.sessionName
-        let script = NewSessionPreferences().rememberedScript(for: host)
+        let preferences = NewSessionPreferences()
+        let script = preferences.rememberedScript(for: host)
         Task {
             defer { creatingTab = false }
             guard let name = await hub.model(for: host).createSession(
@@ -575,7 +577,12 @@ struct TerminalWindowRoot: View {
                 inDirectoryOf: source,
                 applying: host.newSessionTmuxConf,
                 running: script?.normalizedBody,
-                typing: agent?.launchCommand
+                typing: agent.map {
+                    $0.launchCommand(
+                        model: preferences.rememberedModel(for: $0),
+                        initialPrompt: ""
+                    )
+                }
             ) else {
                 newTabFailedHost = host.name
                 return

--- a/MultiplexTests/AgentSignatureTests.swift
+++ b/MultiplexTests/AgentSignatureTests.swift
@@ -12,15 +12,15 @@ final class AgentSignatureTests: XCTestCase {
         let prompt = "Review the SSH path"
 
         XCTAssertEqual(
-            AgentKind.claudeCode.launchCommand(initialPrompt: prompt),
+            AgentKind.claudeCode.launchCommand(model: nil, initialPrompt: prompt),
             "claude 'Review the SSH path'"
         )
         XCTAssertEqual(
-            AgentKind.codex.launchCommand(initialPrompt: prompt),
+            AgentKind.codex.launchCommand(model: nil, initialPrompt: prompt),
             "codex 'Review the SSH path'"
         )
         XCTAssertEqual(
-            AgentKind.pi.launchCommand(initialPrompt: prompt),
+            AgentKind.pi.launchCommand(model: nil, initialPrompt: prompt),
             "pi 'Review the SSH path'"
         )
     }
@@ -29,7 +29,7 @@ final class AgentSignatureTests: XCTestCase {
         let prompt = "Don't run $(touch /tmp/pwned); `id`"
 
         XCTAssertEqual(
-            AgentKind.claudeCode.launchCommand(initialPrompt: prompt),
+            AgentKind.claudeCode.launchCommand(model: nil, initialPrompt: prompt),
             "claude 'Don'\\''t run $(touch /tmp/pwned); `id`'"
         )
     }
@@ -38,19 +38,81 @@ final class AgentSignatureTests: XCTestCase {
         let prompt = "First line\r\nSecond\tcolumn\\n literal"
 
         XCTAssertEqual(
-            AgentKind.pi.launchCommand(initialPrompt: prompt),
+            AgentKind.pi.launchCommand(model: nil, initialPrompt: prompt),
             #"pi "$(printf '%b' 'First line\nSecond\tcolumn\\n literal')""#
         )
     }
 
     func testLaunchCommandIgnoresBlankPromptAndStripsTerminalControls() {
         XCTAssertEqual(
-            AgentKind.codex.launchCommand(initialPrompt: " \r\n\t "),
+            AgentKind.codex.launchCommand(model: nil, initialPrompt: " \r\n\t "),
             "codex"
         )
         XCTAssertEqual(
-            AgentKind.codex.launchCommand(initialPrompt: "Fix\u{0003} this"),
+            AgentKind.codex.launchCommand(model: nil, initialPrompt: "Fix\u{0003} this"),
             "codex 'Fix this'"
+        )
+    }
+
+    // Every supported CLI spells the override `--model <value>` (verified
+    // 2026-07-27: Claude Code 2.1.220, Codex rust 0.145.0, Pi 0.81.1).
+    func testLaunchCommandCarriesModelBeforeThePromptForEveryAgent() {
+        XCTAssertEqual(
+            AgentKind.claudeCode.launchCommand(model: "opus", initialPrompt: ""),
+            "claude --model 'opus'"
+        )
+        XCTAssertEqual(
+            AgentKind.codex.launchCommand(model: "gpt-5-codex", initialPrompt: "go"),
+            "codex --model 'gpt-5-codex' 'go'"
+        )
+        // Pi models may be provider-scoped with a thinking suffix.
+        XCTAssertEqual(
+            AgentKind.pi.launchCommand(
+                model: "anthropic/claude-opus-4:high", initialPrompt: ""),
+            "pi --model 'anthropic/claude-opus-4:high'"
+        )
+    }
+
+    func testLaunchCommandQuotesModelSoAliasBracketsCannotGlob() {
+        // `sonnet[1m]` is a real Claude Code alias; unquoted it is a zsh
+        // glob and a failed-match error instead of a launch.
+        XCTAssertEqual(
+            AgentKind.claudeCode.launchCommand(model: "sonnet[1m]", initialPrompt: ""),
+            "claude --model 'sonnet[1m]'"
+        )
+    }
+
+    func testNormalizedLaunchModelAcceptsRealIdentifierShapes() {
+        XCTAssertEqual(AgentKind.normalizedLaunchModel("  opus  "), "opus")
+        XCTAssertEqual(
+            AgentKind.normalizedLaunchModel("claude-sonnet-4-5-20250929"),
+            "claude-sonnet-4-5-20250929"
+        )
+        XCTAssertEqual(
+            AgentKind.normalizedLaunchModel("google/gemini-2.5-pro:minimal"),
+            "google/gemini-2.5-pro:minimal"
+        )
+    }
+
+    func testNormalizedLaunchModelRejectsNonTokenShapes() {
+        // Empty and whitespace-only mean "agent default".
+        XCTAssertNil(AgentKind.normalizedLaunchModel(""))
+        XCTAssertNil(AgentKind.normalizedLaunchModel("   "))
+        // Interior whitespace could smuggle a second shell word.
+        XCTAssertNil(AgentKind.normalizedLaunchModel(
+            "opus --dangerously-skip-permissions"))
+        // A leading dash must never read as another flag.
+        XCTAssertNil(AgentKind.normalizedLaunchModel("--help"))
+        // Control bytes strip first; what remains must still be a token.
+        XCTAssertEqual(AgentKind.normalizedLaunchModel("op\u{0003}us"), "opus")
+        XCTAssertNil(AgentKind.normalizedLaunchModel(String(repeating: "m", count: 65)))
+    }
+
+    func testLaunchCommandDropsRejectedModels() {
+        XCTAssertEqual(
+            AgentKind.claudeCode.launchCommand(
+                model: "opus extra-word", initialPrompt: "go"),
+            "claude 'go'"
         )
     }
 

--- a/MultiplexTests/ExternalActionTests.swift
+++ b/MultiplexTests/ExternalActionTests.swift
@@ -28,7 +28,8 @@ final class ExternalActionTests: XCTestCase {
             prompt: "fix the build\nthen run tests & say \"done\" 100%",
             askForPrompt: true,
             directory: nil,
-            setupScript: .remembered
+            setupScript: .remembered,
+            model: nil
         )
         let url = ExternalActionURL.url(for: action)
         XCTAssertEqual(ExternalActionURL.action(from: url), action)
@@ -38,7 +39,7 @@ final class ExternalActionTests: XCTestCase {
         let action = ExternalAction.openAgent(
             host: .id(UUID()), agent: .pi, prompt: nil,
             askForPrompt: false, directory: nil,
-            setupScript: .remembered)
+            setupScript: .remembered, model: nil)
         XCTAssertEqual(
             ExternalActionURL.action(from: ExternalActionURL.url(for: action)),
             action
@@ -50,7 +51,7 @@ final class ExternalActionTests: XCTestCase {
             let action = ExternalAction.openAgent(
                 host: .id(UUID()), agent: .claudeCode, prompt: "go",
                 askForPrompt: true, directory: directory,
-                setupScript: .remembered)
+                setupScript: .remembered, model: nil)
             XCTAssertEqual(
                 ExternalActionURL.action(from: ExternalActionURL.url(for: action)),
                 action
@@ -66,13 +67,41 @@ final class ExternalActionTests: XCTestCase {
             let action = ExternalAction.openAgent(
                 host: .id(UUID()), agent: .codex, prompt: nil,
                 askForPrompt: false, directory: nil,
-                setupScript: selection
+                setupScript: selection, model: nil
             )
             XCTAssertEqual(
                 ExternalActionURL.action(from: ExternalActionURL.url(for: action)),
                 action
             )
         }
+    }
+
+    func testAgentURLRoundTripsModel() {
+        for model in ["opus", "sonnet[1m]", "google/gemini-2.5-pro:minimal"] {
+            let action = ExternalAction.openAgent(
+                host: .id(UUID()), agent: .claudeCode, prompt: "go",
+                askForPrompt: false, directory: nil,
+                setupScript: .remembered, model: model)
+            XCTAssertEqual(
+                ExternalActionURL.action(from: ExternalActionURL.url(for: action)),
+                action
+            )
+        }
+    }
+
+    func testMalformedModelParsesAsAgentDefaultNotAsFailure() {
+        // Unlike a bad script token (strict — a wrong script runs arbitrary
+        // text), a model the launch grammar rejects reads as omitted: the
+        // action still runs, on the agent's own default.
+        let url = URL(string:
+            "multiplex://open?host=devbox&action=agent&agent=claude&model=--help")!
+        XCTAssertEqual(
+            ExternalActionURL.action(from: url),
+            .openAgent(
+                host: .named("devbox"), agent: .claudeCode, prompt: nil,
+                askForPrompt: false, directory: nil,
+                setupScript: .remembered, model: nil)
+        )
     }
 
     // MARK: Parsing
@@ -100,13 +129,13 @@ final class ExternalActionTests: XCTestCase {
             .openAgent(
                 host: .named("devbox"), agent: .claudeCode, prompt: nil,
                 askForPrompt: false, directory: nil,
-                setupScript: .remembered)
+                setupScript: .remembered, model: nil)
         )
     }
 
     func testAgentDefaultsToClaudeCode() {
         let url = URL(string: "multiplex://open?host=devbox&action=agent")!
-        guard case .openAgent(_, let agent, _, _, _, _)? = ExternalActionURL.action(from: url) else {
+        guard case .openAgent(_, let agent, _, _, _, _, _)? = ExternalActionURL.action(from: url) else {
             return XCTFail("expected openAgent")
         }
         XCTAssertEqual(agent, .claudeCode)

--- a/MultiplexTests/HostSyncTests.swift
+++ b/MultiplexTests/HostSyncTests.swift
@@ -108,6 +108,32 @@ final class HostSyncTests: XCTestCase {
         XCTAssertNil(host.moshPorts)
         XCTAssertEqual(host.workingDirs, [])
         XCTAssertTrue(host.agentCommandConfiguration.isEmpty)
+        XCTAssertEqual(host.agentLaunchModels, [:])
+    }
+
+    func testHostLaunchModelsRoundTripNormalizedAndKeepUnknownAgents() throws {
+        var original = host("devbox", updatedAt: Date(timeIntervalSince1970: 1234))
+        original.agentLaunchModels = [
+            // Dupes collapse in order; a token the launch grammar rejects
+            // can never ride a launch line, so it never becomes a picker row.
+            "claudeCode": ["opus", "  opus  ", "sonnet[1m]", "not a model"],
+            "codex": [],
+            // A newer schema's agent must survive decode + re-encode here.
+            "futureAgent": ["shiny-model"],
+        ]
+        original.agentLaunchModels = Host.normalizedLaunchModels(original.agentLaunchModels)
+        XCTAssertEqual(
+            original.agentLaunchModels,
+            [
+                "claudeCode": ["opus", "sonnet[1m]"],
+                "futureAgent": ["shiny-model"],
+            ]
+        )
+        XCTAssertEqual(original.launchModels(for: .claudeCode), ["opus", "sonnet[1m]"])
+        XCTAssertEqual(original.launchModels(for: .codex), [])
+
+        let decoded = try JSONDecoder().decode(Host.self, from: JSONEncoder().encode(original))
+        XCTAssertEqual(decoded, original)
     }
 
     func testHostRoundTripsThroughRecordEncoding() throws {
@@ -153,6 +179,7 @@ final class HostSyncTests: XCTestCase {
             for: .claudeCode
         )
         commandsEdited.newSessionTmuxConf = "mouse on\nhistory-limit 50000"
+        commandsEdited.agentLaunchModels = ["claudeCode": ["opus"]]
         commandsEdited.updatedAt = .now
 
         XCTAssertTrue(

--- a/MultiplexTests/NewSessionPreferencesTests.swift
+++ b/MultiplexTests/NewSessionPreferencesTests.swift
@@ -30,13 +30,14 @@ final class NewSessionPreferencesTests: XCTestCase {
 
         XCTAssertFalse(preferences.remembersLastLaunch)
         XCTAssertNil(preferences.rememberedAgent)
+        XCTAssertNil(preferences.rememberedModel(for: .claudeCode))
         XCTAssertNil(preferences.rememberedScript(for: host))
     }
 
     func testPersistsRememberedAgentAcrossInstances() {
         NewSessionPreferences(defaults: defaults).save(
             remembersLastLaunch: true,
-            agent: .codex,
+            agent: .codex, model: nil,
             script: nil,
             hostID: host.id
         )
@@ -49,7 +50,7 @@ final class NewSessionPreferencesTests: XCTestCase {
     func testPersistsRememberedPiAcrossInstances() {
         NewSessionPreferences(defaults: defaults).save(
             remembersLastLaunch: true,
-            agent: .pi,
+            agent: .pi, model: nil,
             script: nil,
             hostID: host.id
         )
@@ -62,7 +63,7 @@ final class NewSessionPreferencesTests: XCTestCase {
     func testCanRememberShellOnly() {
         let preferences = NewSessionPreferences(defaults: defaults)
         preferences.save(
-            remembersLastLaunch: true, agent: nil, script: nil, hostID: host.id
+            remembersLastLaunch: true, agent: nil, model: nil, script: nil, hostID: host.id
         )
 
         XCTAssertTrue(preferences.remembersLastLaunch)
@@ -73,11 +74,11 @@ final class NewSessionPreferencesTests: XCTestCase {
     func testDisablingClearsStaleAgent() {
         let preferences = NewSessionPreferences(defaults: defaults)
         preferences.save(
-            remembersLastLaunch: true, agent: .claudeCode,
+            remembersLastLaunch: true, agent: .claudeCode, model: "opus",
             script: script, hostID: host.id
         )
         preferences.save(
-            remembersLastLaunch: false, agent: .claudeCode,
+            remembersLastLaunch: false, agent: .claudeCode, model: "opus",
             script: script, hostID: host.id
         )
 
@@ -85,8 +86,61 @@ final class NewSessionPreferencesTests: XCTestCase {
         XCTAssertNil(preferences.rememberedAgent)
         XCTAssertNil(defaults.string(forKey: "newSession.lastAgent"))
         XCTAssertNil(preferences.rememberedScript(for: host))
-        // The whole per-host map goes, not just this host's entry.
+        // The whole per-host map goes, not just this host's entry — and the
+        // per-agent model map with it.
         XCTAssertNil(defaults.dictionary(forKey: "newSession.lastScripts"))
+        XCTAssertNil(preferences.rememberedModel(for: .claudeCode))
+        XCTAssertNil(defaults.dictionary(forKey: "newSession.lastModels"))
+    }
+
+    func testRemembersModelPerAgent() {
+        let preferences = NewSessionPreferences(defaults: defaults)
+        preferences.save(
+            remembersLastLaunch: true, agent: .claudeCode, model: "  opus  ",
+            script: nil, hostID: host.id
+        )
+        preferences.save(
+            remembersLastLaunch: true, agent: .codex, model: "gpt-5-codex",
+            script: nil, hostID: host.id
+        )
+
+        let reloaded = NewSessionPreferences(defaults: defaults)
+        XCTAssertEqual(reloaded.rememberedModel(for: .claudeCode), "opus")
+        XCTAssertEqual(reloaded.rememberedModel(for: .codex), "gpt-5-codex")
+        XCTAssertNil(reloaded.rememberedModel(for: .pi))
+    }
+
+    func testShellOnlySaveKeepsOtherAgentsModels() {
+        let preferences = NewSessionPreferences(defaults: defaults)
+        preferences.save(
+            remembersLastLaunch: true, agent: .claudeCode, model: "opus",
+            script: nil, hostID: host.id
+        )
+        preferences.save(
+            remembersLastLaunch: true, agent: nil, model: nil,
+            script: nil, hostID: host.id
+        )
+
+        XCTAssertEqual(preferences.rememberedModel(for: .claudeCode), "opus")
+    }
+
+    func testEmptyModelForgetsOnlyThatAgentsEntry() {
+        let preferences = NewSessionPreferences(defaults: defaults)
+        preferences.save(
+            remembersLastLaunch: true, agent: .claudeCode, model: "opus",
+            script: nil, hostID: host.id
+        )
+        preferences.save(
+            remembersLastLaunch: true, agent: .codex, model: "gpt-5-codex",
+            script: nil, hostID: host.id
+        )
+        preferences.save(
+            remembersLastLaunch: true, agent: .claudeCode, model: "   ",
+            script: nil, hostID: host.id
+        )
+
+        XCTAssertNil(preferences.rememberedModel(for: .claudeCode))
+        XCTAssertEqual(preferences.rememberedModel(for: .codex), "gpt-5-codex")
     }
 
     func testRemembersScriptPerHost() {
@@ -96,7 +150,7 @@ final class NewSessionPreferencesTests: XCTestCase {
         )
         let preferences = NewSessionPreferences(defaults: defaults)
         preferences.save(
-            remembersLastLaunch: true, agent: nil, script: script, hostID: host.id
+            remembersLastLaunch: true, agent: nil, model: nil, script: script, hostID: host.id
         )
 
         let reloaded = NewSessionPreferences(defaults: defaults)
@@ -108,10 +162,10 @@ final class NewSessionPreferencesTests: XCTestCase {
     func testRememberingNoneClearsTheHostEntry() {
         let preferences = NewSessionPreferences(defaults: defaults)
         preferences.save(
-            remembersLastLaunch: true, agent: nil, script: script, hostID: host.id
+            remembersLastLaunch: true, agent: nil, model: nil, script: script, hostID: host.id
         )
         preferences.save(
-            remembersLastLaunch: true, agent: nil, script: nil, hostID: host.id
+            remembersLastLaunch: true, agent: nil, model: nil, script: nil, hostID: host.id
         )
 
         XCTAssertNil(preferences.rememberedScript(for: host))
@@ -120,7 +174,7 @@ final class NewSessionPreferencesTests: XCTestCase {
     func testDeletedScriptFailsSoftToNone() {
         let preferences = NewSessionPreferences(defaults: defaults)
         preferences.save(
-            remembersLastLaunch: true, agent: nil, script: script, hostID: host.id
+            remembersLastLaunch: true, agent: nil, model: nil, script: script, hostID: host.id
         )
 
         var edited = host

--- a/MultiplexTests/SharedStateTests.swift
+++ b/MultiplexTests/SharedStateTests.swift
@@ -159,6 +159,36 @@ final class SharedStateTests: XCTestCase {
         XCTAssertEqual(AgentModelChoices.values(configured: []), [])
     }
 
+    func testAgentModelChoicesAreNeverEmptyAndLeadWithAgentDefault() {
+        // A zero-item options query flash-dismisses the widget config
+        // picker, so Agent Default always leads.
+        XCTAssertEqual(
+            AgentModelChoices.choices(configured: []),
+            [.init(value: "", title: "Agent Default")]
+        )
+        XCTAssertEqual(
+            AgentModelChoices.choices(configured: ["gpt-5-codex"]),
+            [
+                .init(value: "", title: "Agent Default"),
+                .init(value: "gpt-5-codex", title: "gpt-5-codex"),
+            ]
+        )
+        // The sentinel must read as "no model" where the value is consumed:
+        // the launch grammar rejects it and the widget link omits it.
+        XCTAssertNil(AgentKind.normalizedLaunchModel(AgentModelChoices.agentDefaultValue))
+        XCTAssertEqual(
+            ExternalActionURL.action(from: WidgetLink.agentURL(
+                hostID: UUID(), agentRaw: "codex", askForPrompt: false,
+                model: AgentModelChoices.agentDefaultValue))
+                .flatMap { action -> String?? in
+                    guard case .openAgent(_, _, _, _, _, _, let model) = action
+                    else { return nil }
+                    return .some(model)
+                },
+            .some(nil)
+        )
+    }
+
     // MARK: AgentChoice ↔ AgentKind
 
     func testAgentChoiceMirrorsAgentKindOneToOne() {

--- a/MultiplexTests/SharedStateTests.swift
+++ b/MultiplexTests/SharedStateTests.swift
@@ -51,10 +51,34 @@ final class SharedStateTests: XCTestCase {
                     .openAgent(
                         host: .id(id), agent: agent, prompt: nil,
                         askForPrompt: ask, directory: nil,
-                        setupScript: .remembered)
+                        setupScript: .remembered, model: nil)
                 )
             }
         }
+    }
+
+    func testWidgetAgentLinkCarriesConfiguredModel() {
+        let id = UUID()
+        XCTAssertEqual(
+            ExternalActionURL.action(from: WidgetLink.agentURL(
+                hostID: id, agentRaw: "codex", askForPrompt: false,
+                model: "gpt-5-codex")),
+            .openAgent(
+                host: .id(id), agent: .codex, prompt: nil,
+                askForPrompt: false, directory: nil,
+                setupScript: .remembered, model: "gpt-5-codex")
+        )
+        // The widget passes its configuration text through unvalidated; the
+        // app-side parser owns the grammar, so junk reads as agent default.
+        XCTAssertEqual(
+            ExternalActionURL.action(from: WidgetLink.agentURL(
+                hostID: id, agentRaw: "codex", askForPrompt: false,
+                model: "two words")),
+            .openAgent(
+                host: .id(id), agent: .codex, prompt: nil,
+                askForPrompt: false, directory: nil,
+                setupScript: .remembered, model: nil)
+        )
     }
 
     // MARK: Shortcut working directories
@@ -119,6 +143,22 @@ final class SharedStateTests: XCTestCase {
         )
     }
 
+    // MARK: Launch-model choices
+
+    func testAgentModelChoicesTrimAndDedupeInOrder() {
+        XCTAssertEqual(
+            AgentModelChoices.values(configured: [
+                "  gpt-5-codex  ",
+                "gpt-5-codex",
+                "",
+                "anthropic/claude-opus-4:high",
+                "   ",
+            ]),
+            ["gpt-5-codex", "anthropic/claude-opus-4:high"]
+        )
+        XCTAssertEqual(AgentModelChoices.values(configured: []), [])
+    }
+
     // MARK: AgentChoice ↔ AgentKind
 
     func testAgentChoiceMirrorsAgentKindOneToOne() {
@@ -162,7 +202,8 @@ final class SharedStateTests: XCTestCase {
                     miniatureLines: ["$ pnpm build", "✓ 214 modules · 3.2s"],
                     createdAt: Date(timeIntervalSince1970: 100)
                 )],
-                probedAt: Date(timeIntervalSince1970: 200)
+                probedAt: Date(timeIntervalSince1970: 200),
+                agentModels: ["codex": ["gpt-5-codex"], "claudeCode": ["opus"]]
             )],
             generatedAt: Date(timeIntervalSince1970: 300)
         )
@@ -197,6 +238,8 @@ final class SharedStateTests: XCTestCase {
         XCTAssertEqual(session.windowNames, ["editor", "server"])
         XCTAssertEqual(session.windowPaneTitles, [])
         XCTAssertNil(session.activePaneTitle)
+        // Launch-model lists arrived later still; absent decodes as none.
+        XCTAssertNil(state.hosts.first?.agentModels)
     }
 
     func testLoadFailsSoftOnMissingFile() {

--- a/MultiplexTests/TmuxProbeTests.swift
+++ b/MultiplexTests/TmuxProbeTests.swift
@@ -443,6 +443,7 @@ final class TmuxProbeTests: XCTestCase {
 
     func testNewSessionCommandTypesPromptLaunchLiterally() {
         let launch = AgentKind.claudeCode.launchCommand(
+            model: nil,
             initialPrompt: "Review John's $(touch /tmp/pwned)"
         )
         let command = TmuxProbe.newSessionCommand(

--- a/MultiplexTests/WidgetStateBuilderTests.swift
+++ b/MultiplexTests/WidgetStateBuilderTests.swift
@@ -27,7 +27,8 @@ final class WidgetStateBuilderTests: XCTestCase {
     }
 
     func testHostStateProjectsSessionsWindowsAndMiniatures() {
-        let host = Host(name: "devbox", hostname: "10.0.1.7", username: "jhen")
+        var host = Host(name: "devbox", hostname: "10.0.1.7", username: "jhen")
+        host.agentLaunchModels = ["codex": ["gpt-5-codex"]]
         let sessions = [session(
             name: "main",
             created: 100,
@@ -49,6 +50,14 @@ final class WidgetStateBuilderTests: XCTestCase {
         XCTAssertEqual(state.name, "devbox")
         XCTAssertEqual(state.address, "jhen@10.0.1.7")
         XCTAssertEqual(state.probedAt, probed)
+        // Configured launch models feed the widget's Model setting picker;
+        // a host with none stays nil so legacy-file shape and no-config
+        // shape read the same.
+        XCTAssertEqual(state.agentModels, ["codex": ["gpt-5-codex"]])
+        XCTAssertNil(WidgetStateBuilder.hostState(
+            host: Host(name: "b", hostname: "h", username: "u"),
+            sessions: [], miniatures: [:], probedAt: nil
+        ).agentModels)
         XCTAssertEqual(state.sessions.count, 1)
         let main = state.sessions[0]
         XCTAssertEqual(main.name, "main")

--- a/MultiplexWidgets/HostWidget.swift
+++ b/MultiplexWidgets/HostWidget.swift
@@ -126,7 +126,8 @@ struct HostWidgetView: View {
             WidgetLink.agentURL(
                 hostID: host.id,
                 agentRaw: entry.configuration.agent.rawValue,
-                askForPrompt: entry.configuration.askForPrompt
+                askForPrompt: entry.configuration.askForPrompt,
+                model: entry.configuration.model
             )
         }
     }
@@ -194,7 +195,8 @@ struct HostWidgetView: View {
                     Link(destination: WidgetLink.agentURL(
                         hostID: host.id,
                         agentRaw: entry.configuration.agent.rawValue,
-                        askForPrompt: entry.configuration.askForPrompt
+                        askForPrompt: entry.configuration.askForPrompt,
+                        model: entry.configuration.model
                     )) {
                         ActionKey(
                             glyph: "✳",

--- a/MultiplexWidgets/HostWidgetConfigurationIntent.swift
+++ b/MultiplexWidgets/HostWidgetConfigurationIntent.swift
@@ -19,8 +19,39 @@ struct HostWidgetConfigurationIntent: WidgetConfigurationIntent {
     @Parameter(title: "Agent", default: .claudeCode)
     var agent: AgentChoice
 
+    /// Rides the launch as `--model <value>`; unset means the agent's
+    /// default. Choices are the host's pre-configured launch models from the
+    /// published snapshot — full Codex/Pi ids are typed once in Host
+    /// Settings, never into a widget text field. Validation stays app-side
+    /// in the URL parser, so a stale value falls back to the default
+    /// instead of a malformed launch line.
+    @Parameter(title: "Model", optionsProvider: WidgetAgentModelOptionsProvider())
+    var model: String?
+
     @Parameter(title: "Ask for Prompt", default: false)
     var askForPrompt: Bool
+}
+
+/// Widget-process provider: reads the same `HostEntityProvider` surface the
+/// Shortcut picker uses (snapshot-backed here) and the same shared choice
+/// builder, so both pickers offer identical rows.
+struct WidgetAgentModelOptionsProvider: DynamicOptionsProvider {
+    @IntentParameterDependency<HostWidgetConfigurationIntent>(\.$host, \.$agent)
+    private var intent
+
+    func results() async throws -> IntentItemCollection<String> {
+        let hosts = await HostEntityProvider.all()
+        let configured = intent.flatMap { dependency in
+            hosts.first { $0.id == dependency.host.id }?
+                .agentModels[dependency.agent.rawValue]
+        } ?? []
+        let items = AgentModelChoices.values(configured: configured)
+            .map { IntentItem($0) }
+        return IntentItemCollection(
+            promptLabel: "Choose a model",
+            sections: [IntentItemSection(items: items)]
+        )
+    }
 }
 
 enum WidgetTapAction: String, AppEnum {

--- a/MultiplexWidgets/HostWidgetConfigurationIntent.swift
+++ b/MultiplexWidgets/HostWidgetConfigurationIntent.swift
@@ -45,8 +45,10 @@ struct WidgetAgentModelOptionsProvider: DynamicOptionsProvider {
             hosts.first { $0.id == dependency.host.id }?
                 .agentModels[dependency.agent.rawValue]
         } ?? []
-        let items = AgentModelChoices.values(configured: configured)
-            .map { IntentItem($0) }
+        // Never empty — a zero-item options query flash-dismisses the
+        // picker; the leading Agent Default row always renders.
+        let items = AgentModelChoices.choices(configured: configured)
+            .map { IntentItem($0.value, title: "\($0.title)") }
         return IntentItemCollection(
             promptLabel: "Choose a model",
             sections: [IntentItemSection(items: items)]

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -49,10 +49,10 @@ Free surfaces added 2026-07-18 (unreleased; ships with the next binary):
 | Surface | Facts |
 | --- | --- |
 | Widget extension | `MultiplexWidgets` (`app.multiplexterm.multiplex.widgets`), embedded in the app; iPadOS 17.0+, visionOS 26.0+ (WidgetKit does not exist on earlier visionOS — the app itself stays 1.0) |
-| Widgets | "Host Monitor" (small/medium, configurable: host, small-tap action, agent, ask-for-prompt) and "Fleet Wall" (medium/large, host order follows the deck) |
-| Widget data | Last-known sessions/miniatures from an App Group snapshot (`group.app.multiplexterm.multiplex`, `widget-state.json`, secret-free). Widgets never open connections and show no liveness claims — a relative SEEN stamp only |
-| App Shortcuts | "Open Shell" (attach most recent tmux session or create) and "Open Agent" (Claude Code/Codex/Pi, host-configured working-directory and setup-script pickers, optional first prompt) — run in-app with a connection status guard; failures surface as an in-app alert |
-| URL scheme | `multiplex://open?host=<uuid|name>&action=shell\|agent[&session=…][&agent=…][&prompt=…][&ask=1][&dir=…][&script=<uuid\|none>]` — widget taps and user automation; omitting `script` uses the remembered New Session choice |
+| Widgets | "Host Monitor" (small/medium, configurable: host, small-tap action, agent, optional model picked from the host's configured launch models, ask-for-prompt) and "Fleet Wall" (medium/large, host order follows the deck) |
+| Widget data | Last-known sessions/miniatures plus configured agent model names from an App Group snapshot (`group.app.multiplexterm.multiplex`, `widget-state.json`, secret-free). Widgets never open connections and show no liveness claims — a relative SEEN stamp only |
+| App Shortcuts | "Open Shell" (attach most recent tmux session or create) and "Open Agent" (Claude Code/Codex/Pi, host-configured working-directory, setup-script, and launch-model pickers — models passed as `--model` — optional first prompt) — run in-app with a connection status guard; failures surface as an in-app alert |
+| URL scheme | `multiplex://open?host=<uuid|name>&action=shell\|agent[&session=…][&agent=…][&prompt=…][&ask=1][&dir=…][&script=<uuid\|none>][&model=…]` — widget taps and user automation; omitting `script` uses the remembered New Session choice, omitting `model` uses the agent's default |
 | Privacy impact | None: the App Group snapshot stays on-device, contains no credentials, and adds no new data collection; setup-script bodies remain in the app's host record and never become Shortcut parameter values |
 
 The App Group entitlement must exist on the App ID for device/TestFlight
@@ -122,8 +122,10 @@ Current product split:
   shortcut dropdown on both platforms (including touch-native copy-mode
   selection and explicit exit), Home Screen widgets (per-host monitor +
   fleet wall; iPadOS 17+, visionOS 26+) and App Shortcuts ("Open Shell" /
-  "Open Agent" with host-configured working-directory and setup-script
-  pickers plus an optional first prompt) with the
+  "Open Agent" with host-configured working-directory, setup-script, and
+  launch-model pickers plus an optional first prompt; per-host agent model
+  lists are configured once in Host Settings and offered on the New Session
+  sheet and widget setting too) with the
   `multiplex://` deep-link
   scheme behind them, iCloud Keychain host/secret/command-setup sync,
   per-host/per-agent


### PR DESCRIPTION
## What

Pick an agent model before a session opens — on the New Session sheet, the Open Agent Shortcut, and the Host widget setting — with the candidate ids configured **once per host** in Host Settings instead of retyped at every launch.

## Why this shape

- **One verified flag.** Claude Code 2.1.220, Codex rust 0.145.0, and Pi 0.81.1 all spell it `--model <value>` (checked against the real binaries). Composition is one pure function, `AgentKind.launchCommand(model:initialPrompt:)`, with the value always shell-quoted — Claude's `sonnet[1m]` alias would otherwise glob in zsh.
- **Free text alone was a bad experience.** Only Claude Code has short aliases; Codex/Pi need full ids. `Host.agentLaunchModels` stores per-agent lists (compact one-id-per-line fields in Host Settings), and every surface offers them as a picker with free text kept as the escape hatch. Host-scoped on purpose: Pi's available models genuinely differ per machine with its configured providers.
- **Fail-soft.** `normalizedLaunchModel` only enforces argv-token shape (no whitespace, no leading `-`, no controls, ≤64 chars); rejection means the agent's own default, never an error. A wrong-but-token-shaped model fails visibly in the agent's own UI, the existing chip philosophy.

## Surfaces

- New Session sheet: model field + preset menu + live Command preview; REMEMBER stores the choice per agent; + TAB's agent variants inherit it
- Open Agent Shortcut: Model parameter with host+agent-dependent suggestions (String, so Shortcuts variables keep working)
- Host widget: Model setting picks from the same lists in the widget process (`WidgetHostState.agentModels` App Group projection — names only, no secrets)
- ASK-mode prompt sheet: seeded, editable, same menu
- `multiplex://` grammar gains `[&model=<id>]`, parsed fail-soft

Sync/identity follow the scripts/conf precedent: lists ride the synced Host record, are zeroed out of `connectionModelConfiguration` (edits keep the probe link), and unknown agent keys survive normalization so a newer schema's list can't be dropped by an edit-save. External actions never inherit the remembered model — an automation carries its own or gets the agent default, so one widget behaves identically on every device.

## Verification

- 543/543 unit tests (flag composition + sanitizer, URL round-trips, widget-link lockstep, per-agent memory, record round-trip + unknown-key preservation, projection codec/legacy decode)
- E2E on the visionOS sim against the sshd harness: a widget-grammar URL with a model minted a session whose pane shows `pi --model '<value>'` typed at the prompt and the real `pi` binary answering — plus the disabled-host guard correctly refusing along the way
- A seeded host's lists landed normalized in `hosts.json` and in the App Group `widget-state.json` the widget picker reads; the redesigned Host Settings section captured on-sim via the new scroll hook
- New DEBUG hooks (documented in AGENTS.md): `MULTIPLEX_AUTO_ACTION_URL` (headless widget-tap stand-in; `simctl openurl`'s first-open confirmation can't be clicked since Xcode 27 removed SimulatorKit) and `MULTIPLEX_AUTO_HOST_SETTINGS=models`
- Not headlessly checkable: the picker UIs themselves on device (visionOS sims are gaze-only) — worth one human pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)