### PR TITLE
Open a pane's URL in a viewport — an inline browser tab that moves like a session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -758,14 +758,27 @@ views.
   the chip becomes `⌗ OPEN VIA <host>` and rewrites the authority to
   `Host.hostname` (by definition the address this device already dials),
   said in the open on the sheet; LAN/internet targets pass through
-  verbatim, and non-web links are never offered a viewport. **Nothing
+  verbatim, and non-web links are never offered a viewport. The rail's
+  readout is tap-to-edit: a typed address is the user's own intent, so it
+  skips the sheet but rides the same admit path
+  (`ViewportOffer.fromTypedInput` — web schemes only, a schemeless address
+  defaulted by reach: http for LAN/loopback, https otherwise, loopback
+  rewritten via the host), the editor lives in the pane's TOP contextual
+  slot because the pane opts out of keyboard avoidance for the terminal's
+  sake (a bottom-rail field would sit under a docked keyboard), and the
+  rail tag + tab label track the page the viewport is actually on, not the
+  address it was summoned with. **Nothing
   persists**: controllers live only in `TerminalWorkspace`'s memory and are
   registered BEFORE the tab enters any route, so `syncTabs` stripping
   controller-less viewport tabs removes exactly the ones scene restoration
   hands back from a dead process, never a live move. `WKNavigationDelegate`
   re-applies the scheme allowlist per navigation (`multiplex:` is never
   navigable; mailto re-presents the link sheet from the pane), there is no
-  JS bridge and no send path into any terminal, and a viewport never claims
+  JS bridge and no send path into any terminal; the app-scoped persistent
+  `WKWebsiteDataStore` is shared by every viewport (a dev login survives
+  across tabs and reloads) and **Clear Browsing Data…** on the readout's
+  long-press menu wipes it globally after a confirmation that says so,
+  then reloads the page signed out; and a viewport never claims
   `TerminalFocusArbiter` — switching to a ⌗ tab releases the previous
   terminal's responder so hardware keys can't type into a hidden shell.
   ATS is relaxed for **web content only** (`NSAllowsArbitraryLoadsInWebContent`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,11 @@ the focused pane's visible screen through the same resolve → policy →
 confirmation path a long press takes (a screen of only filesystem paths
 must present nothing — that's the decline working), with
 `….debug.linkopen` running the sheet's OPEN action so the system log shows
-the URL reaching SurfBoard, and
+the URL reaching SurfBoard, and `….debug.viewportopen` running the sheet's
+⌗ VIEWPORT chip for the pending link — the headless way to dock the inline
+browser tab (raise the sheet with `….debug.link` first; the loopback proof
+is a `localhost:<port>` URL in the pane rewriting to the seed host's
+address and rendering a page served on the Mac), and
 `… -p app.multiplexterm.multiplex.debug.msgjump` / `….debug.msgjumpback`
 jumps the focused Claude Code terminal to its oldest session-file prompt
 and runs BACK TO LIVE — host-side `tmux capture-pane` proves both (the old
@@ -395,6 +399,11 @@ SwiftUI: classic Deck window + N Terminal windows, or one adaptive Shell
                      only, the channel the remap preserves.
   TerminalWorkspace  tab controllers keyed by tab id + window directory —
                      merge/split move tabs across windows, shells stay live
+    ViewportController  one per ⌗ viewport tab (the inline browser): owns
+                     the WKWebView so merge/split re-parent the live page;
+                     kept in memory only — its absence after a relaunch IS
+                     the viewport's no-persistence rule (syncTabs strips
+                     controller-less viewport tabs)
   TerminalSessionController   one per tab; owns the input pump + TerminalView
     TerminalTransport    the tab's byte pipe (write/resize/close); picked by
                          host.useMosh. exec + SFTP stay SSH-only capabilities
@@ -736,6 +745,34 @@ views.
   "fix" it with a server-scoped `terminal-features` default (the same leak
   the per-host new-session conf documents). Full record + the verified
   experiment table: `local-plan/terminal-links.md`.
+- **The viewport is a citizen of the window system — summoned, never
+  restored** (`TerminalRoute.Mode.viewport`; `ViewportReach`/`ViewportOffer`
+  pure + tested; `ViewportController`, `ViewportPane`; bake-off record in
+  `local-plan/viewport-bakeoff/`): a *confirmed* web link docks as a ⌗ tab
+  beside the session that printed it and moves with the existing
+  merge/split machinery — the WKWebView is controller-owned and re-parents
+  exactly like SwiftTerm views, so the live page (HMR socket included)
+  survives every move; its cell never wears a tally dot (a page is not a
+  shell). The link sheet stays the only gate and grows a REACH row: a pane
+  runs on the host, so `localhost` printed there is the *host's* loopback —
+  the chip becomes `⌗ OPEN VIA <host>` and rewrites the authority to
+  `Host.hostname` (by definition the address this device already dials),
+  said in the open on the sheet; LAN/internet targets pass through
+  verbatim, and non-web links are never offered a viewport. **Nothing
+  persists**: controllers live only in `TerminalWorkspace`'s memory and are
+  registered BEFORE the tab enters any route, so `syncTabs` stripping
+  controller-less viewport tabs removes exactly the ones scene restoration
+  hands back from a dead process, never a live move. `WKNavigationDelegate`
+  re-applies the scheme allowlist per navigation (`multiplex:` is never
+  navigable; mailto re-presents the link sheet from the pane), there is no
+  JS bridge and no send path into any terminal, and a viewport never claims
+  `TerminalFocusArbiter` — switching to a ⌗ tab releases the previous
+  terminal's responder so hardware keys can't type into a hidden shell.
+  ATS is relaxed for **web content only** (`NSAllowsArbitraryLoadsInWebContent`
+  in project.yml — dev servers are cleartext http on LAN addresses; app
+  networking keeps full ATS). Load failures render a chassis NO ROUTE panel
+  naming which network the address lives on, not WebKit's blank page. Free
+  plumbing, not an agent-helper surface.
 - **A bound host is one the machine itself vouched for; the app's key goes
   out, never a private key** (`Multiplex/Models/Bind/`,
   `Multiplex/Services/Bind/`; protocol + shared vectors live in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,10 @@ the URL reaching SurfBoard, and `….debug.viewportopen` running the sheet's
 ⌗ VIEWPORT chip for the pending link — the headless way to dock the inline
 browser tab (raise the sheet with `….debug.link` first; the loopback proof
 is a `localhost:<port>` URL in the pane rewriting to the seed host's
-address and rendering a page served on the Mac), and
+address and rendering a page served on the Mac), and `….debug.linkregions`
+logging what the visionOS gaze hover overlay would light for the focused
+terminal (category `links`, debug level — gaze itself cannot be driven in
+the simulator; the region inventory can), and
 `… -p app.multiplexterm.multiplex.debug.msgjump` / `….debug.msgjumpback`
 jumps the focused Claude Code terminal to its oldest session-file prompt
 and runs BACK TO LIVE — host-side `tmux capture-pane` proves both (the old
@@ -432,7 +435,7 @@ views.
   - `swift-nio-ssh` — Citadel 0.12.0's resolved fork (`Joannis` 0.3.5), patched
     to declare the `NIO` product it imports (Xcode 27's module resolution
     rejects the undeclared import). Also freezes the SSH transport supply chain.
-  - `SwiftTerm` — 1.15.0 (rev `dd2fb8a`), patched in nine behavior groups
+  - `SwiftTerm` — 1.15.0 (rev `dd2fb8a`), patched in ten behavior groups
     (marked `Multiplex patch`; the obscured-tab display guards share the marker
     on their owning state):
     `keyboardType` is settable (upstream is get-only), and Multiplex keeps it
@@ -506,7 +509,12 @@ views.
     the remote wants the tap (upstream resolved links first, so URL-shaped
     text swallowed tmux pane switches and vim cursor placement), while
     `longPress` — local at every mouse mode — resolves one before its
-    context menu. Sample apps trimmed.
+    context menu. And the visible screen's links are enumerable —
+    `Terminal.visibleLinkMatches` (probe-stride scan, wrapped rows
+    reassembled, unit-tested in the fork) with view-space rect mapping in
+    `TerminalView.visibleLinkRegions`, the inverse of `calculateTapHit`'s
+    point→grid math — which is what visionOS gaze hover stands on. Sample
+    apps trimmed.
   - When bumping either, re-apply the patches and diff before trusting it.
 - **Citadel pinned to exactly 0.12.0**: 0.12.1 moved its swift-nio-ssh dep to an
   unaudited personal fork. Don't bump without review — this is the transport.
@@ -743,7 +751,19 @@ views.
   `TERM=xterm-256color`, which has none. So implicit detection is the live
   path in tmux tabs; explicit links reach only direct `.shell` tabs. Don't
   "fix" it with a server-scoped `terminal-features` default (the same leak
-  the per-host new-session conf documents). Full record + the verified
+  the per-host new-session conf documents). **On visionOS, links also glow
+  under the eye** (`TerminalLinkHoverOverlay`, a `TerminalView` subview so
+  its touches keep feeding the terminal's own pan recognizers): gaze is
+  never delivered to apps, so system hover regions are stood over the
+  fork's visible-link enumeration, rebuilt debounced behind
+  `TerminalSessionController.onOutputFlushed` and scrolls. Hover regions
+  ARE hit regions, so a pinch on a lit link deliberately outranks the
+  remote mouse click on those cells and runs the same confirm sheet — the
+  glow is visionOS's own "this activates" affordance (a vim/tmux click
+  landing exactly on URL text is the accepted trade; adjacent cells still
+  click through). Only targets `TerminalLink.resolve` would confirm get a
+  region, so filesystem paths in build logs never glow; obscured tabs
+  clear their regions. Full record + the verified
   experiment table: `local-plan/terminal-links.md`.
 - **The viewport is a citizen of the window system — summoned, never
   restored** (`TerminalRoute.Mode.viewport`; `ViewportReach`/`ViewportOffer`

--- a/Multiplex/Info.plist
+++ b/Multiplex/Info.plist
@@ -33,6 +33,11 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+	</dict>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_multiplex-bind._tcp</string>

--- a/Multiplex/Models/TerminalRoute.swift
+++ b/Multiplex/Models/TerminalRoute.swift
@@ -10,6 +10,13 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
         case create(sessionName: String, directory: String?)
         /// Plain login shell, no tmux.
         case shell
+        /// The viewport — an inline browser tab, docked beside the sessions
+        /// that produced its URL and moved with the same merge/split
+        /// machinery. Not a terminal: no remote command, no tmux session, no
+        /// transport. Never restored across launches — a viewport is
+        /// summoned, not restored (`TerminalWindowRoot.syncTabs` strips
+        /// viewport tabs whose controller didn't survive the process).
+        case viewport(urlString: String)
 
         /// Keeps the pre-directory call shape valid (and mirrors how records
         /// persisted by older builds decode: directory absent → nil).
@@ -32,7 +39,7 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
                 sessionName: name,
                 directory: directory
             )
-        case .shell:
+        case .shell, .viewport:
             return nil
         }
     }
@@ -55,7 +62,7 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
                 command += " -c \(directory.shellQuotedDirectory)"
             }
             return command
-        case .shell:
+        case .shell, .viewport:
             return nil
         }
     }
@@ -64,16 +71,37 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
         switch mode {
         case .attach(let name), .create(let name, _): name
         case .shell: "shell"
+        case .viewport(let urlString): Self.viewportLabel(urlString)
         }
     }
 
     /// The tmux session this tab is bound to; nil for a plain shell (which
-    /// has no probe entry, so no agent detection).
+    /// has no probe entry, so no agent detection) and for the viewport.
     var sessionName: String? {
         switch mode {
         case .attach(let name), .create(let name, _): name
-        case .shell: nil
+        case .shell, .viewport: nil
         }
+    }
+
+    var isViewport: Bool {
+        if case .viewport = mode { return true }
+        return false
+    }
+
+    var viewportURL: URL? {
+        guard case .viewport(let urlString) = mode else { return nil }
+        return URL(string: urlString)
+    }
+
+    /// The viewport's tab-cell/UMD label: `⌗ 5173` for an explicit port
+    /// (the dev-server case, where the port *is* the page's identity), the
+    /// host otherwise. `⌗` — U+2317 VIEWDATA SQUARE — is the viewport mark
+    /// everywhere; a page never wears a tally dot.
+    static func viewportLabel(_ urlString: String) -> String {
+        guard let url = URL(string: urlString) else { return "⌗" }
+        if let port = url.port { return "⌗ \(port)" }
+        return "⌗ \(url.host() ?? "page")"
     }
 }
 

--- a/Multiplex/Models/ViewportReach.swift
+++ b/Multiplex/Models/ViewportReach.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Where a URL printed in a terminal pane actually lives, from this device's
+/// point of view.
+///
+/// A pane runs on the host, so `localhost` printed there names the *host's*
+/// loopback — an address this device cannot dial. A LAN address usually can
+/// be. The viewport (the inline browser) therefore classifies every candidate
+/// URL and shows the verdict instead of guessing silently; the one rewrite it
+/// offers — remote loopback → the host's own dialled address — is performed
+/// in the open, on the confirmation sheet, never behind the user's back.
+///
+/// Pure: no networking here, only address classification. The classification
+/// is honest about what it cannot know — a LAN verdict means "this device may
+/// reach it, network permitting", and the viewport's error panel says which
+/// network the address lives on when it doesn't.
+enum ViewportReach: Equatable {
+    /// A public name or address — reachable from the device's own network.
+    case internet
+    /// RFC 1918 / link-local / mDNS `.local` / unqualified single-label —
+    /// reachable when the device shares the host's network.
+    case lan
+    /// `localhost`, `127.*`, `0.0.0.0`, `::1`, `::` — the host's loopback,
+    /// not the device's. Openable only via the rewrite below.
+    case remoteLoopback
+
+    /// Classifies an http(s) URL's authority. Non-web schemes return nil —
+    /// the viewport renders web pages only (mailto stays a system handoff).
+    static func classify(_ url: URL) -> ViewportReach? {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let rawHost = url.host(), !rawHost.isEmpty
+        else { return nil }
+        let host = rawHost.lowercased()
+        if isLoopback(host) { return .remoteLoopback }
+        if isLAN(host) { return .lan }
+        return .internet
+    }
+
+    /// The host's own loopback spellings, including `0.0.0.0`/`::` — a
+    /// bind-all server banner prints those, and they name "this machine"
+    /// exactly as loopback does. `*.localhost` resolves loopback per RFC 6761.
+    private static func isLoopback(_ host: String) -> Bool {
+        if host == "localhost" || host.hasSuffix(".localhost") { return true }
+        if host == "0.0.0.0" || host == "::" || host == "::1" { return true }
+        if let octets = ipv4Octets(host) { return octets[0] == 127 }
+        return false
+    }
+
+    private static func isLAN(_ host: String) -> Bool {
+        if let octets = ipv4Octets(host) {
+            if octets[0] == 10 { return true }
+            if octets[0] == 192, octets[1] == 168 { return true }
+            if octets[0] == 172, (16...31).contains(octets[1]) { return true }
+            if octets[0] == 169, octets[1] == 254 { return true }
+            return false
+        }
+        // IPv6 unique-local (fc00::/7) and link-local (fe80::/10).
+        if host.hasPrefix("fc") || host.hasPrefix("fd") || host.hasPrefix("fe80:") {
+            return host.contains(":")
+        }
+        if host.hasSuffix(".local") { return true }
+        // An unqualified single-label name resolves through the local
+        // network's search domains — LAN by construction.
+        if !host.contains(".") && !host.contains(":") { return true }
+        return false
+    }
+
+    /// The four octets of a dotted-quad IPv4 literal, or nil for anything
+    /// else (names, IPv6, malformed quads).
+    private static func ipv4Octets(_ host: String) -> [Int]? {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        var octets: [Int] = []
+        for part in parts {
+            guard let value = Int(part), (0...255).contains(value) else { return nil }
+            octets.append(value)
+        }
+        return octets
+    }
+}
+
+/// A confirmed viewport target: the URL exactly as the device will dial it,
+/// plus the classification that admitted it. Built once, on the confirmation
+/// sheet — the rail carries `reachTag` for the life of the page so the
+/// verdict stays visible.
+struct ViewportOffer: Equatable {
+    /// The final URL — rewritten for remote loopback, verbatim otherwise.
+    var url: URL
+    var reach: ViewportReach
+    /// The host's display name when `url` was rewritten to reach it.
+    var viaHostName: String?
+
+    /// The rail's compact verdict: NET / LAN / VIA DEVBOX.
+    var reachTag: String {
+        switch reach {
+        case .internet: "NET"
+        case .lan: "LAN"
+        case .remoteLoopback: "VIA \((viaHostName ?? "HOST").uppercased())"
+        }
+    }
+
+    /// Offers a viewport for a confirmed link, or nil when the link is not a
+    /// web page (mailto, blocked, malformed — those keep today's answers).
+    ///
+    /// Remote loopback rewrites the authority to `host.hostname` — by
+    /// definition the address this device already reaches the host by (it is
+    /// what SSH dials) — keeping port, path, and query. That works when the
+    /// server listens beyond loopback; a truly loopback-only server fails in
+    /// the viewport's error panel, which says so. No host record → no rewrite
+    /// → no offer.
+    static func make(for link: TerminalLink, host: Host?) -> ViewportOffer? {
+        guard let url = link.openableURL, let reach = ViewportReach.classify(url)
+        else { return nil }
+        switch reach {
+        case .internet, .lan:
+            return ViewportOffer(url: url, reach: reach, viaHostName: nil)
+        case .remoteLoopback:
+            guard let host, let rewritten = rewrite(url, toHost: host.hostname)
+            else { return nil }
+            return ViewportOffer(
+                url: rewritten,
+                reach: .remoteLoopback,
+                viaHostName: host.name
+            )
+        }
+    }
+
+    private static func rewrite(_ url: URL, toHost hostname: String) -> URL? {
+        let trimmed = hostname.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+        components.host = trimmed
+        return components.url
+    }
+}

--- a/Multiplex/Models/ViewportReach.swift
+++ b/Multiplex/Models/ViewportReach.swift
@@ -112,6 +112,53 @@ struct ViewportOffer: Equatable {
     static func make(for link: TerminalLink, host: Host?) -> ViewportOffer? {
         guard let url = link.openableURL, let reach = ViewportReach.classify(url)
         else { return nil }
+        return admit(url, reach: reach, host: host)
+    }
+
+    /// The rail's typed address: the user's own intent, so no confirmation
+    /// sheet — but the same admit path as a confirmed link. Web schemes
+    /// only; a schemeless address is defaulted by where it lives (`http`
+    /// for LAN/loopback — dev servers are cleartext — `https` otherwise);
+    /// loopback rewrites via the host exactly as the sheet's chip does.
+    static func fromTypedInput(_ input: String, host: Host?) -> ViewportOffer? {
+        var text = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !text.contains(where: \.isWhitespace) else { return nil }
+        if let separator = text.range(of: "://") {
+            let scheme = text[..<separator.lowerBound].lowercased()
+            guard scheme == "http" || scheme == "https" else { return nil }
+        } else {
+            // Scheme-shaped input without `//` (`mailto:…`, `javascript:…`)
+            // is not an address, and prefixing it with http:// would parse
+            // the scheme as USERINFO (`http://mailto:dev@example.com` reads
+            // host example.com) — the exact trick the link sheet exists to
+            // expose. Only host:port survives: after a colon in the
+            // authority part, digits. Bracketed IPv6 is exempt (its colons
+            // are the address).
+            let authority = text.prefix(while: { $0 != "/" })
+            if !authority.hasPrefix("["),
+               let colon = authority.firstIndex(of: ":"),
+               authority[authority.index(after: colon)...].first?.isNumber != true {
+                return nil
+            }
+            guard let probe = URL(string: "http://" + text),
+                  let reach = ViewportReach.classify(probe)
+            else { return nil }
+            text = (reach == .internet ? "https://" : "http://") + text
+        }
+        guard let url = URL(string: text),
+              // Typed input never needs userinfo, and a userinfo-padded
+              // authority is how a pasted address lies about its host.
+              URLComponents(url: url, resolvingAgainstBaseURL: false)?.user == nil,
+              let reach = ViewportReach.classify(url)
+        else { return nil }
+        return admit(url, reach: reach, host: host)
+    }
+
+    private static func admit(
+        _ url: URL,
+        reach: ViewportReach,
+        host: Host?
+    ) -> ViewportOffer? {
         switch reach {
         case .internet, .lan:
             return ViewportOffer(url: url, reach: reach, viaHostName: nil)

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -455,6 +455,11 @@ final class TerminalSessionController {
         }
     }
 
+    /// Pinged after every coalesced output flush reaches the terminal —
+    /// visionOS's gaze link-hover overlay debounces its region rebuild
+    /// behind this, so affordances follow the screen without polling.
+    var onOutputFlushed: (() -> Void)?
+
     private func feed(_ bytes: [UInt8]) {
         scanForSwallowedHandoff(bytes)
         guard let terminalView else {
@@ -462,6 +467,7 @@ final class TerminalSessionController {
             return
         }
         terminalView.feed(byteArray: bytes[...])
+        onOutputFlushed?()
     }
 
     /// Modern oh-my-zsh drains all buffered stdin before blocking on its

--- a/Multiplex/Services/TerminalWorkspace.swift
+++ b/Multiplex/Services/TerminalWorkspace.swift
@@ -92,12 +92,12 @@ final class TerminalWorkspace {
     /// Register the controller BEFORE the tab enters any route — the strip
     /// above runs on every tabs change, and a viewport tab that arrives
     /// without its controller is indistinguishable from a restored corpse.
-    func openViewport(tab: TerminalRoute, offer: ViewportOffer, hostName: String) {
+    func openViewport(tab: TerminalRoute, offer: ViewportOffer, host: Host) {
         guard tab.isViewport, viewportControllers[tab.id] == nil else { return }
         viewportControllers[tab.id] = ViewportController(
             tabID: tab.id,
             offer: offer,
-            hostName: hostName
+            host: host
         )
     }
 

--- a/Multiplex/Services/TerminalWorkspace.swift
+++ b/Multiplex/Services/TerminalWorkspace.swift
@@ -79,10 +79,38 @@ final class TerminalWorkspace {
         controllers[tabID]
     }
 
-    /// Close a tab for real: detach the SSH channel and drop the controller
-    /// (and with it the terminal view). Never called when a tab merely moves.
+    // MARK: Viewport controllers (one per ⌗ tab)
+
+    /// Transport-less controllers for viewport tabs, keyed like terminal
+    /// controllers so merge/split re-parent the live page the same way.
+    /// Deliberately in-memory only — this dictionary *is* the viewport's
+    /// no-persistence rule: `TerminalWindowRoot.syncTabs` strips any viewport
+    /// tab it cannot find here, which is exactly a tab restored from a dead
+    /// process. Summoned, not restored.
+    private var viewportControllers: [UUID: ViewportController] = [:]
+
+    /// Register the controller BEFORE the tab enters any route — the strip
+    /// above runs on every tabs change, and a viewport tab that arrives
+    /// without its controller is indistinguishable from a restored corpse.
+    func openViewport(tab: TerminalRoute, offer: ViewportOffer, hostName: String) {
+        guard tab.isViewport, viewportControllers[tab.id] == nil else { return }
+        viewportControllers[tab.id] = ViewportController(
+            tabID: tab.id,
+            offer: offer,
+            hostName: hostName
+        )
+    }
+
+    func viewportController(for tabID: UUID) -> ViewportController? {
+        viewportControllers[tabID]
+    }
+
+    /// Close a tab for real: detach the SSH channel (or shut the viewport's
+    /// web view down) and drop the controller. Never called when a tab
+    /// merely moves.
     func closeTab(_ tabID: UUID) {
         controllers.removeValue(forKey: tabID)?.detach()
+        viewportControllers.removeValue(forKey: tabID)?.shutdown()
     }
 
     func resumeConnectionsWaitingForKeyPassphrase(hostID: UUID) {

--- a/Multiplex/Services/ViewportController.swift
+++ b/Multiplex/Services/ViewportController.swift
@@ -1,0 +1,234 @@
+import Observation
+import UIKit
+import WebKit
+
+/// One viewport tab's state: the WKWebView it strongly owns (so the live page
+/// re-parents across merge/split exactly the way a terminal's SwiftTerm view
+/// does), the load/history telemetry the rail shows, and the navigation gate.
+///
+/// The gate re-applies the app's link discipline per navigation: a page may
+/// hop http/https freely, but every other scheme is cancelled — `multiplex:`
+/// can never be navigated into, and an allowlisted external target (mailto)
+/// is re-presented through the same `TerminalLinkSheet` confirmation a pane
+/// press gets, never followed directly. The viewport has no script bridge and
+/// no send path into any terminal; it is a monitor, not an input surface.
+///
+/// Lifetime is the process, on purpose: controllers live in
+/// `TerminalWorkspace` only, are created before their tab enters any route,
+/// and are never persisted — the no-persistence rule ("summoned, not
+/// restored") falls out of their absence after a relaunch.
+@MainActor
+@Observable
+final class ViewportController {
+    let tabID: UUID
+    /// The confirmation that admitted this page; `offer.reachTag` rides the
+    /// rail for the life of the tab.
+    let offer: ViewportOffer
+    /// The source host's display name — the viewport's tether label.
+    let hostName: String
+
+    @ObservationIgnored private(set) var webView: WKWebView!
+    @ObservationIgnored private var bridge: ViewportWebBridge!
+    @ObservationIgnored private var observations: [NSKeyValueObservation] = []
+
+    private(set) var currentURL: URL?
+    private(set) var pageTitle: String?
+    private(set) var isLoading = false
+    private(set) var progress: Double = 0
+    private(set) var canGoBack = false
+    /// A load that ended in an error the user should see — the TALLY panel
+    /// renders it with the reach verdict, instead of WebKit's blank page.
+    private(set) var failure: String?
+    /// A navigation the gate refused but the link discipline can explain:
+    /// the pane presents the same confirmation sheet a terminal press gets.
+    var externalLink: TerminalLink?
+
+    init(tabID: UUID, offer: ViewportOffer, hostName: String) {
+        self.tabID = tabID
+        self.offer = offer
+        self.hostName = hostName
+        self.currentURL = offer.url
+
+        let configuration = WKWebViewConfiguration()
+        // App-scoped and persistent (never shared with Safari): a dev
+        // server's login survives reload. No user scripts, no message
+        // handlers — pages get no bridge into the app.
+        configuration.websiteDataStore = .default()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.allowsBackForwardNavigationGestures = true
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        self.webView = webView
+
+        let bridge = ViewportWebBridge(controller: self)
+        self.bridge = bridge
+        webView.navigationDelegate = bridge
+        webView.uiDelegate = bridge
+
+        observations = [
+            webView.observe(\.estimatedProgress, options: [.new]) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.syncTelemetry() }
+            },
+            webView.observe(\.isLoading, options: [.new]) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.syncTelemetry() }
+            },
+            webView.observe(\.canGoBack, options: [.new]) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.syncTelemetry() }
+            },
+            webView.observe(\.url, options: [.new]) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.syncTelemetry() }
+            },
+            webView.observe(\.title, options: [.new]) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.syncTelemetry() }
+            },
+        ]
+
+        webView.load(URLRequest(url: offer.url))
+    }
+
+    private func syncTelemetry() {
+        guard let webView else { return }
+        progress = webView.estimatedProgress
+        isLoading = webView.isLoading
+        canGoBack = webView.canGoBack
+        if let url = webView.url { currentURL = url }
+        pageTitle = webView.title?.isEmpty == false ? webView.title : nil
+    }
+
+    /// The rail's readout: current host emphasized by the view; falls back
+    /// to the confirmed offer before the first commit.
+    var displayURL: URL { currentURL ?? offer.url }
+
+    func reload() {
+        failure = nil
+        if webView.url == nil {
+            // The very first load failed — there is nothing to reload yet.
+            webView.load(URLRequest(url: offer.url))
+        } else {
+            webView.reload()
+        }
+    }
+
+    func stopLoading() {
+        webView.stopLoading()
+    }
+
+    func goBack() {
+        guard webView.canGoBack else { return }
+        failure = nil
+        webView.goBack()
+    }
+
+    /// SYSTEM — the handoff to the real browser, same as the link sheet's
+    /// OPEN. Always available; the viewport never traps a page.
+    func openInSystemBrowser() {
+        UIApplication.shared.open(displayURL)
+    }
+
+    func copyURL() {
+        UIPasteboard.general.string = displayURL.absoluteString
+    }
+
+    /// Tab is closing for real (never called on a move): stop work and break
+    /// the delegate cycle so the web process can wind down.
+    func shutdown() {
+        observations.removeAll()
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        webView.removeFromSuperview()
+    }
+
+    // Bridge callbacks -----------------------------------------------------
+
+    fileprivate func navigationStarted() {
+        failure = nil
+        syncTelemetry()
+    }
+
+    fileprivate func navigationFailed(_ error: Error) {
+        let nsError = error as NSError
+        // A cancelled load (stop, or a policy decline mid-provisional) is
+        // not a fault the panel should announce.
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled { return }
+        // Legacy WebKit domain, code 102: "frame load interrupted by policy
+        // change" — the gate above declining a navigation, not a fault.
+        if nsError.domain == "WebKitErrorDomain", nsError.code == 102 { return }
+        failure = nsError.localizedDescription
+        syncTelemetry()
+    }
+
+    /// The per-navigation gate. Web schemes render; `about:` covers blank
+    /// initial frames; everything else is cancelled here and — when the link
+    /// discipline has something to say about it — surfaced for confirmation.
+    fileprivate func policy(for url: URL?) -> WKNavigationActionPolicy {
+        guard let url, let scheme = url.scheme?.lowercased() else { return .cancel }
+        if scheme == "http" || scheme == "https" || scheme == "about" {
+            return .allow
+        }
+        if let link = TerminalLink.resolve(url.absoluteString) {
+            externalLink = link
+        }
+        return .cancel
+    }
+}
+
+/// WK delegates live on this retained NSObject so the controller itself can
+/// stay a plain `@Observable` class. WKWebView holds its delegates weakly;
+/// the controller owns the bridge, the bridge points back weakly.
+private final class ViewportWebBridge: NSObject, WKNavigationDelegate, WKUIDelegate {
+    weak var controller: ViewportController?
+
+    init(controller: ViewportController) {
+        self.controller = controller
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        MainActor.assumeIsolated {
+            decisionHandler(
+                controller?.policy(for: navigationAction.request.url) ?? .cancel
+            )
+        }
+    }
+
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        MainActor.assumeIsolated { controller?.navigationStarted() }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        MainActor.assumeIsolated { controller?.navigationFailed(error) }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        MainActor.assumeIsolated { controller?.navigationFailed(error) }
+    }
+
+    /// target=_blank and window.open land in the same viewport — one page
+    /// per tab, and the popup still rides the navigation gate above.
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        MainActor.assumeIsolated {
+            if controller?.policy(for: navigationAction.request.url) == .allow {
+                webView.load(navigationAction.request)
+            }
+        }
+        return nil
+    }
+}

--- a/Multiplex/Services/ViewportController.swift
+++ b/Multiplex/Services/ViewportController.swift
@@ -21,11 +21,15 @@ import WebKit
 @Observable
 final class ViewportController {
     let tabID: UUID
-    /// The confirmation that admitted this page; `offer.reachTag` rides the
-    /// rail for the life of the tab.
+    /// The confirmation that admitted this page.
     let offer: ViewportOffer
+    /// Snapshot of the source host — the tether label and the rewrite
+    /// target for addresses typed into the rail. A value copy on purpose:
+    /// like a terminal's connection, the viewport keeps the record it was
+    /// opened against.
+    private let host: Host
     /// The source host's display name — the viewport's tether label.
-    let hostName: String
+    var hostName: String { host.name }
 
     @ObservationIgnored private(set) var webView: WKWebView!
     @ObservationIgnored private var bridge: ViewportWebBridge!
@@ -36,6 +40,13 @@ final class ViewportController {
     private(set) var isLoading = false
     private(set) var progress: Double = 0
     private(set) var canGoBack = false
+    /// Where the page currently lives, kept honest across typed addresses
+    /// and in-page navigation — the rail tag and the failure panel's hint
+    /// both read this, never the stale admission.
+    private(set) var currentReach: ViewportReach
+    /// The last URL this controller was *asked* to load (admission or rail
+    /// edit) — the reload target while nothing has committed yet.
+    private(set) var lastRequestedURL: URL
     /// A load that ended in an error the user should see — the TALLY panel
     /// renders it with the reach verdict, instead of WebKit's blank page.
     private(set) var failure: String?
@@ -43,11 +54,22 @@ final class ViewportController {
     /// the pane presents the same confirmation sheet a terminal press gets.
     var externalLink: TerminalLink?
 
-    init(tabID: UUID, offer: ViewportOffer, hostName: String) {
+    /// The rail's compact verdict for the page on screen.
+    var railTag: String {
+        switch currentReach {
+        case .internet: "NET"
+        case .lan: "LAN"
+        case .remoteLoopback: "VIA \(hostName.uppercased())"
+        }
+    }
+
+    init(tabID: UUID, offer: ViewportOffer, host: Host) {
         self.tabID = tabID
         self.offer = offer
-        self.hostName = hostName
+        self.host = host
         self.currentURL = offer.url
+        self.currentReach = offer.reach
+        self.lastRequestedURL = offer.url
 
         let configuration = WKWebViewConfiguration()
         // App-scoped and persistent (never shared with Safari): a dev
@@ -92,7 +114,14 @@ final class ViewportController {
         progress = webView.estimatedProgress
         isLoading = webView.isLoading
         canGoBack = webView.canGoBack
-        if let url = webView.url { currentURL = url }
+        if let url = webView.url {
+            currentURL = url
+            // In-page navigation can move the page between worlds (a LAN
+            // dev page linking out to docs); the tag follows. A loopback
+            // classification here is the rewrite's own address (a host
+            // dialled by loopback) — VIA stays the honest word for it.
+            currentReach = ViewportReach.classify(url) ?? currentReach
+        }
         pageTitle = webView.title?.isEmpty == false ? webView.title : nil
     }
 
@@ -103,11 +132,28 @@ final class ViewportController {
     func reload() {
         failure = nil
         if webView.url == nil {
-            // The very first load failed — there is nothing to reload yet.
-            webView.load(URLRequest(url: offer.url))
+            // Nothing has committed yet (the first load, or a typed address
+            // that failed before commit) — retry what was asked for.
+            webView.load(URLRequest(url: lastRequestedURL))
         } else {
             webView.reload()
         }
+    }
+
+    /// The rail's address editor: navigate to what the user typed, or say
+    /// no. Same admit path as a confirmed link (web schemes only, scheme
+    /// defaulted by reach, loopback rewritten via the host) — typing is the
+    /// user's own intent, so no sheet stands between.
+    @discardableResult
+    func navigate(toTyped input: String) -> Bool {
+        guard let typed = ViewportOffer.fromTypedInput(input, host: host)
+        else { return false }
+        failure = nil
+        lastRequestedURL = typed.url
+        currentReach = typed.reach
+        currentURL = typed.url
+        webView.load(URLRequest(url: typed.url))
+        return true
     }
 
     func stopLoading() {
@@ -128,6 +174,22 @@ final class ViewportController {
 
     func copyURL() {
         UIPasteboard.general.string = displayURL.absoluteString
+    }
+
+    /// Wipes the viewport's browsing state — cookies, caches, and site
+    /// storage. The data store is app-scoped and shared by every viewport
+    /// tab (that sharing is what keeps a dev login alive across pages), so
+    /// clearing is necessarily global; the confirmation that leads here
+    /// says so. Reloads this page afterward, so the effect is visible
+    /// exactly where it was asked for — signed out, cold cache.
+    func clearBrowsingData() {
+        let store = webView.configuration.websiteDataStore
+        store.removeData(
+            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            modifiedSince: .distantPast
+        ) { [weak self] in
+            MainActor.assumeIsolated { self?.reload() }
+        }
     }
 
     /// Tab is closing for real (never called on a move): stop work and break

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -106,6 +106,24 @@ struct SwiftTermView: UIViewRepresentable {
             view.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -Self.terminalInsets.right),
             view.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.terminalInsets.bottom),
         ])
+        // Gaze hover for links: the overlay is a subview of the terminal
+        // (its touches keep feeding the terminal's own pan recognizers) and
+        // survives merge/split with it — reuse the one already riding an
+        // adopted view rather than stacking another.
+        let overlay = view.subviews.compactMap { $0 as? TerminalLinkHoverOverlay }.first
+            ?? {
+                let created = TerminalLinkHoverOverlay(terminalView: view)
+                view.addSubview(created)
+                return created
+            }()
+        overlay.activate = { [weak controller] target in
+            _ = controller?.activateLink(target)
+        }
+        context.coordinator.linkHoverOverlay = overlay
+        controller.onOutputFlushed = { [weak overlay] in
+            overlay?.scheduleRefresh()
+        }
+        overlay.scheduleRefresh()
         #else
         let container = KeyboardAvoidingContainer()
         let keyBar = TerminalKeyBar(
@@ -202,6 +220,19 @@ struct SwiftTermView: UIViewRepresentable {
         if view.renderUpdatesEnabled != isActive {
             view.renderUpdatesEnabled = isActive
         }
+        #if os(visionOS)
+        // An obscured tab's links must not glow through the tab on screen.
+        if let overlay = context.coordinator.linkHoverOverlay {
+            if overlay.isHidden == isActive {
+                overlay.isHidden = !isActive
+                if isActive {
+                    overlay.scheduleRefresh()
+                } else {
+                    overlay.clearRegions()
+                }
+            }
+        }
+        #endif
         let fontChanged = view.font.pointSize != fontSize
         if fontChanged {
             view.font = .monospacedSystemFont(ofSize: fontSize, weight: .regular)
@@ -263,6 +294,11 @@ struct SwiftTermView: UIViewRepresentable {
     final class Coordinator: NSObject, TerminalViewDelegate, UIGestureRecognizerDelegate {
         let controller: TerminalSessionController
         weak var terminalView: TerminalView?
+        #if os(visionOS)
+        /// Gaze link regions — owned by the terminal view it floats over,
+        /// referenced here for visibility gating and scroll refreshes.
+        weak var linkHoverOverlay: TerminalLinkHoverOverlay?
+        #endif
         var appliedTheme: TerminalTheme?
 
         init(controller: TerminalSessionController) {
@@ -609,7 +645,13 @@ struct SwiftTermView: UIViewRepresentable {
         }
 
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
-        func scrolled(source: TerminalView, position: Double) {}
+        func scrolled(source: TerminalView, position: Double) {
+            #if os(visionOS)
+            // Scrollback browsing moves links under fixed regions — re-place
+            // them for the rows now visible.
+            linkHoverOverlay?.scheduleRefresh()
+            #endif
+        }
         /// Only reached if the view's `linkActivationHandler` is ever absent —
         /// `bind` installs one. Kept wired so the two routes can't disagree.
         func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {

--- a/Multiplex/Views/Terminal/TerminalLinkHoverOverlay.swift
+++ b/Multiplex/Views/Terminal/TerminalLinkHoverOverlay.swift
@@ -1,0 +1,122 @@
+#if os(visionOS)
+import SwiftTerm
+import UIKit
+
+/// Gaze hover for links on visionOS.
+///
+/// The system renders gaze hover out of process — the app never learns where
+/// the user looks — so the only way to light a URL under the eye is to stand
+/// hover-effect regions over the places links actually are. This overlay
+/// rides as a subview of the `TerminalView` (an ancestor's gesture
+/// recognizers still see touches on it, so pans/scrolls over a link keep
+/// working) and rebuilds its regions from `visibleLinkRegions()` — the
+/// fork's visible-screen enumerator — debounced behind output flushes and
+/// scrolls.
+///
+/// A region is hit-testable by necessity (hover regions are derived from hit
+/// testing), which makes a lit link pinch-activatable: on visionOS the glow
+/// IS the system's "this activates" affordance, so a pinch runs the exact
+/// same confirm path a long press does — the sheet, never the page. Long
+/// press on a region stays the sheet too. Only targets the app would
+/// actually confirm get a region (`TerminalLink.resolve` non-nil), so
+/// filesystem paths in build logs never glow.
+final class TerminalLinkHoverOverlay: UIView {
+    /// Runs the pane's confirm path (`TerminalSessionController.activateLink`).
+    var activate: ((String) -> Void)?
+
+    private weak var terminalView: TerminalView?
+    private var refreshScheduled = false
+
+    init(terminalView: TerminalView) {
+        self.terminalView = terminalView
+        super.init(frame: .zero)
+        backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    /// The overlay itself is transparent to input — only its regions hit.
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        return view === self ? nil : view
+    }
+
+    /// Debounced: output arrives in bursts, and one rebuild per settled
+    /// screen is enough for an affordance.
+    func scheduleRefresh() {
+        guard !refreshScheduled else { return }
+        refreshScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let self else { return }
+            refreshScheduled = false
+            refresh()
+        }
+    }
+
+    func clearRegions() {
+        subviews.forEach { $0.removeFromSuperview() }
+    }
+
+    private func refresh() {
+        guard let terminalView, window != nil, !isHidden else {
+            clearRegions()
+            return
+        }
+        // Track the scroll view's bounds so region frames land in the same
+        // space `calculateTapHit` reads.
+        frame = terminalView.bounds
+        clearRegions()
+        for region in terminalView.visibleLinkRegions() {
+            // Only what the app would confirm gets an affordance — paths
+            // and prose stay dark.
+            guard TerminalLink.resolve(region.target) != nil else { continue }
+            for rect in region.rects {
+                let control = LinkHoverRegion(target: region.target)
+                control.frame = rect.insetBy(dx: -2, dy: -1)
+                control.onActivate = { [weak self] target in
+                    self?.activate?(target)
+                }
+                addSubview(control)
+            }
+        }
+    }
+}
+
+/// One lit rectangle over one row-segment of a link. Square-chassis hover
+/// shape per the app's hover discipline; tap and long press both run the
+/// confirm path (a drag is claimed by the terminal's own recognizers and
+/// cancels the touch, so scrolling over links is untouched).
+private final class LinkHoverRegion: UIControl {
+    let target: String
+    var onActivate: ((String) -> Void)?
+
+    init(target: String) {
+        self.target = target
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 4))
+        addTarget(self, action: #selector(activateTarget), for: .touchUpInside)
+        let longPress = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(longPressed(_:))
+        )
+        addGestureRecognizer(longPress)
+        isAccessibilityElement = true
+        accessibilityTraits = .link
+        accessibilityLabel = target
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    @objc private func activateTarget() {
+        onActivate?(target)
+    }
+
+    @objc private func longPressed(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began else { return }
+        onActivate?(target)
+    }
+}
+#endif

--- a/Multiplex/Views/Terminal/TerminalLinkSheet.swift
+++ b/Multiplex/Views/Terminal/TerminalLinkSheet.swift
@@ -12,10 +12,20 @@ import SwiftUI
 /// Blocked and malformed targets still get here. Saying "Multiplex won't open
 /// a `file:` link" and offering COPY is a better answer than a press that
 /// appears to do nothing.
+///
+/// Web links additionally carry a REACH row and the viewport action — the
+/// inline browser. The reach verdict says which world the address lives in
+/// (a pane runs on the host, so `localhost` there is the *host's* loopback),
+/// and the loopback chip performs its rewrite in the open: `⌗ VIA DEVBOX`
+/// says exactly what will be dialled.
 struct TerminalLinkSheet: View {
     let link: TerminalLink
+    /// The inline-browser offer for this link, when it is a web page and the
+    /// tab's host is known. nil keeps the sheet exactly as it always was.
+    var viewport: ViewportOffer?
     let onOpen: () -> Void
     let onCopy: () -> Void
+    var onOpenViewport: ((ViewportOffer) -> Void)?
 
     @Environment(\.dismiss) private var dismiss
 
@@ -48,12 +58,31 @@ struct TerminalLinkSheet: View {
                                 .background(Theme.screen)
                                 .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
 
+                                if let viewport {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        ChassisLabel("REACH", size: 9, color: Theme.signal3)
+                                        Text(reachDescription(viewport))
+                                            .font(.mono(10))
+                                            .foregroundStyle(Theme.signal2)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                }
+
                                 HStack(spacing: 10) {
+                                    if let viewport, let onOpenViewport {
+                                        ChassisChip(
+                                            viewportChipLabel(viewport),
+                                            prominent: true
+                                        ) {
+                                            onOpenViewport(viewport)
+                                            dismiss()
+                                        }
+                                    }
                                     if link.openableURL != nil {
                                         ChassisChip(
                                             "OPEN",
                                             systemImage: "arrow.up.forward.app",
-                                            prominent: true
+                                            prominent: viewport == nil || onOpenViewport == nil
                                         ) {
                                             onOpen()
                                             dismiss()
@@ -89,7 +118,15 @@ struct TerminalLinkSheet: View {
     }
 
     private var sectionTitle: String {
-        switch link.kind {
+        if let viewport, onOpenViewport != nil {
+            return switch viewport.reach {
+            case .internet: "A public address"
+            case .lan: "On this device's network"
+            case .remoteLoopback:
+                "Lives on \(viewport.viaHostName ?? "the host"), not this device"
+            }
+        }
+        return switch link.kind {
         case .openable: "Leaves Multiplex"
         case .blockedScheme(let scheme): "\(scheme.uppercased()) links stay here"
         case .malformed: "Not a usable address"
@@ -97,7 +134,21 @@ struct TerminalLinkSheet: View {
     }
 
     private var detail: String {
-        switch link.kind {
+        if let viewport, onOpenViewport != nil {
+            return switch viewport.reach {
+            case .internet, .lan:
+                "The viewport renders this address inside Multiplex; OPEN "
+                    + "still hands it to the system browser. It came from the "
+                    + "host — check the address above before opening."
+            case .remoteLoopback:
+                "localhost in a remote pane is the host's own loopback — an "
+                    + "address this device can't dial. VIA aims the viewport "
+                    + "at the address that already reaches the host; the "
+                    + "server must listen beyond loopback (vite --host) to "
+                    + "answer."
+            }
+        }
+        return switch link.kind {
         case .openable:
             "This address came from the host, and a hyperlink's visible text "
                 + "can differ from where it points — check the host above "
@@ -111,6 +162,28 @@ struct TerminalLinkSheet: View {
                 + "open. Copy it if it's still useful."
         }
     }
+
+    private func viewportChipLabel(_ viewport: ViewportOffer) -> String {
+        switch viewport.reach {
+        case .internet, .lan:
+            "⌗ VIEWPORT"
+        case .remoteLoopback:
+            "⌗ VIA \((viewport.viaHostName ?? "HOST").uppercased())"
+        }
+    }
+
+    private func reachDescription(_ viewport: ViewportOffer) -> String {
+        switch viewport.reach {
+        case .internet:
+            return "INTERNET — OPENS FROM THIS DEVICE"
+        case .lan:
+            return "LAN — DIALLED FROM THIS DEVICE, NETWORK PERMITTING"
+        case .remoteLoopback:
+            var rewritten = viewport.url.host() ?? ""
+            if let port = viewport.url.port { rewritten += ":\(port)" }
+            return "REMOTE LOOPBACK → REWRITES TO \(rewritten)"
+        }
+    }
 }
 
 extension View {
@@ -118,8 +191,15 @@ extension View {
     /// modifier because `TerminalWindowRoot`'s body is already at the Swift
     /// type-checker's ceiling — an inline `.sheet(item:)` with its binding and
     /// action closures tips the whole chain over.
+    ///
+    /// `viewportHost` is the active tab's host record — it names the rewrite
+    /// target for a remote-loopback address, so the offer is computed against
+    /// the machine whose pane printed the URL. `openViewport` docks the
+    /// confirmed page as a tab beside that pane.
     func terminalLinkConfirmation(
-        for controller: TerminalSessionController?
+        for controller: TerminalSessionController?,
+        viewportHost: Host? = nil,
+        openViewport: ((ViewportOffer) -> Void)? = nil
     ) -> some View {
         let binding = Binding<TerminalLink?>(
             get: { controller?.pendingLink },
@@ -128,8 +208,10 @@ extension View {
         return sheet(item: binding) { link in
             TerminalLinkSheet(
                 link: link,
+                viewport: ViewportOffer.make(for: link, host: viewportHost),
                 onOpen: { controller?.openPendingLink() },
-                onCopy: { controller?.copyPendingLink() }
+                onCopy: { controller?.copyPendingLink() },
+                onOpenViewport: openViewport
             )
         }
     }
@@ -143,6 +225,38 @@ extension View {
         onCopy: {}
     )
     .frame(width: 720, height: 640)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Viewport LAN") {
+    TerminalLinkSheet(
+        link: TerminalLink.resolve("http://192.168.1.68:5173/")!,
+        viewport: ViewportOffer(
+            url: URL(string: "http://192.168.1.68:5173/")!,
+            reach: .lan,
+            viaHostName: nil
+        ),
+        onOpen: {},
+        onCopy: {},
+        onOpenViewport: { _ in }
+    )
+    .frame(width: 720, height: 700)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Viewport loopback") {
+    TerminalLinkSheet(
+        link: TerminalLink.resolve("http://localhost:5173/")!,
+        viewport: ViewportOffer(
+            url: URL(string: "http://100.84.2.19:5173/")!,
+            reach: .remoteLoopback,
+            viaHostName: "devbox"
+        ),
+        onOpen: {},
+        onCopy: {},
+        onOpenViewport: { _ in }
+    )
+    .frame(width: 720, height: 700)
     .preferredColorScheme(.dark)
 }
 

--- a/Multiplex/Views/Terminal/TerminalTabStrip.swift
+++ b/Multiplex/Views/Terminal/TerminalTabStrip.swift
@@ -13,6 +13,10 @@ struct TerminalTabStrip: View {
         var hostName: String?
         var controller: TerminalSessionController?
         var isActive: Bool
+        /// A viewport tab's cell carries the ⌗ mark in its title and NO
+        /// tally dot — a page is not a shell, and the red dot stays a
+        /// shell's live state.
+        var isViewport = false
     }
 
     let items: [Item]
@@ -36,13 +40,15 @@ struct TerminalTabStrip: View {
             activate(item.id)
         } label: {
             HStack(spacing: 8) {
-                Circle()
-                    .fill(dotColor(item))
-                    .frame(width: 6, height: 6)
-                    .shadow(
-                        color: dotColor(item) == Theme.tally
-                            ? Theme.tally.opacity(0.7) : .clear,
-                        radius: 3)
+                if !item.isViewport {
+                    Circle()
+                        .fill(dotColor(item))
+                        .frame(width: 6, height: 6)
+                        .shadow(
+                            color: dotColor(item) == Theme.tally
+                                ? Theme.tally.opacity(0.7) : .clear,
+                            radius: 3)
+                }
                 ChassisLabel(
                     item.hostName.map { "\(item.title) · \($0)" } ?? item.title,
                     size: 10,

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 #if DEBUG
 import notify
+import os
 import SwiftTerm
 #endif
 
@@ -264,6 +265,9 @@ struct TerminalWindowRoot: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugViewportOpen)) { _ in
                 debugOpenViewportForPendingLink()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugLinkRegions)) { _ in
+                debugLogLinkRegions()
             }
             #endif
     }
@@ -564,6 +568,29 @@ struct TerminalWindowRoot: View {
         else { return }
         controller.dismissPendingLink()
         openViewport(offer)
+    }
+
+    /// Headless proof of the visionOS gaze link regions: logs what the
+    /// hover overlay would light for the focused terminal (category
+    /// `links`, debug level — `log stream`, not `log show`). Gaze itself
+    /// cannot be driven in the simulator; the region inventory can.
+    private func debugLogLinkRegions() {
+        guard let controller = activeController,
+              let view = controller.terminalView,
+              view === TerminalFocusArbiter.current
+        else { return }
+        let logger = Logger(
+            subsystem: "app.multiplexterm.multiplex",
+            category: "links"
+        )
+        let regions = view.visibleLinkRegions()
+            .filter { TerminalLink.resolve($0.target) != nil }
+        logger.debug("link-regions count=\(regions.count, privacy: .public)")
+        for region in regions {
+            logger.debug(
+                "link-region target=\(region.target, privacy: .public) rects=\(String(describing: region.rects), privacy: .public)"
+            )
+        }
     }
 
     /// Headless jump proof: load the focused pane's history and jump to the
@@ -1822,6 +1849,7 @@ extension Notification.Name {
     static let multiplexDebugLink = Notification.Name("MultiplexDebugLink")
     static let multiplexDebugLinkOpen = Notification.Name("MultiplexDebugLinkOpen")
     static let multiplexDebugViewportOpen = Notification.Name("MultiplexDebugViewportOpen")
+    static let multiplexDebugLinkRegions = Notification.Name("MultiplexDebugLinkRegions")
 }
 
 /// `….debug.link` activates the first link on the focused terminal's visible
@@ -1853,6 +1881,12 @@ enum TerminalLinkDebugHook {
             "app.multiplexterm.multiplex.debug.viewportopen", &viewportToken, .main
         ) { _ in
             NotificationCenter.default.post(name: .multiplexDebugViewportOpen, object: nil)
+        }
+        var regionsToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.linkregions", &regionsToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugLinkRegions, object: nil)
         }
     }
 }

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -647,7 +647,7 @@ struct TerminalWindowRoot: View {
             hostID: activeTab.hostID,
             mode: .viewport(urlString: offer.url.absoluteString)
         )
-        workspace.openViewport(tab: tab, offer: offer, hostName: host.name)
+        workspace.openViewport(tab: tab, offer: offer, host: host)
         if let index = route.tabs.firstIndex(where: { $0.id == activeTab.id }) {
             route.tabs.insert(tab, at: index + 1)
         } else {
@@ -1005,12 +1005,22 @@ struct TerminalWindowRoot: View {
         }
     }
 
+    /// A viewport tab's label follows the page it is on — the route's
+    /// urlString is only the address it was summoned with, and the rail's
+    /// editor can move the page after that.
+    private func tabTitle(for tab: TerminalRoute) -> String {
+        guard tab.isViewport,
+              let viewport = workspace.viewportController(for: tab.id)
+        else { return tab.displayName }
+        return TerminalRoute.viewportLabel(viewport.displayURL.absoluteString)
+    }
+
     private var tabItems: [TerminalTabStrip.Item] {
         let multiHost = Set(route.tabs.map(\.hostID)).count > 1
         return route.tabs.map { tab in
             .init(
                 id: tab.id,
-                title: tab.displayName,
+                title: tabTitle(for: tab),
                 hostName: multiHost ? store.host(id: tab.hostID)?.name : nil,
                 controller: workspace.controller(for: tab.id),
                 isActive: tab.id == activeTab?.id,
@@ -1033,7 +1043,7 @@ struct TerminalWindowRoot: View {
 
     private var windowTitle: String {
         if let activeController { return activeController.windowTitle }
-        if let activeTab { return activeTab.displayName }
+        if let activeTab { return tabTitle(for: activeTab) }
         return "terminal"
     }
 
@@ -1041,7 +1051,8 @@ struct TerminalWindowRoot: View {
     private var umdTitle: String {
         guard let activeTab else { return windowTitle }
         let host = store.host(id: activeTab.hostID)?.name
-        return host.map { "\(activeTab.displayName) · \($0)" } ?? activeTab.displayName
+        let name = tabTitle(for: activeTab)
+        return host.map { "\(name) · \($0)" } ?? name
     }
 
     #if !os(visionOS)

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -91,6 +91,12 @@ struct TerminalWindowRoot: View {
     private var activeController: TerminalSessionController? {
         activeTab.flatMap { workspace.controller(for: $0.id) }
     }
+    /// The active tab's host record — the viewport's rewrite target and
+    /// tether name. Computed here so the body's modifier chain (at the
+    /// type-checker's ceiling) never carries the closure.
+    private var activeTabHost: Host? {
+        activeTab.flatMap { store.host(id: $0.hostID) }
+    }
     /// Tabs connect concurrently. Surface the active tab's encrypted-key
     /// challenge first, then any background tab's; accepting one answer
     /// resumes every waiting tab for that host.
@@ -183,73 +189,10 @@ struct TerminalWindowRoot: View {
     }
 
     var body: some View {
-        platformBody
-            .task { syncTabs() }
-            // A restored terminal scene may exist without constructing the
-            // deck. Refresh the mirrored Host record here too so its command
-            // setup can arrive from another device before the editor opens.
-            .task { await store.refreshFromCloud() }
-            .task { entitlements.refreshSlashChipMeter() }
-            .task(id: activeTab?.hostID) { await keepHostProbeWarm() }
-            .task(id: activeTab?.id) { await watchActivePane() }
-            #if DEBUG
-            .task {
-                await DeckScene.autoAttachIfRequested(
-                    store: store,
-                    workspace: workspace,
-                    openTerminalWindow: { route in
-                        if let shell {
-                            shell.openTerminalRoute(route)
-                        } else {
-                            openWindow(id: "terminal", value: route)
-                        }
-                    }
-                )
-            }
-            #endif
-            .onChange(of: route.tabs) { syncTabs() }
-            .onChange(of: terminalFocusAllowed) { _, allowed in
-                guard !allowed else { return }
-                activeController?.restoreFocusIfOwner(allowed: false)
-            }
-            // Keyboard focus follows the visible tab…
-            .onChange(of: route.activeTabID) {
-                if terminalFocusAllowed {
-                    activeController?.focusTerminal()
-                }
-                // No detection grace across tabs — chips must describe the
-                // pane on screen, immediately.
-                hideAgentTask?.cancel()
-                activePaneFingerprint = nil
-                shownAgent = detectedAgent
-            }
-            .onChange(of: detectedAgent) { _, agent in
-                hideAgentTask?.cancel()
-                if let agent {
-                    shownAgent = agent
-                } else {
-                    hideAgentTask = Task {
-                        try? await Task.sleep(for: .seconds(11))
-                        guard !Task.isCancelled else { return }
-                        shownAgent = nil
-                    }
-                }
-            }
-            // …and the window: restore the owner when the scene reactivates,
-            // and prod any mosh transport so it re-establishes contact within
-            // a round trip instead of a heartbeat interval.
-            .onChange(of: scenePhase) { _, phase in
-                if phase == .active {
-                    Task { await store.refreshFromCloud() }
-                    entitlements.refreshSlashChipMeter()
-                    activeController?.restoreFocusIfOwner(
-                        allowed: terminalFocusAllowed
-                    )
-                    for tab in route.tabs {
-                        workspace.controller(for: tab.id)?.transportForegrounded()
-                    }
-                }
-            }
+        // Split from `lifecycleBody` so neither half's modifier chain
+        // reaches the type-checker's ceiling — one combined chain fails to
+        // type-check in reasonable time.
+        lifecycleBody
             .sheet(isPresented: $showingPaywall) { ProPaywallView() }
             .sheet(item: $keychainTipRequest) { tip in
                 KeychainUnlockSheet(
@@ -257,7 +200,11 @@ struct TerminalWindowRoot: View {
                     sessionNames: tip.sessionNames
                 )
             }
-            .terminalLinkConfirmation(for: activeController)
+            .terminalLinkConfirmation(
+                for: activeController,
+                viewportHost: activeTabHost,
+                openViewport: openViewport
+            )
             .alert(
                 "Couldn't Create Session",
                 isPresented: newTabFailedAlertBinding
@@ -315,7 +262,86 @@ struct TerminalWindowRoot: View {
                 else { return }
                 controller.openPendingLink()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugViewportOpen)) { _ in
+                debugOpenViewportForPendingLink()
+            }
             #endif
+    }
+
+    private var lifecycleBody: some View {
+        platformBody
+            .task { syncTabs() }
+            // A restored terminal scene may exist without constructing the
+            // deck. Refresh the mirrored Host record here too so its command
+            // setup can arrive from another device before the editor opens.
+            .task { await store.refreshFromCloud() }
+            .task { entitlements.refreshSlashChipMeter() }
+            .task(id: activeTab?.hostID) { await keepHostProbeWarm() }
+            .task(id: activeTab?.id) { await watchActivePane() }
+            #if DEBUG
+            .task {
+                await DeckScene.autoAttachIfRequested(
+                    store: store,
+                    workspace: workspace,
+                    openTerminalWindow: { route in
+                        if let shell {
+                            shell.openTerminalRoute(route)
+                        } else {
+                            openWindow(id: "terminal", value: route)
+                        }
+                    }
+                )
+            }
+            #endif
+            .onChange(of: route.tabs) { syncTabs() }
+            .onChange(of: terminalFocusAllowed) { _, allowed in
+                guard !allowed else { return }
+                activeController?.restoreFocusIfOwner(allowed: false)
+            }
+            // Keyboard focus follows the visible tab…
+            .onChange(of: route.activeTabID) { previousTabID, _ in
+                if let activeTab, activeTab.isViewport {
+                    // A page makes no responder claim; the terminal now
+                    // hidden behind it must not keep receiving hardware keys.
+                    if let previousTabID {
+                        workspace.controller(for: previousTabID)?.releaseFocus()
+                    }
+                } else if terminalFocusAllowed {
+                    activeController?.focusTerminal()
+                }
+                // No detection grace across tabs — chips must describe the
+                // pane on screen, immediately.
+                hideAgentTask?.cancel()
+                activePaneFingerprint = nil
+                shownAgent = detectedAgent
+            }
+            .onChange(of: detectedAgent) { _, agent in
+                hideAgentTask?.cancel()
+                if let agent {
+                    shownAgent = agent
+                } else {
+                    hideAgentTask = Task {
+                        try? await Task.sleep(for: .seconds(11))
+                        guard !Task.isCancelled else { return }
+                        shownAgent = nil
+                    }
+                }
+            }
+            // …and the window: restore the owner when the scene reactivates,
+            // and prod any mosh transport so it re-establishes contact within
+            // a round trip instead of a heartbeat interval.
+            .onChange(of: scenePhase) { _, phase in
+                if phase == .active {
+                    Task { await store.refreshFromCloud() }
+                    entitlements.refreshSlashChipMeter()
+                    activeController?.restoreFocusIfOwner(
+                        allowed: terminalFocusAllowed
+                    )
+                    for tab in route.tabs {
+                        workspace.controller(for: tab.id)?.transportForegrounded()
+                    }
+                }
+            }
     }
 
     private func acceptKeyPassphrase(
@@ -363,8 +389,10 @@ struct TerminalWindowRoot: View {
     /// reaches the network-heavy branch app-wide.
     private func watchActivePane() async {
         guard let activeTab,
+              !activeTab.isViewport,
               let host = store.host(id: activeTab.hostID)
         else {
+            // A viewport tab has no pane, no agent, and no PTY to watch.
             activePaneFingerprint = nil
             shownAgent = nil
             return
@@ -524,6 +552,20 @@ struct TerminalWindowRoot: View {
         openNewTab(launching: nil)
     }
 
+    /// The sheet's ⌗ VIEWPORT chip, headlessly: requires a pending link
+    /// (raised by `….debug.link`) and runs the exact offer → dock path the
+    /// chip takes.
+    private func debugOpenViewportForPendingLink() {
+        guard let controller = activeController,
+              let view = controller.terminalView,
+              view === TerminalFocusArbiter.current,
+              let link = controller.pendingLink,
+              let offer = ViewportOffer.make(for: link, host: activeTabHost)
+        else { return }
+        controller.dismissPendingLink()
+        openViewport(offer)
+    }
+
     /// Headless jump proof: load the focused pane's history and jump to the
     /// oldest REACHABLE prompt (prompts behind a /compact boundary are
     /// peek-only by design) — the deepest exercise of the pipeline (cwd
@@ -593,6 +635,27 @@ struct TerminalWindowRoot: View {
         }
     }
 
+    /// Dock a confirmed page as a viewport tab immediately after the tab
+    /// whose pane printed the URL — the + TAB precedent: arrive where you
+    /// are, move later (split it out to stand beside the terminal, merge it
+    /// back; the page rides along live). The controller is registered BEFORE
+    /// the tab enters the route — `syncTabs` treats a controller-less
+    /// viewport tab as a restored corpse, which is the no-persistence rule.
+    private func openViewport(_ offer: ViewportOffer) {
+        guard let activeTab, let host = store.host(id: activeTab.hostID) else { return }
+        let tab = TerminalRoute(
+            hostID: activeTab.hostID,
+            mode: .viewport(urlString: offer.url.absoluteString)
+        )
+        workspace.openViewport(tab: tab, offer: offer, hostName: host.name)
+        if let index = route.tabs.firstIndex(where: { $0.id == activeTab.id }) {
+            route.tabs.insert(tab, at: index + 1)
+        } else {
+            route.tabs.append(tab)
+        }
+        route.activate(tab.id)
+    }
+
     // MARK: Layout
 
     @ViewBuilder
@@ -637,6 +700,20 @@ struct TerminalWindowRoot: View {
                 // below-edge anchor (.top) parked the keys and window bar in
                 // the floating keyboard's summon zone (both user-reported).
                 .ornament(attachmentAnchor: .scene(.bottom), contentAlignment: .center) {
+                    if activeTab?.isViewport == true {
+                        // A page needs no keys, helper strip, or session
+                        // controls — the viewport face carries DECK, the
+                        // source label, MERGE, and CLOSE; the in-window rail
+                        // owns everything page-scoped.
+                        ViewportUMD(
+                            title: umdTitle,
+                            mergeSources: mergeSources,
+                            showDeck: showDeck,
+                            merge: { merge($0) },
+                            close: { if let activeTab { close(activeTab.id) } }
+                        )
+                        .alignmentGuide(VerticalAlignment.center) { _ in 24 }
+                    } else {
                     VStack(spacing: 10) {
                         // An ornament has its own intrinsic width. Clamp the
                         // long agent row to the live window width so narrowing
@@ -702,6 +779,7 @@ struct TerminalWindowRoot: View {
                     .alignmentGuide(VerticalAlignment.center) { _ in
                         showsAgentHelper ? 40 : 24
                     }
+                    }
                 }
         }
     }
@@ -731,6 +809,18 @@ struct TerminalWindowRoot: View {
 
     private func shellBody(_ configuration: ShellConfiguration) -> some View {
         VStack(spacing: 0) {
+            if activeTab?.isViewport == true {
+                ViewportUMD(
+                    title: umdTitle,
+                    mergeSources: [],
+                    showDeck: configuration.showDeck,
+                    merge: { _ in },
+                    close: { if let activeTab { close(activeTab.id) } },
+                    style: .shell,
+                    deckControlLabel: configuration.deckControlLabel,
+                    contentSafeArea: configuration.contentSafeArea
+                )
+            } else {
             UMDBar(
                 controller: activeController,
                 title: umdTitle,
@@ -751,6 +841,7 @@ struct TerminalWindowRoot: View {
                 availableWidth: configuration.availableWidth,
                 contentSafeArea: configuration.contentSafeArea
             )
+            }
             if route.tabs.count > 1 {
                 ScrollView(.horizontal, showsIndicators: false) {
                     tabStrip
@@ -764,23 +855,25 @@ struct TerminalWindowRoot: View {
             #if os(visionOS)
             paneStack
                 .overlay(alignment: .bottom) {
-                    VStack(spacing: 8) {
-                        helperStrip(
-                            floating: true,
-                            floatingMaximumWidth: max(
-                                1,
-                                configuration.availableWidth - 24
+                    if activeTab?.isViewport != true {
+                        VStack(spacing: 8) {
+                            helperStrip(
+                                floating: true,
+                                floatingMaximumWidth: max(
+                                    1,
+                                    configuration.availableWidth - 24
+                                )
                             )
-                        )
-                        // The width clamp engages the cluster's compact
-                        // tiers in a phone-narrow shell.
-                        TerminalKeyCluster(controller: activeController)
-                            .frame(maxWidth: max(
-                                1,
-                                configuration.availableWidth - 24
-                            ))
+                            // The width clamp engages the cluster's compact
+                            // tiers in a phone-narrow shell.
+                            TerminalKeyCluster(controller: activeController)
+                                .frame(maxWidth: max(
+                                    1,
+                                    configuration.availableWidth - 24
+                                ))
+                        }
+                        .padding(.bottom, 10)
                     }
-                    .padding(.bottom, 10)
                 }
             #else
             iOSPaneSurface
@@ -824,17 +917,31 @@ struct TerminalWindowRoot: View {
         ZStack {
             ForEach(route.tabs) { tab in
                 let isActive = tab.id == activeTab?.id
-                TerminalPane(
-                    controller: workspace.controller(for: tab.id),
-                    hostExists: store.host(id: tab.hostID) != nil,
-                    fontSize: fontSize,
-                    bottomChromeHeight: terminalBottomChromeHeight,
-                    contentSafeArea: contentSafeArea,
-                    railOwnsBottomSafeArea: railOwnsBottomSafeArea,
-                    isActive: isActive,
-                    focusAllowed: terminalFocusAllowed,
-                    close: { close(tab.id) }
-                )
+                Group {
+                    if tab.isViewport {
+                        // syncTabs guarantees a controller exists for every
+                        // viewport tab still in the route.
+                        if let viewport = workspace.viewportController(for: tab.id) {
+                            ViewportPane(
+                                controller: viewport,
+                                contentSafeArea: contentSafeArea,
+                                close: { close(tab.id) }
+                            )
+                        }
+                    } else {
+                        TerminalPane(
+                            controller: workspace.controller(for: tab.id),
+                            hostExists: store.host(id: tab.hostID) != nil,
+                            fontSize: fontSize,
+                            bottomChromeHeight: terminalBottomChromeHeight,
+                            contentSafeArea: contentSafeArea,
+                            railOwnsBottomSafeArea: railOwnsBottomSafeArea,
+                            isActive: isActive,
+                            focusAllowed: terminalFocusAllowed,
+                            close: { close(tab.id) }
+                        )
+                    }
+                }
                 .opacity(isActive ? 1 : 0)
                 .allowsHitTesting(isActive)
                 .accessibilityHidden(!isActive)
@@ -906,7 +1013,8 @@ struct TerminalWindowRoot: View {
                 title: tab.displayName,
                 hostName: multiHost ? store.host(id: tab.hostID)?.name : nil,
                 controller: workspace.controller(for: tab.id),
-                isActive: tab.id == activeTab?.id
+                isActive: tab.id == activeTab?.id,
+                isViewport: tab.isViewport
             )
         }
     }
@@ -991,7 +1099,20 @@ struct TerminalWindowRoot: View {
             )
             .accessibilityHint("Shows how to unlock the keychain")
         }
-        if horizontalSizeClass == .compact {
+        if activeTab?.isViewport == true {
+            // A page needs none of the terminal's controls: MERGE (the road
+            // home for a split-out viewport) and CLOSE are the window's
+            // whole vocabulary — the rail under the page owns the rest.
+            if !mergeSources.isEmpty {
+                mergeMenu
+            }
+            ChassisChip("CLOSE", prominent: true) {
+                if let activeTab { close(activeTab.id) }
+            }
+            .fixedSize()
+            .accessibilityLabel("Close viewport")
+            .padding(.trailing, trailingPadding)
+        } else if horizontalSizeClass == .compact {
             // UIKit's automatic toolbar overflow keeps only the trailing
             // DETACH menu when custom chassis controls no longer fit. Own the
             // compact overflow just like the iPhone shell so every displaced
@@ -1140,6 +1261,24 @@ struct TerminalWindowRoot: View {
     /// closes), otherwise controllers exist for every tab and the window's
     /// directory entry is fresh.
     private func syncTabs() {
+        // The viewport's no-persistence rule: its controllers exist only in
+        // the process that summoned them (`openViewport` registers before
+        // the tab enters any route), so a viewport tab without one can only
+        // be scene restoration handing back a previous launch's page —
+        // summoned, not restored, it is stripped rather than resurrected.
+        // The mutation re-enters here through onChange; the second pass
+        // finds nothing to strip.
+        let restoredViewports = route.tabs.filter {
+            $0.isViewport && workspace.viewportController(for: $0.id) == nil
+        }
+        if !restoredViewports.isEmpty {
+            let ids = Set(restoredViewports.map(\.id))
+            route.tabs.removeAll { ids.contains($0.id) }
+            if let active = route.activeTabID, ids.contains(active) {
+                route.activeTabID = route.tabs.first?.id
+            }
+            return
+        }
         if route.tabs.isEmpty {
             workspace.unregisterWindow(id: route.id)
             if let shell {
@@ -1152,7 +1291,7 @@ struct TerminalWindowRoot: View {
             }
             return
         }
-        for tab in route.tabs {
+        for tab in route.tabs where !tab.isViewport {
             _ = workspace.controller(for: tab, store: store)
         }
         workspace.registerWindow(.init(
@@ -1671,6 +1810,7 @@ extension Notification.Name {
     )
     static let multiplexDebugLink = Notification.Name("MultiplexDebugLink")
     static let multiplexDebugLinkOpen = Notification.Name("MultiplexDebugLinkOpen")
+    static let multiplexDebugViewportOpen = Notification.Name("MultiplexDebugViewportOpen")
 }
 
 /// `….debug.link` activates the first link on the focused terminal's visible
@@ -1696,6 +1836,12 @@ enum TerminalLinkDebugHook {
             "app.multiplexterm.multiplex.debug.linkopen", &openToken, .main
         ) { _ in
             NotificationCenter.default.post(name: .multiplexDebugLinkOpen, object: nil)
+        }
+        var viewportToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.viewportopen", &viewportToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugViewportOpen, object: nil)
         }
     }
 }

--- a/Multiplex/Views/Terminal/ViewportPane.swift
+++ b/Multiplex/Views/Terminal/ViewportPane.swift
@@ -1,0 +1,335 @@
+import SwiftUI
+import WebKit
+
+/// One viewport tab's surface: the page above, the TALLY rail below.
+///
+/// The page is screen content — it may be bright inside the dark chassis,
+/// exactly like a light terminal theme. The rail keeps the confirmed
+/// verdict visible for the life of the tab (monospace URL, host emphasized,
+/// the REACH tag that admitted it) and carries the only controls a monitor
+/// needs: back, reload/stop, the SYSTEM handoff, and CLOSE. A caution
+/// hairline sweeps its top edge while loading — the rail's only motion,
+/// never red.
+struct ViewportPane: View {
+    @Bindable var controller: ViewportController
+    var contentSafeArea = EdgeInsets()
+    let close: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                Theme.screen
+                ViewportWebHost(controller: controller)
+                if let failure = controller.failure {
+                    failurePanel(failure)
+                }
+            }
+            rail
+        }
+        .background(Theme.bezel)
+        // A page may navigate to something the gate refuses to render
+        // (mailto, a custom scheme). Same discipline as a pane press: the
+        // target is shown and confirmed, never followed.
+        .sheet(item: $controller.externalLink) { link in
+            TerminalLinkSheet(
+                link: link,
+                onOpen: {
+                    if let url = link.openableURL { UIApplication.shared.open(url) }
+                },
+                onCopy: { UIPasteboard.general.string = link.raw }
+            )
+        }
+    }
+
+    // MARK: Rail
+
+    private var rail: some View {
+        HStack(spacing: 9) {
+            ChassisChip("", systemImage: "chevron.left") { controller.goBack() }
+                .disabled(!controller.canGoBack)
+                .opacity(controller.canGoBack ? 1 : 0.45)
+                .accessibilityLabel("Back")
+            ChassisChip(
+                "",
+                systemImage: controller.isLoading ? "xmark" : "arrow.clockwise"
+            ) {
+                controller.isLoading ? controller.stopLoading() : controller.reload()
+            }
+            .accessibilityLabel(controller.isLoading ? "Stop loading" : "Reload")
+            urlReadout
+            ChassisBadge(controller.offer.reachTag)
+                .fixedSize()
+                .accessibilityLabel("Reach: \(controller.offer.reachTag)")
+            ChassisChip("SYSTEM") { controller.openInSystemBrowser() }
+                .fixedSize()
+                .accessibilityLabel("Open in the system browser")
+            ChassisChip("CLOSE", prominent: true, action: close)
+                .fixedSize()
+                .accessibilityLabel("Close viewport")
+        }
+        .padding(.leading, 10 + contentSafeArea.leading)
+        .padding(.trailing, 10 + contentSafeArea.trailing)
+        .padding(.top, 8)
+        .padding(.bottom, 8 + contentSafeArea.bottom)
+        .background(Theme.bezel)
+        .overlay(alignment: .top) {
+            ZStack(alignment: .topLeading) {
+                Rectangle().fill(Theme.bezelHi).frame(height: 1)
+                if controller.isLoading {
+                    GeometryReader { geometry in
+                        Rectangle()
+                            .fill(Theme.caution)
+                            .frame(
+                                width: max(
+                                    0,
+                                    geometry.size.width * controller.progress
+                                ),
+                                height: 2
+                            )
+                    }
+                    .frame(height: 2)
+                    .accessibilityHidden(true)
+                }
+            }
+        }
+    }
+
+    /// Monospace readout, host bright, the rest dim — the identity voice.
+    /// The address is data, not an omnibox: it is never editable in place,
+    /// and a long press copies it.
+    private var urlReadout: some View {
+        Text(readoutText)
+            .font(.mono(10))
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contextMenu {
+                Button {
+                    controller.copyURL()
+                } label: {
+                    Label("Copy Address", systemImage: "doc.on.doc")
+                }
+            }
+            .accessibilityLabel(controller.displayURL.absoluteString)
+    }
+
+    private var readoutText: AttributedString {
+        let url = controller.displayURL
+        var host = AttributedString(url.host() ?? url.absoluteString)
+        if let port = url.port { host += AttributedString(":\(port)") }
+        host.foregroundColor = Theme.signal
+        host.font = .mono(10, weight: .semibold)
+        var rest = AttributedString(pathAndQuery(of: url))
+        rest.foregroundColor = Theme.signal2
+        return host + rest
+    }
+
+    private func pathAndQuery(of url: URL) -> String {
+        var tail = url.path()
+        if tail.isEmpty { tail = "/" }
+        if let query = url.query() { tail += "?\(query)" }
+        return tail
+    }
+
+    // MARK: Failure
+
+    /// WebKit's blank error page never appears — the chassis says what
+    /// happened and, when the address lives on the host's network, whose
+    /// network that is.
+    private func failurePanel(_ message: String) -> some View {
+        VStack(spacing: 14) {
+            TallyLamp(caption: "NO ROUTE", color: Theme.caution)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(Theme.signal2)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 380)
+            if let hint = reachHint {
+                Text(hint)
+                    .font(.footnote)
+                    .foregroundStyle(Theme.signal3)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 380)
+            }
+            HStack(spacing: 12) {
+                ChassisChip("RETRY", prominent: true) { controller.reload() }
+                ChassisChip("SYSTEM") { controller.openInSystemBrowser() }
+            }
+            .padding(.top, 4)
+        }
+        .padding(30)
+        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Theme.bezelHi, lineWidth: 1))
+        .padding(20)
+    }
+
+    private var reachHint: String? {
+        switch controller.offer.reach {
+        case .internet:
+            return nil
+        case .lan:
+            return "This address lives on \(controller.hostName)'s network — "
+                + "the device must share it to load the page."
+        case .remoteLoopback:
+            return "This page rides \(controller.hostName)'s own address. "
+                + "The server must listen beyond loopback (vite --host, "
+                + "-H 0.0.0.0) for anything to answer."
+        }
+    }
+}
+
+/// Adopts the controller-owned WKWebView the way `SwiftTermView` adopts its
+/// terminal view: `removeFromSuperview` + re-pin, so a tab moving between
+/// windows (merge/split) keeps the live page, its scroll position, and any
+/// open sockets. The controller outlives every window the tab passes
+/// through; this representable only hosts.
+private struct ViewportWebHost: UIViewRepresentable {
+    let controller: ViewportController
+
+    func makeUIView(context: Context) -> UIView {
+        let container = UIView()
+        container.backgroundColor = .clear
+        adopt(into: container)
+        return container
+    }
+
+    func updateUIView(_ container: UIView, context: Context) {
+        if controller.webView.superview !== container {
+            adopt(into: container)
+        }
+    }
+
+    private func adopt(into container: UIView) {
+        guard let webView = controller.webView else { return }
+        webView.removeFromSuperview()
+        container.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: container.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+    }
+}
+
+/// The window chrome while a viewport tab is on screen — the UMD's viewport
+/// face. A page needs none of the terminal's controls (keys, FILE, TMUX,
+/// DETACH), so the row carries only what a monitor's frame owes the window:
+/// DECK, the source label, MERGE (the road home for a split-out page), and
+/// CLOSE. The rail below the page owns everything page-scoped.
+struct ViewportUMD: View {
+    enum Style {
+        /// visionOS classic window's bottom ornament row.
+        case regular
+        /// The single-window shell's slim full-width top row.
+        case shell
+    }
+
+    var title: String
+    var mergeSources: [TerminalWorkspace.WindowEntry]
+    var showDeck: () -> Void
+    var merge: (UUID) -> Void
+    var close: () -> Void
+    var style: Style = .regular
+    var deckControlLabel = "DECK"
+    var contentSafeArea = EdgeInsets()
+
+    @ViewBuilder
+    var body: some View {
+        switch style {
+        case .regular: regularBar
+        case .shell: shellBar
+        }
+    }
+
+    private var regularBar: some View {
+        HStack(spacing: 14) {
+            ChassisChip("DECK", action: showDeck)
+            divider
+            ChassisLabel(title, size: 12)
+            if !mergeSources.isEmpty {
+                mergeMenu
+            }
+            divider
+            ChassisChip("CLOSE", prominent: true, action: close)
+                .accessibilityLabel("Close viewport")
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 11)
+        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Theme.bezelHi, lineWidth: 1))
+    }
+
+    private var shellBar: some View {
+        HStack(spacing: 9) {
+            ChassisChip(deckControlLabel, action: showDeck)
+                .fixedSize()
+            ChassisLabel(title, size: 11)
+                .layoutPriority(1)
+            Spacer(minLength: 4)
+            ChassisChip("CLOSE", prominent: true, action: close)
+                .fixedSize()
+                .accessibilityLabel("Close viewport")
+        }
+        .padding(.leading, 10 + contentSafeArea.leading)
+        .padding(.trailing, 10 + contentSafeArea.trailing)
+        .padding(.vertical, 8)
+        .background(Theme.bezel)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Theme.bezelHi).frame(height: 1)
+        }
+    }
+
+    private var mergeMenu: some View {
+        Menu {
+            ForEach(mergeSources) { entry in
+                Button {
+                    merge(entry.id)
+                } label: {
+                    Label(entry.label, systemImage: "macwindow")
+                }
+            }
+        } label: {
+            ChassisBadge("MERGE")
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .chassisHover(2)
+        .accessibilityLabel("Merge another window into this one")
+    }
+
+    private var divider: some View {
+        Rectangle().fill(Theme.bezelHi).frame(width: 1, height: 18)
+    }
+}
+
+#if DEBUG
+#Preview("Viewport UMD") {
+    VStack(spacing: 20) {
+        ViewportUMD(
+            title: "⌗ 5173 · devbox",
+            mergeSources: [],
+            showDeck: {},
+            merge: { _ in },
+            close: {}
+        )
+        ViewportUMD(
+            title: "⌗ 5173 · devbox",
+            mergeSources: [],
+            showDeck: {},
+            merge: { _ in },
+            close: {},
+            style: .shell,
+            deckControlLabel: "WALL"
+        )
+        .frame(width: 500)
+    }
+    .padding()
+    .background(Theme.chassis)
+}
+#endif

--- a/Multiplex/Views/Terminal/ViewportPane.swift
+++ b/Multiplex/Views/Terminal/ViewportPane.swift
@@ -15,6 +15,18 @@ struct ViewportPane: View {
     var contentSafeArea = EdgeInsets()
     let close: () -> Void
 
+    /// The rail's address editor, presented as a top contextual bar — the
+    /// same slot Copy Mode and the jump bar use. Top on purpose: the pane
+    /// opts out of SwiftUI keyboard avoidance for the terminal's sake, so a
+    /// docked keyboard would cover an editor living in the bottom rail.
+    @State private var editingAddress = false
+    @State private var addressDraft = ""
+    @State private var addressRejected = false
+    @FocusState private var addressFieldFocused: Bool
+    /// Clearing wipes the store every viewport shares — destructive, so it
+    /// confirms (the deck's delete-action policy).
+    @State private var confirmingClearBrowsingData = false
+
     var body: some View {
         VStack(spacing: 0) {
             ZStack {
@@ -24,9 +36,31 @@ struct ViewportPane: View {
                     failurePanel(failure)
                 }
             }
+            .overlay(alignment: .top) {
+                if editingAddress {
+                    addressEditor
+                        .padding(.horizontal, 12)
+                        .padding(.top, 12)
+                }
+            }
             rail
         }
         .background(Theme.bezel)
+        .alert(
+            "Clear Browsing Data",
+            isPresented: $confirmingClearBrowsingData
+        ) {
+            Button("Clear", role: .destructive) {
+                controller.clearBrowsingData()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "Clears cookies, caches, and site storage for every "
+                    + "viewport page — dev-server logins included. "
+                    + "This page reloads signed out."
+            )
+        }
         // A page may navigate to something the gate refuses to render
         // (mailto, a custom scheme). Same discipline as a pane press: the
         // target is shown and confirmed, never followed.
@@ -57,9 +91,9 @@ struct ViewportPane: View {
             }
             .accessibilityLabel(controller.isLoading ? "Stop loading" : "Reload")
             urlReadout
-            ChassisBadge(controller.offer.reachTag)
+            ChassisBadge(controller.railTag)
                 .fixedSize()
-                .accessibilityLabel("Reach: \(controller.offer.reachTag)")
+                .accessibilityLabel("Reach: \(controller.railTag)")
             ChassisChip("SYSTEM") { controller.openInSystemBrowser() }
                 .fixedSize()
                 .accessibilityLabel("Open in the system browser")
@@ -95,22 +129,90 @@ struct ViewportPane: View {
     }
 
     /// Monospace readout, host bright, the rest dim — the identity voice.
-    /// The address is data, not an omnibox: it is never editable in place,
-    /// and a long press copies it.
+    /// Tap opens the address editor in the pane's top-bar slot; a long
+    /// press copies. The readout itself never becomes a field — the rail
+    /// stays a monitor's frame, and the editor gets the keyboard-safe slot.
     private var urlReadout: some View {
-        Text(readoutText)
-            .font(.mono(10))
-            .lineLimit(1)
-            .truncationMode(.middle)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contextMenu {
-                Button {
-                    controller.copyURL()
-                } label: {
-                    Label("Copy Address", systemImage: "doc.on.doc")
-                }
+        Button {
+            beginEditingAddress()
+        } label: {
+            Text(readoutText)
+                .font(.mono(10))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .chassisHover(2)
+        .contextMenu {
+            Button {
+                controller.copyURL()
+            } label: {
+                Label("Copy Address", systemImage: "doc.on.doc")
             }
-            .accessibilityLabel(controller.displayURL.absoluteString)
+            Button(role: .destructive) {
+                confirmingClearBrowsingData = true
+            } label: {
+                Label("Clear Browsing Data…", systemImage: "trash")
+            }
+        }
+        .accessibilityLabel(controller.displayURL.absoluteString)
+        .accessibilityHint("Edits the address")
+    }
+
+    // MARK: Address editor
+
+    private func beginEditingAddress() {
+        addressDraft = controller.displayURL.absoluteString
+        addressRejected = false
+        editingAddress = true
+        addressFieldFocused = true
+    }
+
+    private func submitAddress() {
+        if controller.navigate(toTyped: addressDraft) {
+            editingAddress = false
+        } else {
+            addressRejected = true
+        }
+    }
+
+    private var addressEditor: some View {
+        HStack(spacing: 12) {
+            ChassisLabel("ADDRESS", size: 9, color: Theme.signal3)
+            TextField("host:port or https://…", text: $addressDraft)
+                .font(.mono(12))
+                .foregroundStyle(Theme.signal)
+                .textFieldStyle(.plain)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .submitLabel(.go)
+                .focused($addressFieldFocused)
+                .onSubmit(submitAddress)
+                .onChange(of: addressDraft) { addressRejected = false }
+                .frame(minWidth: 160, maxWidth: 420)
+            if addressRejected {
+                ChassisLabel("WEB ADDRESSES ONLY", size: 8, color: Theme.caution)
+                    .fixedSize()
+            }
+            ChassisChip("GO", prominent: true, action: submitAddress)
+                .fixedSize()
+            ChassisChip("CANCEL") { editingAddress = false }
+                .fixedSize()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            Theme.bezel,
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(Theme.bezelHi, lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
     }
 
     private var readoutText: AttributedString {
@@ -166,7 +268,7 @@ struct ViewportPane: View {
     }
 
     private var reachHint: String? {
-        switch controller.offer.reach {
+        switch controller.currentReach {
         case .internet:
             return nil
         case .lan:

--- a/MultiplexTests/ViewportReachTests.swift
+++ b/MultiplexTests/ViewportReachTests.swift
@@ -133,6 +133,86 @@ final class ViewportReachTests: XCTestCase {
         }
     }
 
+    // MARK: Typed rail input
+
+    private func typed(_ input: String, host: Host? = nil) -> ViewportOffer? {
+        ViewportOffer.fromTypedInput(input, host: host)
+    }
+
+    func testTypedInputDefaultsSchemeByReach() {
+        // Dev servers are cleartext — LAN/loopback default http; names on
+        // the internet default https.
+        XCTAssertEqual(
+            typed("192.168.1.68:3000")?.url.absoluteString,
+            "http://192.168.1.68:3000"
+        )
+        XCTAssertEqual(
+            typed("devbox:8080")?.url.absoluteString,
+            "http://devbox:8080"
+        )
+        XCTAssertEqual(
+            typed("vercel.com/docs")?.url.absoluteString,
+            "https://vercel.com/docs"
+        )
+    }
+
+    func testTypedInputRewritesLoopbackViaTheHost() {
+        let offer = typed("localhost:5173", host: devbox)
+        XCTAssertEqual(offer?.url.absoluteString, "http://100.84.2.19:5173")
+        XCTAssertEqual(offer?.reach, .remoteLoopback)
+        XCTAssertEqual(offer?.viaHostName, "devbox")
+        // Without a host record there is nothing to rewrite via.
+        XCTAssertNil(typed("localhost:5173"))
+    }
+
+    func testTypedInputKeepsAnExplicitWebScheme() {
+        XCTAssertEqual(
+            typed("https://192.168.1.68/x")?.url.absoluteString,
+            "https://192.168.1.68/x"
+        )
+        XCTAssertEqual(
+            typed("HTTP://example.com")?.reach,
+            .internet
+        )
+    }
+
+    func testTypedInputRefusesNonWebInput() {
+        for input in [
+            "file:///etc/hosts",
+            "ssh://root@evil.example",
+            "javascript:alert(1)",
+            "mailto:dev@example.com",
+            "multiplex://open?host=devbox",
+            "",
+            "   ",
+            "two words",
+        ] {
+            XCTAssertNil(typed(input, host: devbox), input)
+        }
+    }
+
+    func testTypedInputRefusesUserinfoPaddedAuthorities() {
+        // `http://mailto:dev@example.com` parses "mailto:dev" as userinfo —
+        // the trick the link sheet renders a HOST line to expose. Typed
+        // input never needs userinfo, so it is refused outright.
+        for input in [
+            "https://mailto:dev@example.com",
+            "https://github.com@evil.example/x",
+            "user:pass@10.0.0.5:9090",
+        ] {
+            XCTAssertNil(typed(input, host: devbox), input)
+        }
+        // The colon-digits rule still admits ordinary host:port forms.
+        XCTAssertNotNil(typed("localhost:5173", host: devbox))
+    }
+
+    func testTypedInputTrimsWhitespace() {
+        XCTAssertEqual(
+            typed("  10.0.0.5:9090  ")?.url.absoluteString,
+            "http://10.0.0.5:9090"
+        )
+    }
+
     // MARK: Viewport routes
 
     func testViewportRouteIsNotATerminal() {

--- a/MultiplexTests/ViewportReachTests.swift
+++ b/MultiplexTests/ViewportReachTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import Multiplex
+
+final class ViewportReachTests: XCTestCase {
+    private func classify(_ target: String) -> ViewportReach? {
+        guard let url = URL(string: target) else {
+            XCTFail("unparseable test URL \(target)")
+            return nil
+        }
+        return ViewportReach.classify(url)
+    }
+
+    // MARK: Classification
+
+    func testPublicAddressesAreInternet() {
+        for target in [
+            "https://vercel.com/docs",
+            "http://example.com",
+            "https://93.184.216.34/status",
+            "http://intranet.example.internal:8080/",
+        ] {
+            XCTAssertEqual(classify(target), .internet, target)
+        }
+    }
+
+    func testPrivateRangesAreLAN() {
+        for target in [
+            "http://192.168.1.68:5173/",
+            "http://10.0.0.5/",
+            "http://172.16.0.1:3000/",
+            "http://172.31.255.254/",
+            "http://169.254.10.10/",
+            "http://devbox.local:8080/",
+            "http://[fe80::1]:9090/",
+            "http://[fd12:3456::1]/",
+        ] {
+            XCTAssertEqual(classify(target), .lan, target)
+        }
+    }
+
+    func testUnqualifiedSingleLabelIsLAN() {
+        // A bare machine name resolves through the local network's search
+        // domains — LAN by construction.
+        XCTAssertEqual(classify("http://devbox:3000/"), .lan)
+    }
+
+    func test172RangeBoundariesAreExact() {
+        // Only 172.16/12 is private; its dotted neighbors are internet.
+        XCTAssertEqual(classify("http://172.15.0.1/"), .internet)
+        XCTAssertEqual(classify("http://172.32.0.1/"), .internet)
+    }
+
+    func testLoopbackSpellings() {
+        for target in [
+            "http://localhost:5173/",
+            "http://sub.localhost/",
+            "http://127.0.0.1:9090/metrics",
+            "http://127.5.3.1/",
+            "http://0.0.0.0:3000/",
+            "http://[::1]:8080/",
+        ] {
+            XCTAssertEqual(classify(target), .remoteLoopback, target)
+        }
+    }
+
+    func testNonWebSchemesDoNotClassify() {
+        XCTAssertNil(classify("mailto:dev@example.com"))
+        XCTAssertNil(classify("file:///etc/hosts"))
+        XCTAssertNil(classify("multiplex://open?host=devbox"))
+    }
+
+    // MARK: Offers
+
+    private var devbox: Host {
+        Host(name: "devbox", hostname: "100.84.2.19", username: "jhen")
+    }
+
+    private func offer(_ target: String, host: Host?) -> ViewportOffer? {
+        guard let link = TerminalLink.resolve(target) else {
+            XCTFail("expected \(target) to resolve")
+            return nil
+        }
+        return ViewportOffer.make(for: link, host: host)
+    }
+
+    func testDirectAddressesPassThroughUnchanged() {
+        let lan = offer("http://192.168.1.68:5173/", host: devbox)
+        XCTAssertEqual(lan?.url.absoluteString, "http://192.168.1.68:5173/")
+        XCTAssertEqual(lan?.reach, .lan)
+        XCTAssertNil(lan?.viaHostName)
+        XCTAssertEqual(lan?.reachTag, "LAN")
+
+        let net = offer("https://vercel.com/docs", host: nil)
+        XCTAssertEqual(net?.url.absoluteString, "https://vercel.com/docs")
+        XCTAssertEqual(net?.reach, .internet)
+        XCTAssertEqual(net?.reachTag, "NET")
+    }
+
+    func testLoopbackRewritesToTheHostsDialledAddress() {
+        let rewritten = offer("http://localhost:5173/app?tab=1", host: devbox)
+        XCTAssertEqual(
+            rewritten?.url.absoluteString,
+            "http://100.84.2.19:5173/app?tab=1"
+        )
+        XCTAssertEqual(rewritten?.reach, .remoteLoopback)
+        XCTAssertEqual(rewritten?.viaHostName, "devbox")
+        XCTAssertEqual(rewritten?.reachTag, "VIA DEVBOX")
+    }
+
+    func testLoopbackRewriteKeepsSchemeAndOmittedPort() {
+        let rewritten = offer("https://127.0.0.1/metrics", host: devbox)
+        XCTAssertEqual(
+            rewritten?.url.absoluteString,
+            "https://100.84.2.19/metrics"
+        )
+    }
+
+    func testLoopbackWithoutAHostRecordIsNotOffered() {
+        XCTAssertNil(offer("http://localhost:5173/", host: nil))
+    }
+
+    func testNonWebLinksAreNotOffered() {
+        XCTAssertNil(offer("mailto:dev@example.com", host: devbox))
+    }
+
+    func testBlockedAndMalformedLinksAreNotOffered() {
+        for target in ["file:///etc/shadow", "ssh://root@evil.example"] {
+            guard let link = TerminalLink.resolve(target) else {
+                XCTFail("expected \(target) to resolve as blocked")
+                continue
+            }
+            XCTAssertNil(ViewportOffer.make(for: link, host: devbox), target)
+        }
+    }
+
+    // MARK: Viewport routes
+
+    func testViewportRouteIsNotATerminal() {
+        let route = TerminalRoute(
+            hostID: UUID(),
+            mode: .viewport(urlString: "http://192.168.1.68:5173/")
+        )
+        XCTAssertTrue(route.isViewport)
+        XCTAssertNil(route.remoteCommand)
+        XCTAssertNil(route.moshRemoteCommand)
+        XCTAssertNil(route.sessionName)
+        XCTAssertEqual(route.viewportURL?.absoluteString, "http://192.168.1.68:5173/")
+    }
+
+    func testViewportLabelPrefersThePort() {
+        XCTAssertEqual(
+            TerminalRoute.viewportLabel("http://192.168.1.68:5173/"),
+            "⌗ 5173"
+        )
+        XCTAssertEqual(
+            TerminalRoute.viewportLabel("https://vercel.com/docs"),
+            "⌗ vercel.com"
+        )
+    }
+
+    func testViewportRouteRoundTripsThroughCodable() throws {
+        // The scene value carries viewport tabs like any other tab; the
+        // no-persistence rule lives in syncTabs (a restored viewport tab has
+        // no controller and is stripped), not in the codec.
+        let route = TerminalRoute(
+            hostID: UUID(),
+            mode: .viewport(urlString: "http://localhost:5173/")
+        )
+        let decoded = try JSONDecoder().decode(
+            TerminalRoute.self,
+            from: JSONEncoder().encode(route)
+        )
+        XCTAssertEqual(decoded, route)
+        XCTAssertTrue(decoded.isViewport)
+    }
+}

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -2586,6 +2586,29 @@ extension TerminalView {
         selection.selectNone()
     }
 
+    // Multiplex patch: gaze link regions (visionOS). The visible screen's
+    // links with view-space rects — the exact inverse of calculateTapHit's
+    // point→grid mapping (col = x / cellWidth, row = y / cellHeight), so a
+    // region lights precisely the cells whose tap would resolve the link.
+    public struct VisibleLinkRegion {
+        public let target: String
+        public let rects: [CGRect]
+    }
+
+    public func visibleLinkRegions () -> [VisibleLinkRegion] {
+        guard cellDimension != nil else { return [] }
+        return terminal.visibleLinkMatches (mode: .explicitAndImplicit).map { match in
+            VisibleLinkRegion (
+                target: match.text,
+                rects: match.rowRanges.map { segment in
+                    CGRect (
+                        x: CGFloat (segment.columns.lowerBound) * cellDimension.width,
+                        y: CGFloat (segment.row) * cellDimension.height,
+                        width: CGFloat (segment.columns.count) * cellDimension.width,
+                        height: cellDimension.height)
+                })
+        }
+    }
 }
 
 #if canImport(UIKit) && DEBUG

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
@@ -5974,6 +5974,54 @@ open class Terminal {
         return linkMatch(at: location, mode: mode)?.text
     }
 
+    // Multiplex patch: gaze link regions (visionOS). The system renders gaze
+    // hover out of process — an app never learns where the user looks — so
+    // hover affordances require enumerating where the links ARE. One pass
+    // over the visible screen, probing every `probeStride` cells: a match
+    // found at any probed cell reports its full range (including wrapped
+    // continuation rows), and no URL is narrower than the stride.
+    public struct VisibleLinkMatch {
+        public let text: String
+        public let isExplicit: Bool
+        /// Visible-screen segments, topmost first: row + column range.
+        public let rowRanges: [(row: Int, columns: Range<Int>)]
+    }
+
+    public func visibleLinkMatches(mode: LinkLookupMode = .explicitAndImplicit) -> [VisibleLinkMatch]
+    {
+        var results: [VisibleLinkMatch] = []
+        var covered = Set<Int>()
+        let probeStride = 4
+        func key (_ row: Int, _ col: Int) -> Int { row * 10_000 + col }
+        for row in 0..<rows {
+            var col = 0
+            while col < cols {
+                if covered.contains (key (row, col)) {
+                    col += 1
+                    continue
+                }
+                guard let match = linkMatch (at: .screen(Position(col: col, row: row)), mode: mode) else {
+                    col += probeStride
+                    continue
+                }
+                var segments: [(row: Int, columns: Range<Int>)] = []
+                for rowRange in match.rowRanges {
+                    segments.append ((row: rowRange.row, columns: rowRange.range))
+                    for coveredCol in rowRange.range {
+                        covered.insert (key (rowRange.row, coveredCol))
+                    }
+                }
+                results.append (VisibleLinkMatch (text: match.text, isExplicit: match.isExplicit, rowRanges: segments))
+                if let currentRow = match.rowRanges.first (where: { $0.row == row }) {
+                    col = max (col + 1, currentRow.range.upperBound)
+                } else {
+                    col += probeStride
+                }
+            }
+        }
+        return results
+    }
+
     func getDisplayText (start: Position, end: Position) -> String
     {
         getText(start: start, end: end, buffer: displayBuffer)

--- a/Vendor/SwiftTerm/Tests/SwiftTermTests/LinkLookupTests.swift
+++ b/Vendor/SwiftTerm/Tests/SwiftTermTests/LinkLookupTests.swift
@@ -145,3 +145,49 @@ final class LinkLookupTests: TerminalDelegate {
         #expect(link == "https://www.example.com")
     }
 }
+
+// Multiplex patch: gaze link regions (visionOS) — the visible-screen
+// enumerator behind hover affordances.
+final class VisibleLinkMatchTests: TerminalDelegate {
+    func send(source: Terminal, data: ArraySlice<UInt8>) {
+    }
+
+    @Test func testEnumeratesEveryVisibleLink() {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: 60, rows: 6))
+        terminal.feed(text: "see https://example.com/docs now\r\n")
+        terminal.feed(text: "plain text row\r\n")
+        terminal.feed(text: "next http://192.168.1.68:5173/ here")
+
+        let matches = terminal.visibleLinkMatches()
+        let urls = matches.map(\.text)
+        #expect(urls.contains("https://example.com/docs"))
+        #expect(urls.contains("http://192.168.1.68:5173/"))
+
+        let first = matches.first { $0.text == "https://example.com/docs" }
+        #expect(first?.rowRanges.count == 1)
+        #expect(first?.rowRanges.first?.row == 0)
+        #expect(first?.rowRanges.first?.columns == 4..<28)
+    }
+
+    @Test func testMatchesAreReportedOnceAndProbeStrideCannotMissThem() {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: 40, rows: 4))
+        // Offset by 2 so the match straddles probe-stride boundaries.
+        terminal.feed(text: "ab http://a.io x http://b.io\r\n")
+
+        let matches = terminal.visibleLinkMatches()
+        #expect(matches.filter { $0.text == "http://a.io" }.count == 1)
+        #expect(matches.filter { $0.text == "http://b.io" }.count == 1)
+    }
+
+    @Test func testWrappedLinkReportsBothRowsOnce() {
+        let terminal = Terminal(delegate: self, options: TerminalOptions(cols: 20, rows: 4))
+        // 20-column terminal: the URL wraps onto the second row.
+        terminal.feed(text: "https://example.com/abcdefgh")
+
+        let matches = terminal.visibleLinkMatches()
+        #expect(matches.count == 1)
+        #expect(matches.first?.rowRanges.count == 2)
+        #expect(matches.first?.rowRanges.first?.row == 0)
+        #expect(matches.first?.rowRanges.last?.row == 1)
+    }
+}

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -142,7 +142,9 @@ Current product split:
   tab beside the session that printed it, splits into its own window and
   merges back like any tab with the live page riding along, the sheet's
   REACH row says which network the address lives on and rewrites a remote
-  `localhost` to the host's own dialled address in the open, and viewport
+  `localhost` to the host's own dialled address in the open, the rail's
+  address is tap-to-edit (typed addresses ride the same web-only gate and
+  loopback rewrite), and viewport
   tabs never persist across launches, a
   most-used tmux
   shortcut dropdown on both platforms (including touch-native copy-mode

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -137,7 +137,13 @@ Current product split:
   on iPad) and drag-and-drop through the same SSH upload path, opening web and
   mail links found in terminal output (long press, or tap where the remote is
   not tracking the mouse; the confirmation shows the resolved target and its
-  host, and other schemes are shown for copying rather than followed), a
+  host, and other schemes are shown for copying rather than followed), an
+  inline viewport browser for confirmed web links (⌗): the page docks as a
+  tab beside the session that printed it, splits into its own window and
+  merges back like any tab with the live page riding along, the sheet's
+  REACH row says which network the address lives on and rewrites a remote
+  `localhost` to the host's own dialled address in the open, and viewport
+  tabs never persist across launches, a
   most-used tmux
   shortcut dropdown on both platforms (including touch-native copy-mode
   selection and explicit exit), Home Screen widgets (per-host monitor +

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -72,3 +72,36 @@ Worth checking:
   installed (`mpx unbind --list`) — a passphrase-sealed key is never
   swapped out.
 - Host Settings (editing a host you already have) should show no BIND bar.
+
+VIEWPORT — open a page from the terminal, inside Multiplex
+
+Long-press a URL printed in any pane (tap also works where the remote
+isn't tracking the mouse). The link sheet now shows a REACH row saying
+which network the address lives on, plus a ⌗ VIEWPORT chip. Confirming
+docks the page as a ⌗ tab right beside the session that printed it —
+it moves like any tab: context-menu it to split into its own window
+beside the terminal, MERGE to bring it back, and the live page rides
+along without reloading.
+
+The localhost trick: a pane runs on the host, so http://localhost:5173
+printed there is the HOST's localhost, not your device's. The chip
+becomes ⌗ VIA <HOST> and the sheet shows the rewritten address (the one
+your device already reaches the host by). It works when the dev server
+listens beyond loopback — vite --host, next -H 0.0.0.0.
+
+Worth checking:
+- Print a dev server's Network: URL (LAN address) in a pane, long-press,
+  confirm — the page should render in the ⌗ tab with the address and a
+  LAN tag in the rail below it.
+- The localhost line instead: chip reads ⌗ VIA <your host>, and with the
+  server on --host the page must still load.
+- Split the ⌗ tab to its own window (context menu on the tab cell), put
+  it beside the terminal, save a file, reload — the dev loop with both
+  visible. Merge it back; the page must not reload either way.
+- Quit and relaunch Multiplex: terminals come back, viewport tabs must
+  NOT — a page is summoned, not restored.
+- A page linking to mailto: shows the same confirmation sheet; multiplex://
+  and file: links inside the page must go nowhere.
+- SYSTEM in the rail hands the page to Safari; CLOSE ends the tab. The
+  ⌗ tab cell carries no red dot — only shells wear the tally.
+- iPhone: the viewport stays a docked tab in the shell (no windows there).

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -114,3 +114,9 @@ Worth checking:
   there. Clearing asks first (it wipes cookies/caches/site storage for
   every viewport page), then reloads the page signed out — sign into a
   dev server, clear, and the login must be gone.
+- Vision Pro: URLs in terminal output now glow when you look at them —
+  and a pinch on a glowing link opens the same confirmation sheet a long
+  press does (never the page directly). File paths and plain prose must
+  never glow, links under your gaze in a build log should light within a
+  second of printing, and scrolling/pane-switching over a link must keep
+  working exactly as before.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -105,3 +105,12 @@ Worth checking:
 - SYSTEM in the rail hands the page to Safari; CLOSE ends the tab. The
   ⌗ tab cell carries no red dot — only shells wear the tally.
 - iPhone: the viewport stays a docked tab in the shell (no windows there).
+- Tap the address in the rail: an ADDRESS bar opens at the top (above the
+  keyboard) — type host:port or a full URL and GO. Bare LAN addresses get
+  http://, names get https://, and localhost still means the host (same
+  rewrite). file: or javascript: input must be refused with WEB ADDRESSES
+  ONLY, and the ⌗ tab label should follow wherever you navigate.
+- Long-press the address: COPY ADDRESS and CLEAR BROWSING DATA… live
+  there. Clearing asks first (it wipes cookies/caches/site storage for
+  every viewport page), then reloads the page signed out — sign into a
+  dev server, clear, and the login must be gone.

--- a/project.yml
+++ b/project.yml
@@ -76,6 +76,13 @@ targets:
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         ITSAppUsesNonExemptEncryption: false
+        # The viewport (inline browser) renders dev servers, which are
+        # cleartext http on LAN addresses — blocked by default ATS. This is
+        # Apple's web-content-scoped relaxation: WKWebView loads only; every
+        # other connection the app makes keeps full ATS (SSH rides NIO and
+        # never sees ATS either way).
+        NSAppTransportSecurity:
+          NSAllowsArbitraryLoadsInWebContent: true
         NSCameraUsageDescription: Multiplex uses the camera when you take a photo to send to your remote SSH session, and when you scan the code that binds a machine to the app.
         # Also covers Optic ID on visionOS (there is no separate key).
         NSFaceIDUsageDescription: Multiplex unlocks with Face ID when the optional App Lock setting is turned on.


### PR DESCRIPTION
## What

A URL printed in a terminal pane can now open **inside Multiplex** — as a **⌗ viewport tab** (WKWebView in TALLY chrome) docked beside the session that printed it. From there it moves with the machinery tabs already have: **split it out** to stand beside the terminal (the dev loop with both eyes), **merge it back**, and the live page rides along without reloading. Design decided in the bake-off record (`local-plan/viewport-bakeoff/`, git-ignored): DOCK and OUTBOARD unified into one route kind, **no persistence**.

## How it works

- **Confirmed, never followed — unchanged.** The existing long-press → `TerminalLinkSheet` flow stays the only gate; it grows a REACH row and one chip. Non-web links (mailto/blocked/malformed) keep today's exact behavior.
- **The reach model** (`ViewportReach`, pure + tested): a pane runs on the host, so `localhost` printed there is the *host's* loopback — an address this device cannot dial. The chip becomes **⌗ OPEN VIA \<host\>** and rewrites the authority to `Host.hostname` (by definition the address the device already reaches the host by), shown in the open on the sheet. LAN/internet targets pass through verbatim with their verdict displayed.
- **A citizen of the window system**: `TerminalRoute.Mode.viewport` rides tabs/merge/split/scene values untouched. The WKWebView is owned by `ViewportController` in `TerminalWorkspace` and **re-parents across windows** exactly like SwiftTerm views — scroll position and HMR sockets survive every move. The ⌗ cell never wears a tally dot (a page is not a shell).
- **Summoned, not restored**: controllers are registered *before* a tab enters any route and live only in process memory; `syncTabs` strips any viewport tab without one — which is precisely a tab handed back by scene restoration from a dead process. Relaunch restores terminals, never pages.
- **Security**: `WKNavigationDelegate` re-applies the scheme allowlist per navigation (`multiplex:` is never navigable; mailto re-presents the confirmation sheet from the pane), no script bridge, no send path into any terminal, and a viewport never claims `TerminalFocusArbiter` — activating a ⌗ tab releases the terminal's responder so hardware keys can't type into a hidden shell. ATS relaxed for **web content only** (`NSAllowsArbitraryLoadsInWebContent`) — dev servers are cleartext http on LAN addresses; app networking keeps full ATS.
- **Chrome**: the rail under the page (mono URL readout host-emphasized, REACH tag, back, reload↔stop with a caution progress hairline, SYSTEM handoff, CLOSE) plus a viewport face for the window chrome (`ViewportUMD`: DECK · ⌗ label · MERGE · CLOSE) on visionOS ornament, iPad toolbar, and iPhone shell. Load failures get a chassis **NO ROUTE** panel naming which network the address lives on, not WebKit's blank page.
- Free plumbing, not an agent-helper surface.

## Verification

- `./Tools/build.sh build vos` ✓ · `build ipad` ✓ · `test vos` → **559 tests, 0 failures** (15 new in `ViewportReachTests`: classification incl. 172.16/12 boundaries, loopback spellings, rewrite semantics, route/Codable).
- End-to-end on the visionOS simulator against the harness, using the new DEBUG hook (`….debug.link` → `….debug.viewportopen`):
  - `http://localhost:8471/` printed in a devbox pane → sheet reads *LIVES ON DEVBOX, NOT THIS DEVICE* with `REMOTE LOOPBACK → REWRITES TO 127.0.0.1:8471` and the **⌗ VIA DEVBOX** chip → docked `⌗ 8471` tab renders a page served on the Mac, rail showing the rewritten address + VIA DEVBOX tag.
  - LAN variant (`http://10.187.1.225:8471/`) → LAN classification, page loads through the ATS web-content exception (cleartext LAN http is the feature's primary case).
  - Relaunch → the restored window keeps its terminal tab and **drops the viewport** (no-persist observed live).
  - Standard `verify vos` attach flow unaffected (screenshot checked).
- Not exercised headlessly (no sim tap injection): split/merge of a ⌗ tab specifically — it rides the identical `removeTab`/`openWindow`/`merge` paths terminal tabs use daily; worth one manual pass on device.

## Notes for review

- `TerminalWindowRoot.body` was split into `body` + `lifecycleBody` — the added modifiers tipped the documented type-checker ceiling; no behavior change.
- `docs/store-metadata.md` free-tier inventory and `fastlane/testflight-whats-new.txt` (tester script) updated per repo convention; AGENTS.md carries the architecture line, the debug hook, and the load-bearing-decisions entry.
- Recorded follow-ups (bake-off): SSH direct-tcpip tunnel for true loopback-only servers, PRIVATE (ephemeral) mode, FOLLOW latch, passive dev-server chip.