### PR TITLE
View a pane's path in a file viewer — host files and git diffs beside the terminal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -850,6 +850,10 @@ views.
   Honesty rules: NUL-sniff says BINARY (never garbage), >1.5 MB text renders
   its head under TRUNCATED, a deleted file's row opens its diff (there are
   no working-tree bytes), failures name the cause on a chassis panel.
+  A browse summon (+ TAB ▸ File Viewer — `opensBrowsing`, target == nil)
+  starts the compact drawer OPEN: the tree is the subject until a file is
+  chosen, so the first pick is one tap; a pressed path keeps its file as
+  the subject, and a pane re-parented mid-session keeps what's on screen.
   Images aspect-fit the screen with pinch zoom (0.25–8×, double-tap
   toggles fit ↔ 2×, the % readout resets); the tree hides the
   editor-default set everywhere — rows, CHANGED, change dots —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -850,6 +850,12 @@ views.
   Honesty rules: NUL-sniff says BINARY (never garbage), >1.5 MB text renders
   its head under TRUNCATED, a deleted file's row opens its diff (there are
   no working-tree bytes), failures name the cause on a chassis panel.
+  Images aspect-fit the screen with pinch zoom (0.25–8×, double-tap
+  toggles fit ↔ 2×, the % readout resets); the tree hides the
+  editor-default set everywhere — rows, CHANGED, change dots —
+  (`FileTree.hiddenNames`: .git/.svn/.hg/CVS/.DS_Store/Thumbs.db,
+  deliberately NOT all dotfiles: .gitignore stays a file people open;
+  content is untouched, a pressed path into .git still opens).
   Markdown links confirm through the link sheet; relative ones navigate
   inside the viewer; images render as captioned placeholders (fetching is
   its own decision). Shared auxiliary-pane rules with the viewport: no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,11 @@ SwiftUI: classic Deck window + N Terminal windows, or one adaptive Shell
                      kept in memory only — its absence after a relaunch IS
                      the viewport's no-persistence rule (syncTabs strips
                      controller-less viewport tabs)
+    FileViewerController  one per ▤ file-viewer tab (host files + git
+                     diffs): dials its OWN SSHConnection lazily (SFTP for
+                     bytes/listings, exec for git), owns tree/git/document
+                     state; same in-memory-only lifecycle as the viewport
+                     (the two share the isAuxiliaryPane rules)
   TerminalSessionController   one per tab; owns the input pump + TerminalView
     TerminalTransport    the tab's byte pipe (write/resize/close); picked by
                          host.useMosh. exec + SFTP stay SSH-only capabilities
@@ -806,6 +811,53 @@ views.
   networking keeps full ATS). Load failures render a chassis NO ROUTE panel
   naming which network the address lives on, not WebKit's blank page. Free
   plumbing, not an agent-helper surface.
+- **The file viewer is the viewport's sibling for paths — and path presses
+  now confirm instead of falling to selection**
+  (`TerminalRoute.Mode.fileViewer`; pure models under `Models/FileViewer/`;
+  `FileViewerController`, `FileViewerPane`; bake-off + stack research in
+  `local-plan/file-viewer-bakeoff/` and `local-plan/file-viewer.md`). Two
+  summon doors: + TAB ▸ File Viewer roots at the pane's cwd (the same
+  `list-panes` truth drops use; $HOME when no pane answers), and a
+  long-pressed filesystem path — `TerminalPathTarget` classifies what the
+  fork's ghostty matcher hands over (`/x`, `~/x`, `./x`, `src/foo.ts`,
+  `:12[:col]` suffixes ride along as a scroll target) — raises
+  `TerminalFilePathSheet`, whose ▤ VIEW docks the tab. **This changed a
+  load-bearing behavior**: path-shaped presses used to fall through to text
+  selection; now only what BOTH resolvers decline ($VAR/…, colon prose,
+  interior whitespace) still does. visionOS gaze regions stay URL-only on
+  purpose (hover regions are hit regions; build logs are walls of paths).
+  Load-bearing details: **the viewer dials its own SSHConnection** — never
+  the probe's (a disabled host must not be revived by a tab) and never the
+  summoning tab's transport (merge/split moves the viewer away) — redialed
+  once per op when a reused socket died in suspension, which is the whole
+  resume story (request/response needs no policy); works for mosh hosts
+  (SSH stays the control plane). **SFTP for listings/bytes** (structural —
+  never parse `ls`; one SFTP READ is server-capped so reads loop chunks),
+  **exec for git** with the TmuxProbe discipline plus one more rule:
+  Citadel's `executeCommand` THROWS on nonzero exit, so every git command
+  tails `printf '\nMPXFV_EXIT:%s' "$?"` (`GitCommands.splitExit`) — "not a
+  repo" ≠ "empty diff", and `--no-index` (untracked files rendered as
+  all-adds) exits 1 routinely. `-c core.quotepath=false` keeps non-ASCII
+  paths raw; `--no-ext-diff` keeps host diff tools from running under app
+  reads. **Rendering is zero-dependency on purpose** (2026 survey in the
+  local-plan doc: no maintained pure-Swift multi-language highlighter
+  exists, and every alternative vendors MBs of C or JS): `CodeHighlighter`
+  is a line-oriented table-driven scanner whose carry state survives line
+  breaks (what lets rows render lazily and diff rows highlight per-side),
+  `MarkdownDocument` a GFM subset, `GitDiff`/`GitFileStatus` pure parsers —
+  all fixture-tested; the recorded graduation path is the tree-sitter
+  stack, and the seam is exactly `CodeHighlighter.highlight(_:language:)`.
+  Honesty rules: NUL-sniff says BINARY (never garbage), >1.5 MB text renders
+  its head under TRUNCATED, a deleted file's row opens its diff (there are
+  no working-tree bytes), failures name the cause on a chassis panel.
+  Markdown links confirm through the link sheet; relative ones navigate
+  inside the viewer; images render as captioned placeholders (fetching is
+  its own decision). Shared auxiliary-pane rules with the viewport: no
+  tally dot, no `TerminalFocusArbiter` claim, `syncTabs` strips
+  controller-less tabs (summoned, never restored), and **`syncTabs` must
+  never mint a `TerminalSessionController` for an auxiliary route** — a
+  file-viewer route has no PTY to dial. Free host plumbing, not an
+  agent-helper surface.
 - **A bound host is one the machine itself vouched for; the app's key goes
   out, never a private key** (`Multiplex/Models/Bind/`,
   `Multiplex/Services/Bind/`; protocol + shared vectors live in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -832,7 +832,9 @@ views.
   once per op when a reused socket died in suspension, which is the whole
   resume story (request/response needs no policy); works for mosh hosts
   (SSH stays the control plane). **SFTP for listings/bytes** (structural —
-  never parse `ls`; one SFTP READ is server-capped so reads loop chunks),
+  never parse `ls`; one SFTP READ is server-capped AND costs a round trip,
+  so reads fill fixed chunks concurrently — sequential chunk walks cost
+  seconds per megabyte at real RTT),
   **exec for git** with the TmuxProbe discipline plus one more rule:
   Citadel's `executeCommand` THROWS on nonzero exit, so every git command
   tails `printf '\nMPXFV_EXIT:%s' "$?"` (`GitCommands.splitExit`) — "not a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -856,6 +856,22 @@ views.
   (`FileTree.hiddenNames`: .git/.svn/.hg/CVS/.DS_Store/Thumbs.db,
   deliberately NOT all dotfiles: .gitignore stays a file people open;
   content is untouched, a pressed path into .git still opens).
+  **The viewer watches by polling, the deck's way** (never a remote
+  inotify/fswatch process — nothing long-running is assumed onto the
+  host): while its tab is the window's ACTIVE tab and
+  `applicationState == .active`, a 5 s tick runs ONE combined git exec
+  (`GitCommands.watchProbe`: branch + porcelain -z + shortstat behind
+  sentinels, parsed by `parseWatchProbe`) plus one SFTP stat
+  (size+mtime) on the path on screen; expanded listings sweep every
+  third tick and on any git change. Everything lands as a QUIET swap —
+  no .loading, no scroll reset (row ids are indices, so the offset
+  survives a content swap) — and a `contentGeneration` counter drops
+  any watch result that finishes after the person navigated. Known
+  blind spot, on record: a net-zero-delta edit under an unchanged
+  porcelain line escapes the repo-wide diff until REFRESH (the
+  per-file stamp catches it everywhere a single file is on screen);
+  a watched document the server says is gone flips to an honest FILE
+  GONE panel, while transport blips change nothing.
   Markdown links confirm through the link sheet; relative ones navigate
   inside the viewer; images render as captioned placeholders (fetching is
   its own decision). Shared auxiliary-pane rules with the viewport: no

--- a/Multiplex/Design/Chassis.swift
+++ b/Multiplex/Design/Chassis.swift
@@ -409,6 +409,31 @@ struct TallyLamp: View {
     }
 }
 
+/// The chassis verdict card: content on a bezel panel, optionally led by a
+/// captioned tally lamp — NO ROUTE, BINARY, FILE GONE, "host removed". One
+/// spelling so every pane's verdict surface stays aligned; callers add
+/// their own outer padding/frame.
+struct ChassisPanel<Content: View>: View {
+    var caption: String? = nil
+    var color = Theme.caution
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(spacing: 14) {
+            if let caption {
+                TallyLamp(caption: caption, color: color)
+            }
+            content
+        }
+        .padding(30)
+        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Theme.bezelHi, lineWidth: 1)
+        )
+    }
+}
+
 extension View {
     /// Square-cornered gaze-hover highlight. The default visionOS platter is
     /// heavily rounded and fights the chassis geometry; buttonBorderShape

--- a/Multiplex/Models/FileViewer/CodeHighlighter.swift
+++ b/Multiplex/Models/FileViewer/CodeHighlighter.swift
@@ -1,0 +1,889 @@
+import Foundation
+
+/// Token classes the viewer's screens color. Deliberately few: this is a
+/// *viewer's* highlighter — enough structure to read a file comfortably,
+/// mapped onto the terminal theme's own palette so the screen matches the
+/// terminal beside it. (2026 survey: there is no maintained pure-Swift
+/// multi-language highlighter, and every alternative — tree-sitter grammars,
+/// highlight.js in JSC, Shiki in a web view — means vendoring megabytes of
+/// C or JS. This in-repo scanner is the clean-room answer, same instinct as
+/// the mosh stack; the tree-sitter route stays on record in
+/// local-plan/file-viewer.md as the upgrade path if quality ever outranks
+/// the supply-chain cost.)
+enum CodeTokenKind: Equatable {
+    case plain
+    case keyword
+    /// Builtin/lowercase type names and — where the language capitalizes
+    /// types — capitalized identifiers.
+    case type
+    case string
+    case comment
+    case number
+    /// An identifier a call site follows: `name(`.
+    case function
+    /// Keys and members: JSON/YAML keys, shell `$VARS`, markup attributes.
+    case property
+    /// Attributes, decorators, preprocessor, sections: `@Observable`,
+    /// `#if`, `[dependencies]`, `<!DOCTYPE`.
+    case meta
+}
+
+/// One rendered line: contiguous segments, in order, covering the line.
+struct HighlightedLine: Equatable {
+    struct Segment: Equatable {
+        var text: String
+        var kind: CodeTokenKind
+    }
+
+    var segments: [Segment]
+
+    var text: String { segments.map(\.text).joined() }
+}
+
+/// Line-oriented scanner with a carry state, so block comments, triple
+/// quotes, and template literals survive line breaks while every line still
+/// highlights independently — which is what lets views render lazily and
+/// diffs highlight per-row. Pure and synchronous; callers own threading.
+enum CodeHighlighter {
+    /// What a line break can carry into the next line.
+    enum LineState: Equatable {
+        case normal
+        /// Inside a block comment; `depth` only moves when the language
+        /// nests them (Swift, Rust).
+        case blockComment(open: String, close: String, depth: Int, nests: Bool)
+        /// Inside a multi-line string: Python/Swift triple quotes, JS
+        /// template literals, markup `<!--` handled as comment above.
+        case multilineString(delimiter: String, escapes: Bool)
+    }
+
+    struct Rules {
+        var keywords: Set<String> = []
+        /// Lowercase builtin types (`int`, `usize`, `string`); capitalized
+        /// identifiers classify as types separately when
+        /// `capitalizedTypes` is on.
+        var builtinTypes: Set<String> = []
+        var lineCommentPrefixes: [String] = []
+        /// `#` starts a comment only at line start or after whitespace —
+        /// keeps `foo#bar` and shell parameter forms intact.
+        var hashCommentNeedsBoundary = true
+        var blockComment: (open: String, close: String)? = nil
+        var nestedBlockComments = false
+        /// Plain quote characters with backslash escapes; unterminated ones
+        /// end at the line break (single-line strings don't carry).
+        var quotes: [Character] = ["\""]
+        /// Multi-line string openers, longest first (`"""` before `"`).
+        var multilineQuotes: [String] = []
+        /// Template-literal style: carries across lines with escapes.
+        var backtickTemplate = false
+        var capitalizedTypes = false
+        /// `@word` / `#word` attribute-style meta.
+        var atMeta = false
+        var hashMetaAtLineStart = false
+        /// `$name` / `${…}` / `$(…)` as property (shell, makefile).
+        var dollarVariables = false
+        /// `key:` at the start of a member position → property (JSON/YAML).
+        var propertyBeforeColon = false
+        /// `[section]` alone on a line → meta (TOML/INI).
+        var sectionHeaders = false
+        var caseInsensitiveKeywords = false
+        /// Markup mode replaces the identifier scanner: tags, attributes,
+        /// entities (XML/HTML).
+        var markup = false
+    }
+
+    /// Highlight a whole text. `language: nil` is the plain-text fast path.
+    static func highlight(_ text: String, language: CodeLanguage?) -> [HighlightedLine] {
+        var pieces = text.split(separator: "\n", omittingEmptySubsequences: false)
+        if pieces.last == "" { pieces.removeLast() }
+        guard let language, let rules = rules(for: language) else {
+            return pieces.map {
+                HighlightedLine(segments: [.init(text: String($0), kind: .plain)])
+            }
+        }
+        var state = LineState.normal
+        return pieces.map { highlightLine(String($0), state: &state, rules: rules) }
+    }
+
+    /// One line, one entry state, one exit state — the diff renderer calls
+    /// this directly so each side of a hunk can carry its own state.
+    static func highlightLine(
+        _ line: String,
+        state: inout LineState,
+        rules: Rules
+    ) -> HighlightedLine {
+        var segments: [HighlightedLine.Segment] = []
+        let characters = Array(line)
+        var index = 0
+
+        func emit(_ text: String, _ kind: CodeTokenKind) {
+            guard !text.isEmpty else { return }
+            if let last = segments.last, last.kind == kind {
+                segments[segments.count - 1].text += text
+            } else {
+                segments.append(.init(text: text, kind: kind))
+            }
+        }
+
+        func remainder(from start: Int) -> String {
+            String(characters[start...])
+        }
+
+        func matches(_ needle: String, at position: Int) -> Bool {
+            let needleChars = Array(needle)
+            guard position + needleChars.count <= characters.count else { return false }
+            for (offset, character) in needleChars.enumerated()
+            where characters[position + offset] != character {
+                return false
+            }
+            return true
+        }
+
+        // Resume a carried state.
+        carried: while index < characters.count {
+            switch state {
+            case .normal:
+                break carried
+            case .blockComment(let open, let close, let depth, let nests):
+                var cursor = index
+                var level = depth
+                while cursor < characters.count {
+                    if nests, matches(open, at: cursor) {
+                        level += 1
+                        cursor += open.count
+                        continue
+                    }
+                    if matches(close, at: cursor) {
+                        level -= 1
+                        cursor += close.count
+                        if level == 0 { break }
+                        continue
+                    }
+                    cursor += 1
+                }
+                emit(String(characters[index..<min(cursor, characters.count)]), .comment)
+                index = cursor
+                if level == 0 {
+                    state = .normal
+                } else {
+                    state = .blockComment(open: open, close: close, depth: level, nests: nests)
+                    return HighlightedLine(segments: segments)
+                }
+            case .multilineString(let delimiter, let escapes):
+                var cursor = index
+                var closed = false
+                while cursor < characters.count {
+                    if escapes, characters[cursor] == "\\", cursor + 1 < characters.count {
+                        cursor += 2
+                        continue
+                    }
+                    if matches(delimiter, at: cursor) {
+                        cursor += delimiter.count
+                        closed = true
+                        break
+                    }
+                    cursor += 1
+                }
+                emit(String(characters[index..<min(cursor, characters.count)]), .string)
+                index = cursor
+                if closed {
+                    state = .normal
+                } else {
+                    return HighlightedLine(segments: segments)
+                }
+            }
+        }
+
+        if rules.markup {
+            scanMarkup(characters, from: &index, emit: emit, matches: matches, state: &state, rules: rules)
+            return HighlightedLine(segments: segments.isEmpty && line.isEmpty
+                ? [.init(text: "", kind: .plain)]
+                : segments)
+        }
+
+        // TOML/INI section header: the whole (trimmed) line is [section].
+        if rules.sectionHeaders {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("["), trimmed.hasSuffix("]"), trimmed.count > 2 {
+                emit(line, .meta)
+                return HighlightedLine(segments: segments)
+            }
+        }
+
+        var lineStart = true
+        while index < characters.count {
+            let character = characters[index]
+
+            // Whitespace passes through and preserves "line start" until
+            // real content shows up.
+            if character == " " || character == "\t" {
+                var end = index
+                while end < characters.count,
+                      characters[end] == " " || characters[end] == "\t" { end += 1 }
+                emit(String(characters[index..<end]), .plain)
+                index = end
+                continue
+            }
+
+            // Line comments.
+            var commented = false
+            for prefix in rules.lineCommentPrefixes where matches(prefix, at: index) {
+                if prefix == "#", rules.hashCommentNeedsBoundary,
+                   !lineStart, index > 0,
+                   characters[index - 1] != " ", characters[index - 1] != "\t" {
+                    continue
+                }
+                emit(remainder(from: index), .comment)
+                index = characters.count
+                commented = true
+                break
+            }
+            if commented { break }
+
+            // Block comment open.
+            if let block = rules.blockComment, matches(block.open, at: index) {
+                state = .blockComment(
+                    open: block.open, close: block.close,
+                    depth: 1, nests: rules.nestedBlockComments
+                )
+                var cursor = index + block.open.count
+                var level = 1
+                while cursor < characters.count {
+                    if rules.nestedBlockComments, matches(block.open, at: cursor) {
+                        level += 1
+                        cursor += block.open.count
+                        continue
+                    }
+                    if matches(block.close, at: cursor) {
+                        level -= 1
+                        cursor += block.close.count
+                        if level == 0 { break }
+                        continue
+                    }
+                    cursor += 1
+                }
+                emit(String(characters[index..<min(cursor, characters.count)]), .comment)
+                index = cursor
+                if level == 0 {
+                    state = .normal
+                } else {
+                    state = .blockComment(
+                        open: block.open, close: block.close,
+                        depth: level, nests: rules.nestedBlockComments
+                    )
+                    return HighlightedLine(segments: segments)
+                }
+                lineStart = false
+                continue
+            }
+
+            // Multi-line quotes (longest first by construction of the rule).
+            var openedMultiline = false
+            for delimiter in rules.multilineQuotes where matches(delimiter, at: index) {
+                var cursor = index + delimiter.count
+                var closed = false
+                while cursor < characters.count {
+                    if characters[cursor] == "\\", cursor + 1 < characters.count {
+                        cursor += 2
+                        continue
+                    }
+                    if matches(delimiter, at: cursor) {
+                        cursor += delimiter.count
+                        closed = true
+                        break
+                    }
+                    cursor += 1
+                }
+                emit(String(characters[index..<min(cursor, characters.count)]), .string)
+                index = cursor
+                if !closed {
+                    state = .multilineString(delimiter: delimiter, escapes: true)
+                    return HighlightedLine(segments: segments)
+                }
+                openedMultiline = true
+                break
+            }
+            if openedMultiline { lineStart = false; continue }
+
+            // Template literal.
+            if rules.backtickTemplate, character == "`" {
+                var cursor = index + 1
+                var closed = false
+                while cursor < characters.count {
+                    if characters[cursor] == "\\", cursor + 1 < characters.count {
+                        cursor += 2
+                        continue
+                    }
+                    if characters[cursor] == "`" {
+                        cursor += 1
+                        closed = true
+                        break
+                    }
+                    cursor += 1
+                }
+                emit(String(characters[index..<min(cursor, characters.count)]), .string)
+                index = cursor
+                if !closed {
+                    state = .multilineString(delimiter: "`", escapes: true)
+                    return HighlightedLine(segments: segments)
+                }
+                lineStart = false
+                continue
+            }
+
+            // Single-line strings. Unterminated → string to end of line,
+            // no carry: most languages' plain strings cannot span lines,
+            // and carrying one would paint the rest of the file green.
+            if rules.quotes.contains(character) {
+                var cursor = index + 1
+                while cursor < characters.count {
+                    if characters[cursor] == "\\", cursor + 1 < characters.count {
+                        cursor += 2
+                        continue
+                    }
+                    if characters[cursor] == character {
+                        cursor += 1
+                        break
+                    }
+                    cursor += 1
+                }
+                emit(String(characters[index..<min(cursor, characters.count)]), .string)
+                index = cursor
+                lineStart = false
+                continue
+            }
+
+            // $variables (shell, makefile).
+            if rules.dollarVariables, character == "$" {
+                var cursor = index + 1
+                if cursor < characters.count,
+                   characters[cursor] == "{" || characters[cursor] == "(" {
+                    let close: Character = characters[cursor] == "{" ? "}" : ")"
+                    cursor += 1
+                    while cursor < characters.count, characters[cursor] != close {
+                        cursor += 1
+                    }
+                    if cursor < characters.count { cursor += 1 }
+                } else {
+                    while cursor < characters.count, isIdentifier(characters[cursor]) {
+                        cursor += 1
+                    }
+                }
+                emit(String(characters[index..<cursor]), .property)
+                index = cursor
+                lineStart = false
+                continue
+            }
+
+            // @attribute / #directive meta.
+            if (rules.atMeta && character == "@")
+                || (rules.hashMetaAtLineStart && character == "#" && lineStart) {
+                var cursor = index + 1
+                while cursor < characters.count, isIdentifier(characters[cursor]) {
+                    cursor += 1
+                }
+                if cursor > index + 1 {
+                    emit(String(characters[index..<cursor]), .meta)
+                    index = cursor
+                    lineStart = false
+                    continue
+                }
+            }
+
+            // Numbers.
+            if character.isNumber
+                || (character == "." && index + 1 < characters.count
+                    && characters[index + 1].isNumber) {
+                var cursor = index + 1
+                while cursor < characters.count, isNumberBody(characters[cursor]) {
+                    cursor += 1
+                }
+                emit(String(characters[index..<cursor]), .number)
+                index = cursor
+                lineStart = false
+                continue
+            }
+
+            // Identifiers.
+            if isIdentifierStart(character) {
+                var cursor = index + 1
+                while cursor < characters.count, isIdentifier(characters[cursor]) {
+                    cursor += 1
+                }
+                let word = String(characters[index..<cursor])
+                let lookup = rules.caseInsensitiveKeywords ? word.lowercased() : word
+                var kind = CodeTokenKind.plain
+                if rules.keywords.contains(lookup) {
+                    kind = .keyword
+                } else if rules.builtinTypes.contains(lookup) {
+                    kind = .type
+                } else if rules.propertyBeforeColon,
+                          nextContentCharacter(characters, from: cursor) == ":" {
+                    kind = .property
+                } else if rules.capitalizedTypes, word.first?.isUppercase == true {
+                    kind = .type
+                } else if nextContentCharacter(characters, from: cursor) == "(" {
+                    kind = .function
+                }
+                emit(word, kind)
+                index = cursor
+                lineStart = false
+                continue
+            }
+
+            // JSON/YAML string keys: a closed string we just emitted
+            // followed by ":" is handled by propertyBeforeColon at emit
+            // time only for bare words; quoted keys keep string color —
+            // acceptable, the colon still separates.
+
+            emit(String(character), .plain)
+            index += 1
+            lineStart = false
+        }
+
+        if segments.isEmpty {
+            segments = [.init(text: line, kind: .plain)]
+        }
+        return HighlightedLine(segments: segments)
+    }
+
+    // MARK: Markup scanning (XML/HTML)
+
+    private static func scanMarkup(
+        _ characters: [Character],
+        from index: inout Int,
+        emit: (String, CodeTokenKind) -> Void,
+        matches: (String, Int) -> Bool,
+        state: inout LineState,
+        rules: Rules
+    ) {
+        while index < characters.count {
+            if matches("<!--", index) {
+                var cursor = index + 4
+                var closed = false
+                while cursor < characters.count {
+                    if matches("-->", cursor) {
+                        cursor += 3
+                        closed = true
+                        break
+                    }
+                    cursor += 1
+                }
+                emit(String(characters[index..<min(cursor, characters.count)]), .comment)
+                index = cursor
+                if !closed {
+                    state = .blockComment(open: "<!--", close: "-->", depth: 1, nests: false)
+                    return
+                }
+                continue
+            }
+            if characters[index] == "<" {
+                // <tag, </tag, <!DOCTYPE, <?xml
+                var cursor = index + 1
+                if cursor < characters.count,
+                   characters[cursor] == "/" || characters[cursor] == "!" || characters[cursor] == "?" {
+                    cursor += 1
+                }
+                var nameEnd = cursor
+                while nameEnd < characters.count,
+                      isIdentifier(characters[nameEnd]) || characters[nameEnd] == "-" {
+                    nameEnd += 1
+                }
+                emit(String(characters[index..<nameEnd]), .keyword)
+                index = nameEnd
+                // Attributes until '>'.
+                while index < characters.count, characters[index] != ">" {
+                    let character = characters[index]
+                    if character == "\"" || character == "'" {
+                        var end = index + 1
+                        while end < characters.count, characters[end] != character {
+                            end += 1
+                        }
+                        if end < characters.count { end += 1 }
+                        emit(String(characters[index..<end]), .string)
+                        index = end
+                        continue
+                    }
+                    if isIdentifierStart(character) {
+                        var end = index + 1
+                        while end < characters.count,
+                              isIdentifier(characters[end]) || characters[end] == "-" {
+                            end += 1
+                        }
+                        emit(String(characters[index..<end]), .property)
+                        index = end
+                        continue
+                    }
+                    emit(String(character), .plain)
+                    index += 1
+                }
+                if index < characters.count {
+                    emit(">", .keyword)
+                    index += 1
+                }
+                continue
+            }
+            var end = index
+            while end < characters.count, characters[end] != "<" { end += 1 }
+            emit(String(characters[index..<end]), .plain)
+            index = end
+        }
+    }
+
+    // MARK: Character classes
+
+    private static func isIdentifierStart(_ character: Character) -> Bool {
+        character.isLetter || character == "_" || character == "$"
+    }
+
+    private static func isIdentifier(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "_" || character == "$"
+    }
+
+    private static func isNumberBody(_ character: Character) -> Bool {
+        character.isHexDigit || character == "_" || character == "."
+            || character == "x" || character == "X" || character == "o" || character == "O"
+            || character == "b" || character == "B" || character == "e" || character == "E"
+            || character == "p" || character == "P" || character == "+" || character == "-"
+            || character == "u" || character == "U" || character == "l" || character == "L"
+            || character == "f" || character == "F" || character == "i"
+    }
+
+    private static func nextContentCharacter(
+        _ characters: [Character],
+        from index: Int
+    ) -> Character? {
+        var cursor = index
+        while cursor < characters.count {
+            let character = characters[cursor]
+            if character != " " && character != "\t" { return character }
+            cursor += 1
+        }
+        return nil
+    }
+
+    // MARK: Rule tables
+
+    /// nil = render plain (markdown raw mode uses its own renderer; CONF
+    /// falls through to the INI profile).
+    static func rules(for language: CodeLanguage) -> Rules? {
+        switch language {
+        case .swift:
+            var rules = cFamily(keywords: [
+                "func", "let", "var", "if", "else", "guard", "return", "switch", "case",
+                "default", "for", "while", "repeat", "break", "continue", "struct",
+                "class", "enum", "protocol", "extension", "import", "init", "deinit",
+                "self", "Self", "super", "nil", "true", "false", "throws", "rethrows",
+                "throw", "do", "try", "catch", "as", "is", "in", "where", "defer",
+                "static", "final", "private", "fileprivate", "internal", "public",
+                "open", "mutating", "nonmutating", "override", "required",
+                "convenience", "lazy", "weak", "unowned", "indirect", "associatedtype",
+                "typealias", "subscript", "operator", "inout", "some", "any", "await",
+                "async", "actor", "nonisolated", "isolated", "consuming", "borrowing",
+                "package", "willSet", "didSet", "get", "set",
+            ])
+            rules.nestedBlockComments = true
+            rules.multilineQuotes = ["\"\"\""]
+            rules.atMeta = true
+            rules.hashMetaAtLineStart = true
+            return rules
+        case .typescript, .javascript:
+            var rules = cFamily(keywords: [
+                "const", "let", "var", "function", "return", "if", "else", "for",
+                "while", "do", "switch", "case", "default", "break", "continue", "new",
+                "delete", "typeof", "instanceof", "in", "of", "class", "extends",
+                "implements", "interface", "type", "enum", "namespace", "import",
+                "export", "from", "as", "async", "await", "yield", "this", "super",
+                "null", "undefined", "true", "false", "try", "catch", "finally",
+                "throw", "void", "public", "private", "protected", "readonly",
+                "static", "get", "set", "declare", "abstract", "satisfies", "keyof",
+                "infer", "is", "asserts", "never", "require", "module",
+            ])
+            rules.builtinTypes = [
+                "string", "number", "boolean", "any", "unknown", "object", "symbol",
+                "bigint",
+            ]
+            rules.quotes = ["\"", "'"]
+            rules.backtickTemplate = true
+            rules.atMeta = true
+            return rules
+        case .rust:
+            var rules = cFamily(keywords: [
+                "fn", "let", "mut", "const", "static", "if", "else", "match", "loop",
+                "while", "for", "in", "break", "continue", "return", "struct", "enum",
+                "trait", "impl", "mod", "pub", "use", "crate", "super", "self", "Self",
+                "where", "as", "dyn", "ref", "move", "async", "await", "unsafe",
+                "extern", "type", "true", "false", "box", "macro_rules",
+            ])
+            rules.builtinTypes = [
+                "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32", "u64",
+                "u128", "usize", "f32", "f64", "bool", "char", "str",
+            ]
+            rules.nestedBlockComments = true
+            rules.hashMetaAtLineStart = true
+            return rules
+        case .python:
+            var rules = Rules()
+            rules.keywords = [
+                "def", "class", "return", "if", "elif", "else", "for", "while",
+                "break", "continue", "pass", "import", "from", "as", "with", "try",
+                "except", "finally", "raise", "lambda", "global", "nonlocal", "yield",
+                "assert", "del", "in", "is", "not", "and", "or", "None", "True",
+                "False", "async", "await", "match", "case", "self",
+            ]
+            rules.lineCommentPrefixes = ["#"]
+            rules.hashCommentNeedsBoundary = false
+            rules.quotes = ["\"", "'"]
+            rules.multilineQuotes = ["\"\"\"", "'''"]
+            rules.capitalizedTypes = true
+            rules.atMeta = true
+            return rules
+        case .go:
+            var rules = cFamily(keywords: [
+                "func", "package", "import", "var", "const", "type", "struct",
+                "interface", "map", "chan", "if", "else", "for", "range", "switch",
+                "case", "default", "break", "continue", "return", "go", "defer",
+                "select", "fallthrough", "goto", "nil", "true", "false", "iota",
+            ])
+            rules.builtinTypes = [
+                "string", "int", "int8", "int16", "int32", "int64", "uint", "uint8",
+                "uint16", "uint32", "uint64", "uintptr", "byte", "rune", "float32",
+                "float64", "complex64", "complex128", "bool", "error",
+            ]
+            rules.quotes = ["\"", "'"]
+            rules.backtickTemplate = true
+            return rules
+        case .c, .cpp, .objectiveC:
+            var rules = cFamily(keywords: [
+                "if", "else", "for", "while", "do", "switch", "case", "default",
+                "break", "continue", "return", "goto", "struct", "union", "enum",
+                "typedef", "sizeof", "static", "extern", "const", "volatile",
+                "register", "inline", "restrict", "auto",
+                // C++
+                "class", "namespace", "template", "typename", "public", "private",
+                "protected", "virtual", "override", "final", "new", "delete", "this",
+                "nullptr", "true", "false", "try", "catch", "throw", "using",
+                "constexpr", "consteval", "constinit", "decltype", "operator",
+                "friend", "mutable", "explicit", "noexcept", "co_await", "co_return",
+                // Obj-C
+                "id", "nil", "YES", "NO", "self", "super", "instancetype",
+            ])
+            rules.builtinTypes = [
+                "void", "char", "short", "int", "long", "float", "double", "signed",
+                "unsigned", "bool", "size_t", "ssize_t", "wchar_t", "int8_t",
+                "int16_t", "int32_t", "int64_t", "uint8_t", "uint16_t", "uint32_t",
+                "uint64_t", "intptr_t", "uintptr_t", "NSInteger", "NSUInteger",
+                "CGFloat", "BOOL",
+            ]
+            rules.quotes = ["\"", "'"]
+            rules.hashMetaAtLineStart = true
+            rules.atMeta = true
+            return rules
+        case .java, .kotlin, .dart, .csharp:
+            var rules = cFamily(keywords: [
+                "class", "interface", "enum", "extends", "implements", "import",
+                "package", "public", "private", "protected", "static", "final", "void",
+                "new", "return", "if", "else", "for", "while", "do", "switch", "case",
+                "default", "break", "continue", "try", "catch", "finally", "throw",
+                "throws", "this", "super", "null", "true", "false", "abstract",
+                "synchronized", "instanceof",
+                // Kotlin
+                "fun", "val", "var", "when", "object", "companion", "data", "sealed",
+                "suspend", "override", "lateinit", "by", "in", "out", "is", "as",
+                // C#
+                "namespace", "using", "async", "await", "readonly", "struct", "record",
+                "get", "set", "internal", "sealed", "partial",
+                // Dart
+                "late", "required", "factory", "extension", "mixin", "typedef",
+            ])
+            rules.builtinTypes = [
+                "int", "long", "short", "byte", "float", "double", "boolean", "char",
+                "string", "bool", "num", "dynamic",
+            ]
+            rules.quotes = ["\"", "'"]
+            rules.multilineQuotes = ["\"\"\""]
+            rules.capitalizedTypes = true
+            rules.atMeta = true
+            return rules
+        case .ruby:
+            var rules = Rules()
+            rules.keywords = [
+                "def", "end", "class", "module", "if", "elsif", "else", "unless",
+                "while", "until", "for", "in", "do", "case", "when", "then", "break",
+                "next", "redo", "retry", "return", "yield", "begin", "rescue",
+                "ensure", "raise", "require", "require_relative", "include", "extend",
+                "attr_accessor", "attr_reader", "attr_writer", "new", "self", "nil",
+                "true", "false", "and", "or", "not", "lambda", "proc", "puts", "p",
+            ]
+            rules.lineCommentPrefixes = ["#"]
+            rules.hashCommentNeedsBoundary = false
+            rules.quotes = ["\"", "'"]
+            rules.capitalizedTypes = true
+            rules.atMeta = true
+            rules.dollarVariables = true
+            return rules
+        case .php:
+            var rules = cFamily(keywords: [
+                "function", "class", "interface", "trait", "extends", "implements",
+                "namespace", "use", "public", "private", "protected", "static",
+                "const", "return", "if", "else", "elseif", "for", "foreach", "while",
+                "do", "switch", "case", "default", "break", "continue", "try",
+                "catch", "finally", "throw", "new", "echo", "print", "require",
+                "include", "require_once", "include_once", "null", "true", "false",
+                "array", "fn", "match", "readonly", "as",
+            ])
+            rules.lineCommentPrefixes = ["//", "#"]
+            rules.quotes = ["\"", "'"]
+            rules.capitalizedTypes = true
+            rules.dollarVariables = true
+            rules.atMeta = true
+            return rules
+        case .shell:
+            var rules = Rules()
+            rules.keywords = [
+                "if", "then", "elif", "else", "fi", "for", "while", "until", "do",
+                "done", "case", "esac", "in", "function", "select", "time", "local",
+                "export", "readonly", "return", "exit", "break", "continue", "shift",
+                "unset", "eval", "exec", "set", "source", "alias", "trap", "echo",
+                "printf", "read", "cd", "test",
+            ]
+            rules.lineCommentPrefixes = ["#"]
+            rules.quotes = ["\"", "'"]
+            rules.backtickTemplate = true
+            rules.dollarVariables = true
+            return rules
+        case .json:
+            var rules = Rules()
+            rules.keywords = ["true", "false", "null"]
+            rules.lineCommentPrefixes = ["//"]
+            rules.quotes = ["\""]
+            rules.propertyBeforeColon = true
+            return rules
+        case .yaml:
+            var rules = Rules()
+            rules.keywords = ["true", "false", "null", "yes", "no", "on", "off"]
+            rules.caseInsensitiveKeywords = true
+            rules.lineCommentPrefixes = ["#"]
+            rules.quotes = ["\"", "'"]
+            rules.propertyBeforeColon = true
+            rules.dollarVariables = false
+            return rules
+        case .toml, .ini:
+            var rules = Rules()
+            rules.keywords = ["true", "false"]
+            rules.lineCommentPrefixes = ["#", ";"]
+            rules.hashCommentNeedsBoundary = false
+            rules.quotes = ["\"", "'"]
+            rules.multilineQuotes = ["\"\"\""]
+            rules.sectionHeaders = true
+            rules.propertyBeforeColon = false
+            return rules
+        case .xml, .html:
+            var rules = Rules()
+            rules.markup = true
+            return rules
+        case .css:
+            var rules = Rules()
+            rules.keywords = ["important", "inherit", "initial", "unset", "auto", "none"]
+            rules.blockComment = ("/*", "*/")
+            rules.quotes = ["\"", "'"]
+            rules.propertyBeforeColon = true
+            rules.atMeta = true
+            return rules
+        case .sql:
+            var rules = Rules()
+            rules.keywords = [
+                "select", "from", "where", "insert", "into", "values", "update",
+                "set", "delete", "create", "table", "index", "view", "drop", "alter",
+                "add", "join", "left", "right", "inner", "outer", "full", "on", "as",
+                "and", "or", "not", "null", "is", "in", "like", "between", "order",
+                "by", "group", "having", "limit", "offset", "distinct", "union",
+                "all", "exists", "case", "when", "then", "else", "end", "primary",
+                "key", "foreign", "references", "default", "unique", "constraint",
+                "begin", "commit", "rollback", "transaction", "if", "returning",
+            ]
+            rules.caseInsensitiveKeywords = true
+            rules.lineCommentPrefixes = ["--"]
+            rules.blockComment = ("/*", "*/")
+            rules.quotes = ["'", "\""]
+            return rules
+        case .dockerfile:
+            var rules = Rules()
+            rules.keywords = [
+                "from", "run", "cmd", "entrypoint", "copy", "add", "env", "arg",
+                "expose", "volume", "workdir", "user", "label", "onbuild",
+                "healthcheck", "shell", "stopsignal", "maintainer",
+            ]
+            rules.caseInsensitiveKeywords = true
+            rules.lineCommentPrefixes = ["#"]
+            rules.hashCommentNeedsBoundary = false
+            rules.quotes = ["\"", "'"]
+            rules.dollarVariables = true
+            return rules
+        case .makefile:
+            var rules = Rules()
+            rules.keywords = [
+                "ifeq", "ifneq", "ifdef", "ifndef", "endif", "include", "define",
+                "endef", "export", "unexport", "override", ".PHONY",
+            ]
+            rules.lineCommentPrefixes = ["#"]
+            rules.hashCommentNeedsBoundary = false
+            rules.quotes = ["\"", "'"]
+            rules.dollarVariables = true
+            return rules
+        case .lua:
+            var rules = Rules()
+            rules.keywords = [
+                "and", "break", "do", "else", "elseif", "end", "false", "for",
+                "function", "goto", "if", "in", "local", "nil", "not", "or",
+                "repeat", "return", "then", "true", "until", "while", "require",
+            ]
+            rules.lineCommentPrefixes = ["--"]
+            rules.quotes = ["\"", "'"]
+            return rules
+        case .zig:
+            var rules = cFamily(keywords: [
+                "const", "var", "fn", "pub", "return", "if", "else", "while", "for",
+                "switch", "defer", "errdefer", "try", "catch", "orelse", "struct",
+                "enum", "union", "error", "comptime", "inline", "export", "extern",
+                "test", "unreachable", "null", "undefined", "true", "false", "and",
+                "or", "break", "continue", "usingnamespace", "async", "await",
+            ])
+            rules.builtinTypes = [
+                "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "usize",
+                "isize", "f32", "f64", "bool", "void", "anytype", "type",
+            ]
+            rules.atMeta = true
+            return rules
+        case .elixir:
+            var rules = Rules()
+            rules.keywords = [
+                "def", "defp", "defmodule", "defmacro", "defstruct", "do", "end",
+                "if", "else", "unless", "case", "cond", "with", "for", "when", "fn",
+                "receive", "after", "raise", "rescue", "try", "catch", "import",
+                "alias", "require", "use", "quote", "unquote", "nil", "true",
+                "false", "and", "or", "not", "in",
+            ]
+            rules.lineCommentPrefixes = ["#"]
+            rules.hashCommentNeedsBoundary = false
+            rules.quotes = ["\"", "'"]
+            rules.multilineQuotes = ["\"\"\""]
+            rules.capitalizedTypes = true
+            rules.atMeta = true
+            return rules
+        case .markdown:
+            // Raw markdown gets the rendered surface instead; RAW mode
+            // shows plain text.
+            return nil
+        }
+    }
+
+    private static func cFamily(keywords: Set<String>) -> Rules {
+        var rules = Rules()
+        rules.keywords = keywords
+        rules.lineCommentPrefixes = ["//"]
+        rules.blockComment = ("/*", "*/")
+        rules.quotes = ["\""]
+        rules.capitalizedTypes = true
+        return rules
+    }
+}

--- a/Multiplex/Models/FileViewer/CodeHighlighter.swift
+++ b/Multiplex/Models/FileViewer/CodeHighlighter.swift
@@ -53,7 +53,9 @@ enum CodeHighlighter {
         case blockComment(open: String, close: String, depth: Int, nests: Bool)
         /// Inside a multi-line string: Python/Swift triple quotes, JS
         /// template literals, markup `<!--` handled as comment above.
-        case multilineString(delimiter: String, escapes: Bool)
+        /// Backslash escapes always apply — every carrying string form has
+        /// them.
+        case multilineString(delimiter: String)
     }
 
     struct Rules {
@@ -144,48 +146,24 @@ enum CodeHighlighter {
             case .normal:
                 break carried
             case .blockComment(let open, let close, let depth, let nests):
-                var cursor = index
-                var level = depth
-                while cursor < characters.count {
-                    if nests, matches(open, at: cursor) {
-                        level += 1
-                        cursor += open.count
-                        continue
-                    }
-                    if matches(close, at: cursor) {
-                        level -= 1
-                        cursor += close.count
-                        if level == 0 { break }
-                        continue
-                    }
-                    cursor += 1
-                }
-                emit(String(characters[index..<min(cursor, characters.count)]), .comment)
-                index = cursor
-                if level == 0 {
+                let scan = scanBlockComment(
+                    characters, from: index,
+                    open: Array(open), close: Array(close),
+                    depth: depth, nests: nests
+                )
+                emit(String(characters[index..<scan.end]), .comment)
+                index = scan.end
+                if scan.depth == 0 {
                     state = .normal
                 } else {
-                    state = .blockComment(open: open, close: close, depth: level, nests: nests)
+                    state = .blockComment(open: open, close: close, depth: scan.depth, nests: nests)
                     return HighlightedLine(segments: segments)
                 }
-            case .multilineString(let delimiter, let escapes):
-                var cursor = index
-                var closed = false
-                while cursor < characters.count {
-                    if escapes, characters[cursor] == "\\", cursor + 1 < characters.count {
-                        cursor += 2
-                        continue
-                    }
-                    if matches(delimiter, at: cursor) {
-                        cursor += delimiter.count
-                        closed = true
-                        break
-                    }
-                    cursor += 1
-                }
-                emit(String(characters[index..<min(cursor, characters.count)]), .string)
-                index = cursor
-                if closed {
+            case .multilineString(let delimiter):
+                let scan = scanToDelimiter(characters, from: index, delimiter: Array(delimiter))
+                emit(String(characters[index..<scan.end]), .string)
+                index = scan.end
+                if scan.closed {
                     state = .normal
                 } else {
                     return HighlightedLine(segments: segments)
@@ -194,7 +172,7 @@ enum CodeHighlighter {
         }
 
         if rules.markup {
-            scanMarkup(characters, from: &index, emit: emit, matches: matches, state: &state, rules: rules)
+            scanMarkup(characters, from: &index, emit: emit, state: &state)
             return HighlightedLine(segments: segments.isEmpty && line.isEmpty
                 ? [.init(text: "", kind: .plain)]
                 : segments)
@@ -241,34 +219,17 @@ enum CodeHighlighter {
 
             // Block comment open.
             if let block = rules.blockComment, matches(block.open, at: index) {
-                state = .blockComment(
-                    open: block.open, close: block.close,
+                let scan = scanBlockComment(
+                    characters, from: index + block.open.count,
+                    open: Array(block.open), close: Array(block.close),
                     depth: 1, nests: rules.nestedBlockComments
                 )
-                var cursor = index + block.open.count
-                var level = 1
-                while cursor < characters.count {
-                    if rules.nestedBlockComments, matches(block.open, at: cursor) {
-                        level += 1
-                        cursor += block.open.count
-                        continue
-                    }
-                    if matches(block.close, at: cursor) {
-                        level -= 1
-                        cursor += block.close.count
-                        if level == 0 { break }
-                        continue
-                    }
-                    cursor += 1
-                }
-                emit(String(characters[index..<min(cursor, characters.count)]), .comment)
-                index = cursor
-                if level == 0 {
-                    state = .normal
-                } else {
+                emit(String(characters[index..<scan.end]), .comment)
+                index = scan.end
+                if scan.depth > 0 {
                     state = .blockComment(
                         open: block.open, close: block.close,
-                        depth: level, nests: rules.nestedBlockComments
+                        depth: scan.depth, nests: rules.nestedBlockComments
                     )
                     return HighlightedLine(segments: segments)
                 }
@@ -279,24 +240,13 @@ enum CodeHighlighter {
             // Multi-line quotes (longest first by construction of the rule).
             var openedMultiline = false
             for delimiter in rules.multilineQuotes where matches(delimiter, at: index) {
-                var cursor = index + delimiter.count
-                var closed = false
-                while cursor < characters.count {
-                    if characters[cursor] == "\\", cursor + 1 < characters.count {
-                        cursor += 2
-                        continue
-                    }
-                    if matches(delimiter, at: cursor) {
-                        cursor += delimiter.count
-                        closed = true
-                        break
-                    }
-                    cursor += 1
-                }
-                emit(String(characters[index..<min(cursor, characters.count)]), .string)
-                index = cursor
-                if !closed {
-                    state = .multilineString(delimiter: delimiter, escapes: true)
+                let scan = scanToDelimiter(
+                    characters, from: index + delimiter.count, delimiter: Array(delimiter)
+                )
+                emit(String(characters[index..<scan.end]), .string)
+                index = scan.end
+                if !scan.closed {
+                    state = .multilineString(delimiter: delimiter)
                     return HighlightedLine(segments: segments)
                 }
                 openedMultiline = true
@@ -306,24 +256,11 @@ enum CodeHighlighter {
 
             // Template literal.
             if rules.backtickTemplate, character == "`" {
-                var cursor = index + 1
-                var closed = false
-                while cursor < characters.count {
-                    if characters[cursor] == "\\", cursor + 1 < characters.count {
-                        cursor += 2
-                        continue
-                    }
-                    if characters[cursor] == "`" {
-                        cursor += 1
-                        closed = true
-                        break
-                    }
-                    cursor += 1
-                }
-                emit(String(characters[index..<min(cursor, characters.count)]), .string)
-                index = cursor
-                if !closed {
-                    state = .multilineString(delimiter: "`", escapes: true)
+                let scan = scanToDelimiter(characters, from: index + 1, delimiter: ["`"])
+                emit(String(characters[index..<scan.end]), .string)
+                index = scan.end
+                if !scan.closed {
+                    state = .multilineString(delimiter: "`")
                     return HighlightedLine(segments: segments)
                 }
                 lineStart = false
@@ -334,20 +271,9 @@ enum CodeHighlighter {
             // no carry: most languages' plain strings cannot span lines,
             // and carrying one would paint the rest of the file green.
             if rules.quotes.contains(character) {
-                var cursor = index + 1
-                while cursor < characters.count {
-                    if characters[cursor] == "\\", cursor + 1 < characters.count {
-                        cursor += 2
-                        continue
-                    }
-                    if characters[cursor] == character {
-                        cursor += 1
-                        break
-                    }
-                    cursor += 1
-                }
-                emit(String(characters[index..<min(cursor, characters.count)]), .string)
-                index = cursor
+                let scan = scanToDelimiter(characters, from: index + 1, delimiter: [character])
+                emit(String(characters[index..<scan.end]), .string)
+                index = scan.end
                 lineStart = false
                 continue
             }
@@ -446,31 +372,95 @@ enum CodeHighlighter {
         return HighlightedLine(segments: segments)
     }
 
+    // MARK: Shared scan loops
+
+    /// Walk block-comment content from `start` until the comment closes or
+    /// the line ends. Returns the index just past the scan (never beyond the
+    /// line) and the nesting depth still open — 0 means it closed here.
+    private static func scanBlockComment(
+        _ characters: [Character],
+        from start: Int,
+        open: [Character],
+        close: [Character],
+        depth: Int,
+        nests: Bool
+    ) -> (end: Int, depth: Int) {
+        var cursor = start
+        var level = depth
+        while cursor < characters.count {
+            if nests, matches(characters, open, at: cursor) {
+                level += 1
+                cursor += open.count
+                continue
+            }
+            if matches(characters, close, at: cursor) {
+                level -= 1
+                cursor += close.count
+                if level == 0 { break }
+                continue
+            }
+            cursor += 1
+        }
+        return (cursor, level)
+    }
+
+    /// Walk string content from `start` until the delimiter closes it or the
+    /// line ends; a backslash escapes the next character. `end` sits just
+    /// past the closing delimiter when `closed`.
+    private static func scanToDelimiter(
+        _ characters: [Character],
+        from start: Int,
+        delimiter: [Character]
+    ) -> (end: Int, closed: Bool) {
+        var cursor = start
+        while cursor < characters.count {
+            if characters[cursor] == "\\", cursor + 1 < characters.count {
+                cursor += 2
+                continue
+            }
+            if matches(characters, delimiter, at: cursor) {
+                return (cursor + delimiter.count, true)
+            }
+            cursor += 1
+        }
+        return (cursor, false)
+    }
+
+    /// Needle pre-converted to `[Character]` so the per-character scan loops
+    /// above never re-allocate it. (The `String` closure in `highlightLine`
+    /// stays for once-per-token checks, where the conversion is cheap.)
+    private static func matches(
+        _ characters: [Character], _ needle: [Character], at position: Int
+    ) -> Bool {
+        guard position + needle.count <= characters.count else { return false }
+        for (offset, character) in needle.enumerated()
+        where characters[position + offset] != character {
+            return false
+        }
+        return true
+    }
+
     // MARK: Markup scanning (XML/HTML)
+
+    private static let markupCommentOpen: [Character] = Array("<!--")
+    private static let markupCommentClose: [Character] = Array("-->")
 
     private static func scanMarkup(
         _ characters: [Character],
         from index: inout Int,
         emit: (String, CodeTokenKind) -> Void,
-        matches: (String, Int) -> Bool,
-        state: inout LineState,
-        rules: Rules
+        state: inout LineState
     ) {
         while index < characters.count {
-            if matches("<!--", index) {
-                var cursor = index + 4
-                var closed = false
-                while cursor < characters.count {
-                    if matches("-->", cursor) {
-                        cursor += 3
-                        closed = true
-                        break
-                    }
-                    cursor += 1
-                }
-                emit(String(characters[index..<min(cursor, characters.count)]), .comment)
-                index = cursor
-                if !closed {
+            if matches(characters, markupCommentOpen, at: index) {
+                let scan = scanBlockComment(
+                    characters, from: index + markupCommentOpen.count,
+                    open: markupCommentOpen, close: markupCommentClose,
+                    depth: 1, nests: false
+                )
+                emit(String(characters[index..<scan.end]), .comment)
+                index = scan.end
+                if scan.depth > 0 {
                     state = .blockComment(open: "<!--", close: "-->", depth: 1, nests: false)
                     return
                 }
@@ -564,8 +554,21 @@ enum CodeHighlighter {
     // MARK: Rule tables
 
     /// nil = render plain (markdown raw mode uses its own renderer; CONF
-    /// falls through to the INI profile).
+    /// falls through to the INI profile). Tables are built once — diff rows
+    /// look rules up per row, so this must never rebuild the keyword sets.
     static func rules(for language: CodeLanguage) -> Rules? {
+        rulesCache[language]
+    }
+
+    private static let rulesCache: [CodeLanguage: Rules] = {
+        var cache: [CodeLanguage: Rules] = [:]
+        for language in CodeLanguage.allCases {
+            cache[language] = makeRules(for: language)
+        }
+        return cache
+    }()
+
+    private static func makeRules(for language: CodeLanguage) -> Rules? {
         switch language {
         case .swift:
             var rules = cFamily(keywords: [
@@ -765,7 +768,6 @@ enum CodeHighlighter {
             rules.lineCommentPrefixes = ["#"]
             rules.quotes = ["\"", "'"]
             rules.propertyBeforeColon = true
-            rules.dollarVariables = false
             return rules
         case .toml, .ini:
             var rules = Rules()
@@ -775,7 +777,6 @@ enum CodeHighlighter {
             rules.quotes = ["\"", "'"]
             rules.multilineQuotes = ["\"\"\""]
             rules.sectionHeaders = true
-            rules.propertyBeforeColon = false
             return rules
         case .xml, .html:
             var rules = Rules()

--- a/Multiplex/Models/FileViewer/FileKind.swift
+++ b/Multiplex/Models/FileViewer/FileKind.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The languages the viewer's highlighter has rule tables for. The raw
 /// value is the badge the file header shows.
-enum CodeLanguage: String, Equatable {
+enum CodeLanguage: String, Equatable, CaseIterable {
     case swift = "SWIFT"
     case typescript = "TYPESCRIPT"
     case javascript = "JAVASCRIPT"

--- a/Multiplex/Models/FileViewer/FileKind.swift
+++ b/Multiplex/Models/FileViewer/FileKind.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// The languages the viewer's highlighter has rule tables for. The raw
+/// value is the badge the file header shows.
+enum CodeLanguage: String, Equatable {
+    case swift = "SWIFT"
+    case typescript = "TYPESCRIPT"
+    case javascript = "JAVASCRIPT"
+    case rust = "RUST"
+    case python = "PYTHON"
+    case go = "GO"
+    case c = "C"
+    case cpp = "C++"
+    case objectiveC = "OBJ-C"
+    case java = "JAVA"
+    case kotlin = "KOTLIN"
+    case ruby = "RUBY"
+    case php = "PHP"
+    case shell = "SHELL"
+    case json = "JSON"
+    case yaml = "YAML"
+    case toml = "TOML"
+    case xml = "XML"
+    case html = "HTML"
+    case css = "CSS"
+    case sql = "SQL"
+    case dockerfile = "DOCKERFILE"
+    case makefile = "MAKEFILE"
+    case ini = "CONF"
+    case lua = "LUA"
+    case dart = "DART"
+    case csharp = "C#"
+    case zig = "ZIG"
+    case elixir = "ELIXIR"
+    case markdown = "MARKDOWN"
+}
+
+/// How the content screen renders a file, decided from its name — the
+/// cheap verdict. Binary-vs-text is a *content* question layered on top
+/// (`FileKind.looksBinary`), because extensions lie in both directions.
+enum FileRenderKind: Equatable {
+    /// Monospace grid + syntax color; nil language = plain text.
+    case code(CodeLanguage?)
+    /// Rendered document with a RAW flip.
+    case markdown
+    /// Fit-to-screen image.
+    case image
+    /// Known-opaque formats (archives, databases, executables): never read
+    /// as text, the header says BINARY and the size.
+    case binary
+}
+
+enum FileKind {
+    /// Name-based classification. Full-name matches (Dockerfile, Makefile)
+    /// win over extensions; unknown extensions fall to plain text — the
+    /// honest default for a viewer (the binary sniff still runs on bytes).
+    static func classify(fileName: String) -> FileRenderKind {
+        let name = fileName.lowercased()
+        if let kind = fullNameKinds[name] { return kind }
+        // Compound extensions the simple split would misread.
+        if name.hasSuffix(".tar.gz") || name.hasSuffix(".tar.bz2")
+            || name.hasSuffix(".tar.xz") || name.hasSuffix(".tar.zst") {
+            return .binary
+        }
+        guard let dot = name.lastIndex(of: "."), dot != name.startIndex else {
+            return .code(nil)
+        }
+        let ext = String(name[name.index(after: dot)...])
+        if let language = languageByExtension[ext] { return .code(language) }
+        if markdownExtensions.contains(ext) { return .markdown }
+        if imageExtensions.contains(ext) { return .image }
+        if binaryExtensions.contains(ext) { return .binary }
+        return .code(nil)
+    }
+
+    /// The language a markdown fence's info string names (```swift), for
+    /// the renderer's embedded highlighting. Forgiving: first word, common
+    /// aliases folded.
+    static func fenceLanguage(_ info: String) -> CodeLanguage? {
+        let word = info.trimmingCharacters(in: .whitespaces)
+            .split(separator: " ").first.map(String.init)?.lowercased() ?? ""
+        guard !word.isEmpty else { return nil }
+        if let language = languageByExtension[word] { return language }
+        return fenceAliases[word]
+    }
+
+    /// The text/binary sniff: a NUL in the head is the classic verdict —
+    /// no text encoding the viewer renders contains one.
+    static func looksBinary(_ data: Data) -> Bool {
+        data.prefix(8192).contains(0)
+    }
+
+    private static let fullNameKinds: [String: FileRenderKind] = [
+        "dockerfile": .code(.dockerfile),
+        "containerfile": .code(.dockerfile),
+        "makefile": .code(.makefile),
+        "gnumakefile": .code(.makefile),
+        "cmakelists.txt": .code(nil),
+        "gemfile": .code(.ruby),
+        "rakefile": .code(.ruby),
+        "podfile": .code(.ruby),
+        "fastfile": .code(.ruby),
+        "brewfile": .code(.ruby),
+        "justfile": .code(.makefile),
+        "license": .code(nil),
+        "readme": .markdown,
+        ".gitignore": .code(.ini),
+        ".gitattributes": .code(.ini),
+        ".gitmodules": .code(.ini),
+        ".editorconfig": .code(.ini),
+        ".env": .code(.shell),
+        ".zshrc": .code(.shell),
+        ".bashrc": .code(.shell),
+        ".bash_profile": .code(.shell),
+        ".profile": .code(.shell),
+        ".tmux.conf": .code(.ini),
+        ".vimrc": .code(nil),
+    ]
+
+    private static let languageByExtension: [String: CodeLanguage] = [
+        "swift": .swift,
+        "ts": .typescript, "tsx": .typescript, "mts": .typescript, "cts": .typescript,
+        "js": .javascript, "jsx": .javascript, "mjs": .javascript, "cjs": .javascript,
+        "rs": .rust,
+        "py": .python, "pyi": .python,
+        "go": .go,
+        "c": .c, "h": .c,
+        "cpp": .cpp, "cc": .cpp, "cxx": .cpp, "hpp": .cpp, "hh": .cpp, "hxx": .cpp,
+        "m": .objectiveC, "mm": .objectiveC,
+        "java": .java,
+        "kt": .kotlin, "kts": .kotlin,
+        "rb": .ruby, "erb": .ruby,
+        "php": .php,
+        "sh": .shell, "bash": .shell, "zsh": .shell, "fish": .shell,
+        "json": .json, "jsonc": .json, "json5": .json, "jsonl": .json,
+        "storekit": .json, "webmanifest": .json,
+        "yml": .yaml, "yaml": .yaml,
+        "toml": .toml, "lock": .toml,
+        "xml": .xml, "plist": .xml, "svg": .xml, "xib": .xml, "storyboard": .xml,
+        "entitlements": .xml, "xcprivacy": .xml,
+        "html": .html, "htm": .html, "vue": .html, "svelte": .html, "astro": .html,
+        "css": .css, "scss": .css, "less": .css,
+        "sql": .sql,
+        "ini": .ini, "cfg": .ini, "conf": .ini, "properties": .ini, "gitconfig": .ini,
+        "lua": .lua,
+        "dart": .dart,
+        "cs": .csharp,
+        "zig": .zig,
+        "ex": .elixir, "exs": .elixir,
+        "mod": .go, "sum": .ini,
+        "gradle": .kotlin,
+        "diff": .ini, "patch": .ini,
+    ]
+
+    private static let fenceAliases: [String: CodeLanguage] = [
+        "typescript": .typescript, "javascript": .javascript,
+        "swift": .swift, "rust": .rust, "python": .python, "golang": .go,
+        "shell": .shell, "console": .shell, "terminal": .shell,
+        "objc": .objectiveC, "objective-c": .objectiveC,
+        "kotlin": .kotlin, "ruby": .ruby, "csharp": .csharp,
+        "dockerfile": .dockerfile, "makefile": .makefile, "make": .makefile,
+        "elixir": .elixir, "markdown": .markdown, "md": .markdown,
+    ]
+
+    private static let markdownExtensions: Set<String> = [
+        "md", "markdown", "mdown", "mdx",
+    ]
+
+    private static let imageExtensions: Set<String> = [
+        "png", "jpg", "jpeg", "gif", "heic", "heif", "webp", "bmp", "tiff", "tif", "ico",
+    ]
+
+    private static let binaryExtensions: Set<String> = [
+        "zip", "gz", "tgz", "bz2", "xz", "zst", "7z", "rar", "tar",
+        "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx",
+        "sqlite", "sqlite3", "db", "realm",
+        "a", "o", "so", "dylib", "dll", "exe", "bin", "wasm", "class", "jar",
+        "mp3", "mp4", "mov", "m4a", "m4v", "avi", "mkv", "wav", "flac", "ogg",
+        "ttf", "otf", "woff", "woff2",
+        "car", "ipa", "apk", "dmg", "iso",
+        "psd", "sketch", "fig", "afdesign",
+        "pyc", "beam", "keystore", "p12", "mobileprovision",
+    ]
+}

--- a/Multiplex/Models/FileViewer/FileTree.swift
+++ b/Multiplex/Models/FileViewer/FileTree.swift
@@ -30,6 +30,28 @@ enum FileTree {
         var id: String { entry.path }
     }
 
+    /// The names every code editor hides by default (VS Code's
+    /// files.exclude set plus each platform's litter) — invisible to the
+    /// tree everywhere: rows, the CHANGED list, and the change-dot trail,
+    /// so a stray untracked .DS_Store can't light a directory whose
+    /// expansion then shows nothing. Deliberately NOT all dotfiles:
+    /// .gitignore, .env, .zshrc are files people open, and this is a dev
+    /// tool. Content is untouched — a pressed path into .git still opens;
+    /// only the tree declines to advertise it.
+    static let hiddenNames: Set<String> = [
+        ".git", ".svn", ".hg", "CVS", ".DS_Store", "Thumbs.db",
+    ]
+
+    static func isHidden(_ name: String) -> Bool {
+        hiddenNames.contains(name)
+    }
+
+    /// A repo-relative status path touching any hidden component (the
+    /// .DS_Store itself, or anything under a hidden directory).
+    private static func statusIsHidden(_ path: String) -> Bool {
+        path.split(separator: "/").contains { hiddenNames.contains(String($0)) }
+    }
+
     /// Directories first, then files, case-insensitive by name — the one
     /// order every file browser owes its user.
     static func sorted(_ entries: [FileTreeEntry]) -> [FileTreeEntry] {
@@ -71,7 +93,7 @@ enum FileTree {
         into rows: inout [Row]
     ) {
         guard let entries = children[directory] else { return }
-        for entry in sorted(entries) {
+        for entry in sorted(entries) where !isHidden(entry.name) {
             let isExpanded = entry.isDirectory && expanded.contains(entry.path)
             rows.append(Row(
                 entry: entry,
@@ -105,13 +127,14 @@ enum FileTree {
     }
 
     /// Every directory that holds a change, up to (and excluding) the repo
-    /// root — the tree marks the trail to what moved.
+    /// root — the tree marks the trail to what moved. Hidden-set statuses
+    /// don't count: a dot must never point at a row the tree won't show.
     static func changedDirectories(
         statuses: [GitFileStatus],
         repoRoot: String
     ) -> Set<String> {
         var set: Set<String> = []
-        for status in statuses {
+        for status in statuses where !statusIsHidden(status.path) {
             var components = status.path.split(separator: "/").dropLast()
             while !components.isEmpty {
                 set.insert(join(repoRoot, components.joined(separator: "/")))
@@ -122,12 +145,14 @@ enum FileTree {
     }
 
     /// The CHANGED filter's flat rows: repo-relative paths straight from
-    /// porcelain, no directory nesting — the review index.
+    /// porcelain, no directory nesting — the review index. Same hidden-set
+    /// rule as the tree.
     static func changedRows(
         statuses: [GitFileStatus],
         repoRoot: String
     ) -> [Row] {
         statuses
+            .filter { !statusIsHidden($0.path) }
             .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
             .map { status in
                 Row(

--- a/Multiplex/Models/FileViewer/FileTree.swift
+++ b/Multiplex/Models/FileViewer/FileTree.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// One remote directory entry, as the controller learned it from SFTP.
+/// Pure value — Citadel types never cross into Models.
+struct FileTreeEntry: Equatable, Identifiable {
+    var name: String
+    /// Absolute remote path.
+    var path: String
+    var isDirectory: Bool
+    var isSymlink = false
+    var size: UInt64?
+
+    var id: String { path }
+}
+
+/// Pure tree bookkeeping: sorting, expansion → visible rows, git badges,
+/// and the CHANGED flattening. The controller owns the caches; this owns
+/// the rules.
+enum FileTree {
+    struct Row: Equatable, Identifiable {
+        var entry: FileTreeEntry
+        var depth: Int
+        var isExpanded = false
+        /// nil while a directory's children haven't been listed yet.
+        var badge: GitFileStatus.Badge?
+        /// A directory holding changes gets a dot, not a letter — the
+        /// letter belongs to the file that earned it.
+        var containsChanges = false
+
+        var id: String { entry.path }
+    }
+
+    /// Directories first, then files, case-insensitive by name — the one
+    /// order every file browser owes its user.
+    static func sorted(_ entries: [FileTreeEntry]) -> [FileTreeEntry] {
+        entries.sorted { a, b in
+            if a.isDirectory != b.isDirectory { return a.isDirectory }
+            let byName = a.name.localizedCaseInsensitiveCompare(b.name)
+            if byName != .orderedSame { return byName == .orderedAscending }
+            return a.name < b.name
+        }
+    }
+
+    /// Flattens the loaded tree into visible rows: expanded directories
+    /// contribute their (already listed) children; an expanded directory
+    /// whose listing hasn't arrived contributes only itself.
+    static func rows(
+        root: String,
+        children: [String: [FileTreeEntry]],
+        expanded: Set<String>,
+        badges: [String: GitFileStatus.Badge],
+        changedDirectories: Set<String>
+    ) -> [Row] {
+        var rows: [Row] = []
+        appendRows(
+            of: root, depth: 0,
+            children: children, expanded: expanded,
+            badges: badges, changedDirectories: changedDirectories,
+            into: &rows
+        )
+        return rows
+    }
+
+    private static func appendRows(
+        of directory: String,
+        depth: Int,
+        children: [String: [FileTreeEntry]],
+        expanded: Set<String>,
+        badges: [String: GitFileStatus.Badge],
+        changedDirectories: Set<String>,
+        into rows: inout [Row]
+    ) {
+        guard let entries = children[directory] else { return }
+        for entry in sorted(entries) {
+            let isExpanded = entry.isDirectory && expanded.contains(entry.path)
+            rows.append(Row(
+                entry: entry,
+                depth: depth,
+                isExpanded: isExpanded,
+                badge: entry.isDirectory ? nil : badges[entry.path],
+                containsChanges: entry.isDirectory
+                    && changedDirectories.contains(entry.path)
+            ))
+            if isExpanded {
+                appendRows(
+                    of: entry.path, depth: depth + 1,
+                    children: children, expanded: expanded,
+                    badges: badges, changedDirectories: changedDirectories,
+                    into: &rows
+                )
+            }
+        }
+    }
+
+    /// Absolute-path badge map from repo-root-relative statuses.
+    static func badges(
+        statuses: [GitFileStatus],
+        repoRoot: String
+    ) -> [String: GitFileStatus.Badge] {
+        var map: [String: GitFileStatus.Badge] = [:]
+        for status in statuses {
+            map[join(repoRoot, status.path)] = status.badge
+        }
+        return map
+    }
+
+    /// Every directory that holds a change, up to (and excluding) the repo
+    /// root — the tree marks the trail to what moved.
+    static func changedDirectories(
+        statuses: [GitFileStatus],
+        repoRoot: String
+    ) -> Set<String> {
+        var set: Set<String> = []
+        for status in statuses {
+            var components = status.path.split(separator: "/").dropLast()
+            while !components.isEmpty {
+                set.insert(join(repoRoot, components.joined(separator: "/")))
+                components = components.dropLast()
+            }
+        }
+        return set
+    }
+
+    /// The CHANGED filter's flat rows: repo-relative paths straight from
+    /// porcelain, no directory nesting — the review index.
+    static func changedRows(
+        statuses: [GitFileStatus],
+        repoRoot: String
+    ) -> [Row] {
+        statuses
+            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+            .map { status in
+                Row(
+                    entry: FileTreeEntry(
+                        name: status.path,
+                        path: join(repoRoot, status.path),
+                        isDirectory: false
+                    ),
+                    depth: 0,
+                    badge: status.badge
+                )
+            }
+    }
+
+    static func join(_ directory: String, _ relative: String) -> String {
+        if directory.hasSuffix("/") { return directory + relative }
+        return directory + "/" + relative
+    }
+
+    /// The parent directory of an absolute path; nil at the filesystem root.
+    static func parent(of path: String) -> String? {
+        guard path != "/", let slash = path.lastIndex(of: "/") else { return nil }
+        if slash == path.startIndex { return "/" }
+        return String(path[..<slash])
+    }
+
+    static func name(of path: String) -> String {
+        guard let slash = path.lastIndex(of: "/"),
+              slash != path.index(before: path.endIndex)
+        else { return path }
+        return String(path[path.index(after: slash)...])
+    }
+}

--- a/Multiplex/Models/FileViewer/FileTree.swift
+++ b/Multiplex/Models/FileViewer/FileTree.swift
@@ -7,8 +7,6 @@ struct FileTreeEntry: Equatable, Identifiable {
     /// Absolute remote path.
     var path: String
     var isDirectory: Bool
-    var isSymlink = false
-    var size: UInt64?
 
     var id: String { path }
 }
@@ -65,7 +63,9 @@ enum FileTree {
 
     /// Flattens the loaded tree into visible rows: expanded directories
     /// contribute their (already listed) children; an expanded directory
-    /// whose listing hasn't arrived contributes only itself.
+    /// whose listing hasn't arrived contributes only itself. `children`
+    /// values are stored pre-sorted (`sorted(_:)` at listing time) — this
+    /// runs on every tree render and must not re-sort them.
     static func rows(
         root: String,
         children: [String: [FileTreeEntry]],
@@ -93,7 +93,7 @@ enum FileTree {
         into rows: inout [Row]
     ) {
         guard let entries = children[directory] else { return }
-        for entry in sorted(entries) where !isHidden(entry.name) {
+        for entry in entries where !isHidden(entry.name) {
             let isExpanded = entry.isDirectory && expanded.contains(entry.path)
             rows.append(Row(
                 entry: entry,

--- a/Multiplex/Models/FileViewer/GitDiff.swift
+++ b/Multiplex/Models/FileViewer/GitDiff.swift
@@ -1,0 +1,338 @@
+import Foundation
+
+/// A parsed `git diff` — the file viewer's DIFF render and the repo-wide
+/// review surface both stand on this. Pure: text in, structure out, no
+/// networking and no git knowledge beyond the unified format itself.
+///
+/// The input is always produced by our own command builder
+/// (`GitCommands.diff…`: `--no-color --no-ext-diff` under
+/// `-c core.quotepath=false`), so ANSI sequences and octal-escaped
+/// non-ASCII paths never reach the parser; quoted paths are still handled
+/// because git quotes controls regardless of quotepath.
+struct GitDiff: Equatable {
+    var files: [GitDiffFile] = []
+
+    var additions: Int { files.reduce(0) { $0 + $1.additions } }
+    var deletions: Int { files.reduce(0) { $0 + $1.deletions } }
+
+    /// Parses `git diff` output. Unknown header lines are skipped rather
+    /// than failed — the render must survive git versions growing new
+    /// extended headers.
+    static func parse(_ text: String) -> GitDiff {
+        var files: [GitDiffFile] = []
+        var current: GitDiffFile?
+        var hunk: GitDiffHunk?
+        var oldLine = 0
+        var newLine = 0
+
+        func closeHunk() {
+            if let done = hunk, var file = current {
+                file.hunks.append(done)
+                current = file
+                hunk = nil
+            }
+        }
+        func closeFile() {
+            closeHunk()
+            if let done = current { files.append(done) }
+            current = nil
+        }
+
+        // Split keeping empty lines: a context line can be empty (" " is
+        // trimmed to "" by data transports that strip trailing spaces), and
+        // dropping it would shift every line number after it. The one empty
+        // piece a trailing newline produces is not a line, though — parsing
+        // it would append a phantom context row to the final hunk.
+        var pieces = text.split(separator: "\n", omittingEmptySubsequences: false)
+        if pieces.last == "" { pieces.removeLast() }
+        for rawLine in pieces {
+            let line = String(rawLine)
+            if line.hasPrefix("diff --git ") {
+                closeFile()
+                current = GitDiffFile(headerPaths: String(line.dropFirst("diff --git ".count)))
+                continue
+            }
+            guard current != nil else { continue }
+
+            if hunk != nil {
+                // Inside a hunk until the next header. Order matters: a
+                // context line legitimately starts with anything after its
+                // marker column, so headers are recognized first.
+                if line.hasPrefix("@@") {
+                    closeHunk()
+                    // fall through to the hunk-open branch below
+                } else if line.hasPrefix("diff --git ") {
+                    // handled above; unreachable, kept for clarity
+                    continue
+                } else if line.hasPrefix("\\") {
+                    // "\ No newline at end of file" — annotate the previous
+                    // line rather than rendering a phantom row.
+                    if var h = hunk, !h.lines.isEmpty {
+                        h.lines[h.lines.count - 1].noTrailingNewline = true
+                        hunk = h
+                    }
+                    continue
+                } else {
+                    let marker = line.first
+                    let body = String(line.dropFirst())
+                    switch marker {
+                    case "+":
+                        hunk?.lines.append(GitDiffLine(
+                            kind: .addition, text: body,
+                            oldNumber: nil, newNumber: newLine
+                        ))
+                        newLine += 1
+                    case "-":
+                        hunk?.lines.append(GitDiffLine(
+                            kind: .deletion, text: body,
+                            oldNumber: oldLine, newNumber: nil
+                        ))
+                        oldLine += 1
+                    case " ", nil:
+                        // nil: a completely empty line is a context line
+                        // whose single space was stripped in transit.
+                        hunk?.lines.append(GitDiffLine(
+                            kind: .context, text: body,
+                            oldNumber: oldLine, newNumber: newLine
+                        ))
+                        oldLine += 1
+                        newLine += 1
+                    default:
+                        // An unrecognized marker ends the hunk (git never
+                        // emits one mid-hunk; this is a truncated diff).
+                        closeHunk()
+                    }
+                    if hunk != nil { continue }
+                }
+            }
+
+            if line.hasPrefix("@@") {
+                guard let header = GitDiffHunk.parseHeader(line) else { continue }
+                hunk = header
+                oldLine = header.oldStart
+                newLine = header.newStart
+                continue
+            }
+            if line.hasPrefix("--- ") {
+                if line == "--- /dev/null" { current?.kind = .added }
+                continue
+            }
+            if line.hasPrefix("+++ ") {
+                let path = GitDiffFile.stripPathPrefix(String(line.dropFirst(4)))
+                if path == nil { current?.kind = .deleted } // +++ /dev/null
+                else if let path { current?.newPath = path }
+                continue
+            }
+            if line.hasPrefix("rename from ") {
+                current?.oldPath = GitDiffFile.unquote(String(line.dropFirst("rename from ".count)))
+                current?.kind = .renamed
+                continue
+            }
+            if line.hasPrefix("rename to ") {
+                current?.newPath = GitDiffFile.unquote(String(line.dropFirst("rename to ".count)))
+                current?.kind = .renamed
+                continue
+            }
+            if line.hasPrefix("new file mode ") { current?.kind = .added; continue }
+            if line.hasPrefix("deleted file mode ") { current?.kind = .deleted; continue }
+            if line.hasPrefix("Binary files ") || line.hasPrefix("GIT binary patch") {
+                current?.isBinary = true
+                continue
+            }
+            // "index …", "old mode …", "similarity index …" and future
+            // extended headers: skipped.
+        }
+        closeFile()
+        return GitDiff(files: files)
+    }
+}
+
+struct GitDiffFile: Equatable {
+    enum Kind: Equatable {
+        case modified, added, deleted, renamed
+    }
+
+    var oldPath: String = ""
+    var newPath: String = ""
+    var kind: Kind = .modified
+    var isBinary = false
+    var hunks: [GitDiffHunk] = []
+
+    /// The path the viewer shows and keys by: where the file lives NOW —
+    /// the old path only when the new side is gone.
+    var displayPath: String {
+        if kind == .deleted { return oldPath.isEmpty ? newPath : oldPath }
+        return newPath.isEmpty ? oldPath : newPath
+    }
+
+    var additions: Int {
+        hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .addition }.count }
+    }
+    var deletions: Int {
+        hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .deletion }.count }
+    }
+
+    init() {}
+
+    /// Seeds both paths from the `diff --git a/X b/Y` line. The line is
+    /// ambiguous for paths containing " b/", so `---`/`+++`/`rename` headers
+    /// overwrite these when present — this is only the fallback (mode-only
+    /// changes have no `---` line at all).
+    init(headerPaths: String) {
+        let (old, new) = Self.splitHeaderPaths(headerPaths)
+        oldPath = old
+        newPath = new
+    }
+
+    static func splitHeaderPaths(_ text: String) -> (String, String) {
+        // Quoted spellings are unambiguous: "a/…" "b/…".
+        if text.hasPrefix("\"") {
+            var paths: [String] = []
+            var index = text.startIndex
+            while index < text.endIndex, paths.count < 2 {
+                guard text[index] == "\"" else { index = text.index(after: index); continue }
+                var cursor = text.index(after: index)
+                var raw = "\""
+                while cursor < text.endIndex {
+                    let character = text[cursor]
+                    raw.append(character)
+                    if character == "\\" {
+                        let next = text.index(after: cursor)
+                        if next < text.endIndex {
+                            raw.append(text[next])
+                            cursor = text.index(after: next)
+                            continue
+                        }
+                    }
+                    cursor = text.index(after: cursor)
+                    if character == "\"" { break }
+                }
+                paths.append(raw)
+                index = cursor
+            }
+            if paths.count == 2 {
+                return (
+                    stripPathPrefix(paths[0]) ?? "",
+                    stripPathPrefix(paths[1]) ?? ""
+                )
+            }
+        }
+        // Unquoted: split at the LAST " b/" — an interior " b/" in the old
+        // path is possible but the last occurrence is the boundary whenever
+        // both sides are the same path (the overwhelmingly common case).
+        if let range = text.range(of: " b/", options: .backwards) {
+            let old = String(text[..<range.lowerBound])
+            let new = String(text[range.upperBound...])
+            return (stripPathPrefix(old) ?? old, new)
+        }
+        return (text, text)
+    }
+
+    /// Drops the `a/`/`b/` prefix and unquotes; nil for `/dev/null`.
+    static func stripPathPrefix(_ raw: String) -> String? {
+        var text = unquote(raw)
+        if text == "/dev/null" { return nil }
+        if text.hasPrefix("a/") || text.hasPrefix("b/") {
+            text = String(text.dropFirst(2))
+        }
+        return text
+    }
+
+    /// Reverses git's C-style path quoting (controls and, with quotepath
+    /// on, non-ASCII as octal escapes). Unquoted input passes through.
+    static func unquote(_ raw: String) -> String {
+        guard raw.hasPrefix("\""), raw.hasSuffix("\""), raw.count >= 2 else { return raw }
+        var bytes: [UInt8] = []
+        let scalars = Array(raw.dropFirst().dropLast().utf8)
+        var index = 0
+        while index < scalars.count {
+            let byte = scalars[index]
+            guard byte == UInt8(ascii: "\\"), index + 1 < scalars.count else {
+                bytes.append(byte)
+                index += 1
+                continue
+            }
+            let escape = scalars[index + 1]
+            index += 2
+            switch escape {
+            case UInt8(ascii: "n"): bytes.append(0x0A)
+            case UInt8(ascii: "t"): bytes.append(0x09)
+            case UInt8(ascii: "r"): bytes.append(0x0D)
+            case UInt8(ascii: "\\"): bytes.append(0x5C)
+            case UInt8(ascii: "\""): bytes.append(0x22)
+            case UInt8(ascii: "0")...UInt8(ascii: "7"):
+                // Up to three octal digits.
+                var value = Int(escape - UInt8(ascii: "0"))
+                var digits = 1
+                while digits < 3, index < scalars.count,
+                      (UInt8(ascii: "0")...UInt8(ascii: "7")).contains(scalars[index]) {
+                    value = value * 8 + Int(scalars[index] - UInt8(ascii: "0"))
+                    index += 1
+                    digits += 1
+                }
+                bytes.append(UInt8(truncatingIfNeeded: value))
+            default:
+                bytes.append(escape)
+            }
+        }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}
+
+struct GitDiffHunk: Equatable {
+    var oldStart: Int
+    var oldCount: Int
+    var newStart: Int
+    var newCount: Int
+    /// The `@@ … @@ context` trailer, often a function name.
+    var heading: String
+    var lines: [GitDiffLine] = []
+
+    var header: String {
+        var text = "@@ -\(oldStart),\(oldCount) +\(newStart),\(newCount) @@"
+        if !heading.isEmpty { text += " \(heading)" }
+        return text
+    }
+
+    /// `@@ -41,8 +41,11 @@ enum AgentKind` → starts, counts, heading.
+    /// Counts default to 1 when omitted (`@@ -1 +1 @@`).
+    static func parseHeader(_ line: String) -> GitDiffHunk? {
+        guard line.hasPrefix("@@ ") else { return nil }
+        guard let close = line.range(of: " @@", range: line.index(line.startIndex, offsetBy: 3)..<line.endIndex)
+        else { return nil }
+        let ranges = line[line.index(line.startIndex, offsetBy: 3)..<close.lowerBound]
+        let heading = String(line[close.upperBound...]).trimmingCharacters(in: .whitespaces)
+        let parts = ranges.split(separator: " ")
+        guard parts.count == 2,
+              parts[0].hasPrefix("-"), parts[1].hasPrefix("+"),
+              let old = parseRange(parts[0].dropFirst()),
+              let new = parseRange(parts[1].dropFirst())
+        else { return nil }
+        return GitDiffHunk(
+            oldStart: old.0, oldCount: old.1,
+            newStart: new.0, newCount: new.1,
+            heading: heading
+        )
+    }
+
+    private static func parseRange(_ text: Substring) -> (Int, Int)? {
+        let parts = text.split(separator: ",")
+        guard let start = Int(parts.first ?? "") else { return nil }
+        let count = parts.count > 1 ? Int(parts[1]) ?? 1 : 1
+        return (start, count)
+    }
+}
+
+struct GitDiffLine: Equatable {
+    enum Kind: Equatable {
+        case context, addition, deletion
+    }
+
+    var kind: Kind
+    var text: String
+    /// Line numbers on each side; an addition has no old number, a deletion
+    /// no new one.
+    var oldNumber: Int?
+    var newNumber: Int?
+    var noTrailingNewline = false
+}

--- a/Multiplex/Models/FileViewer/GitDiff.swift
+++ b/Multiplex/Models/FileViewer/GitDiff.swift
@@ -27,6 +27,13 @@ struct GitDiff: Equatable {
 
         func closeHunk() {
             if let done = hunk, var file = current {
+                for line in done.lines {
+                    switch line.kind {
+                    case .addition: file.additions += 1
+                    case .deletion: file.deletions += 1
+                    case .context: break
+                    }
+                }
                 file.hunks.append(done)
                 current = file
                 hunk = nil
@@ -61,9 +68,6 @@ struct GitDiff: Equatable {
                 if line.hasPrefix("@@") {
                     closeHunk()
                     // fall through to the hunk-open branch below
-                } else if line.hasPrefix("diff --git ") {
-                    // handled above; unreachable, kept for clarity
-                    continue
                 } else if line.hasPrefix("\\") {
                     // "\ No newline at end of file" — annotate the previous
                     // line rather than rendering a phantom row.
@@ -157,19 +161,16 @@ struct GitDiffFile: Equatable {
     var kind: Kind = .modified
     var isBinary = false
     var hunks: [GitDiffHunk] = []
+    /// Counted once as hunks close during parse — headers re-read these on
+    /// every render, and a repo-wide diff's line count is unbounded.
+    var additions = 0
+    var deletions = 0
 
     /// The path the viewer shows and keys by: where the file lives NOW —
     /// the old path only when the new side is gone.
     var displayPath: String {
         if kind == .deleted { return oldPath.isEmpty ? newPath : oldPath }
         return newPath.isEmpty ? oldPath : newPath
-    }
-
-    var additions: Int {
-        hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .addition }.count }
-    }
-    var deletions: Int {
-        hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .deletion }.count }
     }
 
     init() {}

--- a/Multiplex/Models/FileViewer/GitFileStatus.swift
+++ b/Multiplex/Models/FileViewer/GitFileStatus.swift
@@ -65,7 +65,7 @@ struct GitFileStatus: Equatable {
         if x == "R" || x == "C" || y == "R" || y == "C" { return .renamed }
         if y == "D" || x == "D" { return .deleted }
         if x == "A" { return .added }
-        if y == "M" || x == "M" || y == "T" || x == "T" { return .modified }
+        // M/T on either side, and any pair porcelain grows later.
         return .modified
     }
 }

--- a/Multiplex/Models/FileViewer/GitFileStatus.swift
+++ b/Multiplex/Models/FileViewer/GitFileStatus.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// One porcelain-v1 status entry, reduced to the letter vocabulary the
+/// file viewer speaks: the deck-style badge on tree rows and the CHANGED
+/// filter's population. Pure parsing of `git status --porcelain -z`.
+struct GitFileStatus: Equatable {
+    /// The viewer's letters, not git's: git's own U means "unmerged", but a
+    /// standing column has more use for "untracked" — conflicts get the
+    /// louder mark.
+    enum Badge: String, Equatable {
+        case modified = "M"
+        case added = "A"
+        case deleted = "D"
+        case renamed = "R"
+        case untracked = "U"
+        case conflicted = "!"
+    }
+
+    /// Path relative to the repo root, exactly as git reports it.
+    var path: String
+    /// The rename origin, when this entry is a rename.
+    var originPath: String?
+    var badge: Badge
+
+    /// Parses `git status --porcelain=v1 -z` (NUL-separated, no quoting —
+    /// that is the whole point of -z). A rename entry's origin path follows
+    /// the target path as its own NUL token.
+    static func parse(porcelainZ text: String) -> [GitFileStatus] {
+        var entries: [GitFileStatus] = []
+        let tokens = text.split(separator: "\0", omittingEmptySubsequences: true)
+        var index = 0
+        while index < tokens.count {
+            let token = tokens[index]
+            index += 1
+            // "XY PATH" — two status letters, one space, then the path.
+            guard token.count >= 4 else { continue }
+            let x = token[token.startIndex]
+            let y = token[token.index(after: token.startIndex)]
+            let path = String(token.dropFirst(3))
+            var origin: String?
+            if x == "R" || x == "C" || y == "R" || y == "C" {
+                // A rename/copy in either column carries ORIG_PATH as the
+                // next -z token.
+                if index < tokens.count {
+                    origin = String(tokens[index])
+                    index += 1
+                }
+            }
+            guard let badge = badge(x: x, y: y) else { continue }
+            entries.append(GitFileStatus(path: path, originPath: origin, badge: badge))
+        }
+        return entries
+    }
+
+    /// X = index status, Y = worktree status. Display collapses the pair:
+    /// conflicts loudest, untracked its own thing, then whichever side
+    /// moved. `!!` (ignored) is never requested and drops if it appears.
+    private static func badge(x: Character, y: Character) -> Badge? {
+        if x == "?" || y == "?" { return .untracked }
+        if x == "!" || y == "!" { return nil }
+        // Any unmerged combination: DD, AA, or anything carrying U.
+        if x == "U" || y == "U" || (x == "D" && y == "D") || (x == "A" && y == "A") {
+            return .conflicted
+        }
+        if x == "R" || x == "C" || y == "R" || y == "C" { return .renamed }
+        if y == "D" || x == "D" { return .deleted }
+        if x == "A" { return .added }
+        if y == "M" || x == "M" || y == "T" || x == "T" { return .modified }
+        return .modified
+    }
+}
+
+/// `git diff --shortstat` reduced to the tree header's ± counts.
+/// "3 files changed, 42 insertions(+), 17 deletions(-)" — every piece is
+/// optional (a pure-deletion diff has no insertions clause; an empty diff
+/// prints nothing at all).
+struct GitShortStat: Equatable {
+    var filesChanged = 0
+    var insertions = 0
+    var deletions = 0
+
+    var isEmpty: Bool { filesChanged == 0 && insertions == 0 && deletions == 0 }
+
+    static func parse(_ text: String) -> GitShortStat {
+        var stat = GitShortStat()
+        let line = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !line.isEmpty else { return stat }
+        for clause in line.split(separator: ",") {
+            let words = clause.split(separator: " ")
+            guard let number = words.first.flatMap({ Int($0) }) else { continue }
+            let clauseText = clause.lowercased()
+            if clauseText.contains("file") { stat.filesChanged = number }
+            else if clauseText.contains("insertion") { stat.insertions = number }
+            else if clauseText.contains("deletion") { stat.deletions = number }
+        }
+        return stat
+    }
+}

--- a/Multiplex/Models/FileViewer/MarkdownDocument.swift
+++ b/Multiplex/Models/FileViewer/MarkdownDocument.swift
@@ -1,0 +1,474 @@
+import Foundation
+
+/// The file viewer's Markdown model — a deliberate GFM *subset*, parsed by
+/// hand for the same reason the highlighter is hand-rolled: every real
+/// renderer (swift-markdown/cmark, MarkdownUI) is a vendored C library this
+/// feature doesn't need yet, and SwiftUI's built-in
+/// `AttributedString(markdown:)` cannot lay out block structure at all
+/// (headings render as body text; tables, lists, and fences don't render).
+///
+/// Covered: ATX headings, paragraphs, fenced code (with language info),
+/// block quotes, flat-ish lists (two indent levels), GFM tables, thematic
+/// breaks, inline emphasis/code/links/images. Not covered, on purpose:
+/// setext headings, reference links, HTML blocks, footnotes — a README
+/// renders honestly without them, and RAW mode is one chip away.
+enum MarkdownBlock: Equatable {
+    case heading(level: Int, inlines: [MarkdownInline])
+    case paragraph(inlines: [MarkdownInline])
+    case code(language: CodeLanguage?, info: String, lines: [String])
+    case quote(blocks: [MarkdownBlock])
+    /// Flat list item; `level` is nesting depth (0 or 1 — deeper indents
+    /// clamp), `marker` is what the renderer draws ("•", "3.").
+    case listItem(marker: String, level: Int, inlines: [MarkdownInline])
+    case table(header: [[MarkdownInline]], rows: [[[MarkdownInline]]])
+    case rule
+}
+
+struct MarkdownEmphasis: OptionSet, Equatable {
+    let rawValue: Int
+    static let bold = MarkdownEmphasis(rawValue: 1 << 0)
+    static let italic = MarkdownEmphasis(rawValue: 1 << 1)
+    static let strikethrough = MarkdownEmphasis(rawValue: 1 << 2)
+}
+
+enum MarkdownInline: Equatable {
+    case text(String, MarkdownEmphasis)
+    case code(String)
+    /// The destination is untrusted remote text: the renderer offers it
+    /// through the link sheet's confirm discipline, never follows it.
+    case link(text: String, destination: String)
+    /// v1 renders a captioned placeholder — fetching a document's images
+    /// over SFTP (or the network!) is its own decision, not a side effect.
+    case image(alt: String)
+}
+
+enum MarkdownDocument {
+    static func parse(_ text: String) -> [MarkdownBlock] {
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        if lines.last == "" { lines.removeLast() }
+        return parseLines(lines)
+    }
+
+    private static func parseLines(_ lines: [String]) -> [MarkdownBlock] {
+        var blocks: [MarkdownBlock] = []
+        var paragraph: [String] = []
+        var index = 0
+
+        func flushParagraph() {
+            guard !paragraph.isEmpty else { return }
+            let joined = paragraph.joined(separator: " ")
+            blocks.append(.paragraph(inlines: parseInlines(joined)))
+            paragraph = []
+        }
+
+        while index < lines.count {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.isEmpty {
+                flushParagraph()
+                index += 1
+                continue
+            }
+
+            // Fenced code.
+            if let fence = fenceOpener(trimmed) {
+                flushParagraph()
+                var body: [String] = []
+                index += 1
+                while index < lines.count {
+                    let candidate = lines[index].trimmingCharacters(in: .whitespaces)
+                    if candidate.hasPrefix(fence.marker),
+                       candidate.allSatisfy({ $0 == fence.marker.first }) {
+                        index += 1
+                        break
+                    }
+                    body.append(lines[index])
+                    index += 1
+                }
+                blocks.append(.code(
+                    language: FileKind.fenceLanguage(fence.info),
+                    info: fence.info,
+                    lines: body
+                ))
+                continue
+            }
+
+            // ATX heading.
+            if trimmed.hasPrefix("#") {
+                let level = trimmed.prefix(while: { $0 == "#" }).count
+                if level <= 6 {
+                    let rest = trimmed.dropFirst(level)
+                    if rest.isEmpty || rest.first == " " {
+                        flushParagraph()
+                        var content = rest.trimmingCharacters(in: .whitespaces)
+                        // Trailing closing hashes are decoration.
+                        while content.hasSuffix("#") { content.removeLast() }
+                        blocks.append(.heading(
+                            level: level,
+                            inlines: parseInlines(content.trimmingCharacters(in: .whitespaces))
+                        ))
+                        index += 1
+                        continue
+                    }
+                }
+            }
+
+            // Thematic break (also swallows what CommonMark would call a
+            // setext underline — documented simplification).
+            if isThematicBreak(trimmed) {
+                flushParagraph()
+                blocks.append(.rule)
+                index += 1
+                continue
+            }
+
+            // Block quote: collect the run, strip one marker, recurse.
+            if trimmed.hasPrefix(">") {
+                flushParagraph()
+                var inner: [String] = []
+                while index < lines.count {
+                    let quoteLine = lines[index].trimmingCharacters(in: .whitespaces)
+                    guard quoteLine.hasPrefix(">") else { break }
+                    var stripped = String(quoteLine.dropFirst())
+                    if stripped.hasPrefix(" ") { stripped.removeFirst() }
+                    inner.append(stripped)
+                    index += 1
+                }
+                blocks.append(.quote(blocks: parseLines(inner)))
+                continue
+            }
+
+            // Table: a pipe row whose next line is the separator row.
+            if trimmed.contains("|"), index + 1 < lines.count,
+               isTableSeparator(lines[index + 1].trimmingCharacters(in: .whitespaces)) {
+                flushParagraph()
+                let header = tableCells(trimmed).map(parseInlines)
+                index += 2
+                var rows: [[[MarkdownInline]]] = []
+                while index < lines.count {
+                    let rowLine = lines[index].trimmingCharacters(in: .whitespaces)
+                    guard rowLine.contains("|"), !rowLine.isEmpty else { break }
+                    rows.append(tableCells(rowLine).map(parseInlines))
+                    index += 1
+                }
+                blocks.append(.table(header: header, rows: rows))
+                continue
+            }
+
+            // List item.
+            if let item = listItem(line) {
+                flushParagraph()
+                blocks.append(.listItem(
+                    marker: item.marker,
+                    level: item.level,
+                    inlines: parseInlines(item.content)
+                ))
+                index += 1
+                // Continuation lines (indented, not themselves items) fold
+                // into the item so wrapped bullets read as one row.
+                while index < lines.count {
+                    let next = lines[index]
+                    let nextTrimmed = next.trimmingCharacters(in: .whitespaces)
+                    guard !nextTrimmed.isEmpty,
+                          next.hasPrefix("  "),
+                          listItem(next) == nil,
+                          fenceOpener(nextTrimmed) == nil
+                    else { break }
+                    if case .listItem(let marker, let level, var inlines) = blocks.removeLast() {
+                        inlines.append(.text(" ", []))
+                        inlines.append(contentsOf: parseInlines(nextTrimmed))
+                        blocks.append(.listItem(marker: marker, level: level, inlines: inlines))
+                    }
+                    index += 1
+                }
+                continue
+            }
+
+            paragraph.append(trimmed)
+            index += 1
+        }
+        flushParagraph()
+        return blocks
+    }
+
+    // MARK: Block helpers
+
+    private static func fenceOpener(_ line: String) -> (marker: String, info: String)? {
+        for character in ["`", "~"] {
+            let run = line.prefix(while: { String($0) == character })
+            if run.count >= 3 {
+                let info = line.dropFirst(run.count).trimmingCharacters(in: .whitespaces)
+                // CommonMark: an info string on a backtick fence cannot
+                // contain backticks (that's an inline code span).
+                if character == "`", info.contains("`") { return nil }
+                return (String(run), info)
+            }
+        }
+        return nil
+    }
+
+    private static func isThematicBreak(_ line: String) -> Bool {
+        guard let first = line.first, "-*_".contains(first) else { return false }
+        var count = 0
+        for character in line {
+            if character == first { count += 1 }
+            else if character != " " { return false }
+        }
+        return count >= 3
+    }
+
+    private static func isTableSeparator(_ line: String) -> Bool {
+        guard line.contains("-") else { return false }
+        let stripped = line.replacingOccurrences(of: " ", with: "")
+        guard !stripped.isEmpty else { return false }
+        return stripped.allSatisfy { "|:-".contains($0) }
+    }
+
+    private static func tableCells(_ line: String) -> [String] {
+        var cells = line.split(separator: "|", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        // A leading/trailing pipe produces empty edge cells — decoration,
+        // not data. Interior empties are real (an empty cell).
+        if cells.first == "" { cells.removeFirst() }
+        if cells.last == "" { cells.removeLast() }
+        return cells
+    }
+
+    private static func listItem(
+        _ line: String
+    ) -> (marker: String, level: Int, content: String)? {
+        let indent = line.prefix(while: { $0 == " " }).count
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let level = min(indent / 2, 1)
+        for bullet in ["- ", "* ", "+ "] where trimmed.hasPrefix(bullet) {
+            var content = String(trimmed.dropFirst(2))
+            var marker = "•"
+            // Task list marker.
+            if content.hasPrefix("[ ] ") { marker = "□"; content = String(content.dropFirst(4)) }
+            else if content.hasPrefix("[x] ") || content.hasPrefix("[X] ") {
+                marker = "▣"
+                content = String(content.dropFirst(4))
+            }
+            return (marker, level, content)
+        }
+        let digits = trimmed.prefix(while: \.isNumber)
+        if !digits.isEmpty, digits.count <= 9 {
+            let rest = trimmed.dropFirst(digits.count)
+            if rest.hasPrefix(". ") || rest.hasPrefix(") ") {
+                return ("\(digits).", level, String(rest.dropFirst(2)))
+            }
+        }
+        return nil
+    }
+
+    // MARK: Inline parsing
+
+    static func parseInlines(_ text: String) -> [MarkdownInline] {
+        parseInlines(Substring(text), emphasis: [])
+    }
+
+    private static func parseInlines(
+        _ text: Substring,
+        emphasis: MarkdownEmphasis
+    ) -> [MarkdownInline] {
+        var inlines: [MarkdownInline] = []
+        var plain = ""
+        var index = text.startIndex
+
+        func flushPlain() {
+            guard !plain.isEmpty else { return }
+            inlines.append(.text(plain, emphasis))
+            plain = ""
+        }
+
+        while index < text.endIndex {
+            let character = text[index]
+
+            // Code span: a backtick run closed by an equal run.
+            if character == "`" {
+                let runEnd = text[index...].prefix(while: { $0 == "`" }).endIndex
+                let fence = text[index..<runEnd]
+                if let close = text.range(of: String(fence), range: runEnd..<text.endIndex) {
+                    flushPlain()
+                    inlines.append(.code(
+                        String(text[runEnd..<close.lowerBound])
+                            .trimmingCharacters(in: .whitespaces)
+                    ))
+                    index = close.upperBound
+                    continue
+                }
+            }
+
+            // Image / link.
+            if character == "!" || character == "[" {
+                let isImage = character == "!"
+                var cursor = index
+                if isImage {
+                    cursor = text.index(after: cursor)
+                    guard cursor < text.endIndex, text[cursor] == "[" else {
+                        plain.append(character)
+                        index = text.index(after: index)
+                        continue
+                    }
+                }
+                if let parsed = parseBracketed(text, from: cursor) {
+                    flushPlain()
+                    if isImage {
+                        inlines.append(.image(alt: parsed.label))
+                    } else {
+                        inlines.append(.link(text: parsed.label, destination: parsed.destination))
+                    }
+                    index = parsed.end
+                    continue
+                }
+            }
+
+            // Autolink <https://…>.
+            if character == "<" {
+                if let close = text[index...].firstIndex(of: ">") {
+                    let inner = text[text.index(after: index)..<close]
+                    if inner.hasPrefix("https://") || inner.hasPrefix("http://") {
+                        flushPlain()
+                        inlines.append(.link(text: String(inner), destination: String(inner)))
+                        index = text.index(after: close)
+                        continue
+                    }
+                }
+            }
+
+            // Emphasis delimiters: **, __, *, _, ~~. Underscores follow the
+            // intraword rule: `snake_case_names` fill READMEs, and an
+            // opener glued to a word (letter/digit before it) is prose,
+            // not emphasis.
+            if character == "*" || character == "_" || character == "~" {
+                let runEnd = text[index...].prefix(while: { $0 == character }).endIndex
+                var runLength = text.distance(from: index, to: runEnd)
+                if character == "~", runLength < 2 { runLength = 0 }
+                if character == "_",
+                   let previous = plain.last ?? previousCharacter(text, before: index),
+                   previous.isLetter || previous.isNumber {
+                    runLength = 0
+                }
+                if runLength > 0 {
+                    let useLength = min(runLength, 2)
+                    let delimiterEnd = text.index(index, offsetBy: useLength)
+                    let delimiter = String(text[index..<delimiterEnd])
+                    // Opener must press against content.
+                    if delimiterEnd < text.endIndex, text[delimiterEnd] != " ",
+                       let close = matchingClose(
+                           text,
+                           delimiter: delimiter,
+                           from: delimiterEnd,
+                           intraword: character != "_"
+                       ) {
+                        flushPlain()
+                        var style = emphasis
+                        switch delimiter {
+                        case "**", "__": style.insert(.bold)
+                        case "~~": style.insert(.strikethrough)
+                        default: style.insert(.italic)
+                        }
+                        inlines.append(contentsOf: parseInlines(
+                            text[delimiterEnd..<close.lowerBound],
+                            emphasis: style
+                        ))
+                        index = close.upperBound
+                        continue
+                    }
+                }
+            }
+
+            plain.append(character)
+            index = text.index(after: index)
+        }
+        flushPlain()
+        return inlines
+    }
+
+    /// The closing delimiter run, preceded by non-space content. With
+    /// `intraword` off (underscores), a closer glued into a word
+    /// (letter/digit right after it) doesn't count either.
+    private static func matchingClose(
+        _ text: Substring,
+        delimiter: String,
+        from start: Substring.Index,
+        intraword: Bool
+    ) -> Range<Substring.Index>? {
+        var search = start
+        while let range = text.range(of: delimiter, range: search..<text.endIndex) {
+            if range.lowerBound > text.startIndex {
+                let before = text[text.index(before: range.lowerBound)]
+                let after = range.upperBound < text.endIndex ? text[range.upperBound] : " "
+                if before != " ", intraword || !(after.isLetter || after.isNumber) {
+                    return range
+                }
+            }
+            search = range.upperBound
+        }
+        return nil
+    }
+
+    private static func previousCharacter(
+        _ text: Substring,
+        before index: Substring.Index
+    ) -> Character? {
+        guard index > text.startIndex else { return nil }
+        return text[text.index(before: index)]
+    }
+
+    /// `[label](destination)` starting at `open` (which must point at `[`).
+    private static func parseBracketed(
+        _ text: Substring,
+        from open: Substring.Index
+    ) -> (label: String, destination: String, end: Substring.Index)? {
+        guard text[open] == "[" else { return nil }
+        var depth = 0
+        var cursor = open
+        var closeBracket: Substring.Index?
+        while cursor < text.endIndex {
+            let character = text[cursor]
+            if character == "[" { depth += 1 }
+            if character == "]" {
+                depth -= 1
+                if depth == 0 { closeBracket = cursor; break }
+            }
+            cursor = text.index(after: cursor)
+        }
+        guard let closeBracket else { return nil }
+        let afterBracket = text.index(after: closeBracket)
+        guard afterBracket < text.endIndex, text[afterBracket] == "(" else { return nil }
+        var parenDepth = 0
+        var scan = afterBracket
+        while scan < text.endIndex {
+            let character = text[scan]
+            if character == "(" { parenDepth += 1 }
+            if character == ")" {
+                parenDepth -= 1
+                if parenDepth == 0 {
+                    let label = flattenedLabel(text[text.index(after: open)..<closeBracket])
+                    let destination = String(
+                        text[text.index(after: afterBracket)..<scan]
+                    ).trimmingCharacters(in: .whitespaces)
+                    return (label, destination, text.index(after: scan))
+                }
+            }
+            scan = text.index(after: scan)
+        }
+        return nil
+    }
+
+    /// Link labels render as plain text — emphasis markers inside are
+    /// stripped rather than styled (a viewer's simplification).
+    private static func flattenedLabel(_ text: Substring) -> String {
+        parseInlines(text, emphasis: []).map { inline in
+            switch inline {
+            case .text(let value, _): value
+            case .code(let value): value
+            case .link(let value, _): value
+            case .image(let alt): alt
+            }
+        }.joined()
+    }
+}

--- a/Multiplex/Models/FileViewer/TerminalPathTarget.swift
+++ b/Multiplex/Models/FileViewer/TerminalPathTarget.swift
@@ -83,7 +83,7 @@ struct TerminalPathTarget: Equatable, Identifiable {
                 // path:line:column
                 line = first
                 text = pieces.dropLast(2).joined(separator: ":")
-            } else if let only = Int(pieces.last!), pieces.count >= 2 {
+            } else if let only = Int(pieces.last!) {
                 line = only
                 text = pieces.dropLast().joined(separator: ":")
             }

--- a/Multiplex/Models/FileViewer/TerminalPathTarget.swift
+++ b/Multiplex/Models/FileViewer/TerminalPathTarget.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// A filesystem path pressed in a terminal pane — the file viewer's twin of
+/// `TerminalLink`. SwiftTerm's implicit detection (ghostty-derived) matches
+/// path shapes as readily as URLs; `TerminalLink` deliberately resolves them
+/// to nil, and historically the press fell through to text selection. Now a
+/// path-shaped press confirms into the file viewer the way a URL confirms
+/// into the viewport: same gate (a sheet naming the host), same "shown,
+/// never followed" discipline — pane bytes are untrusted, so nothing opens
+/// without the person seeing the resolved target first.
+///
+/// Pure classification. What it accepts mirrors what the fork's matcher can
+/// hand it: rooted (`/x`), home (`~/x`, `$HOME/x`), dot-relative (`./x`,
+/// `../x`, `.config/x`), and bare relative with a slash (`src/foo.ts`).
+/// Other `$VAR/…` shapes resolve to nil — the app cannot know the remote's
+/// environment, and a wrong guess opens the wrong file — so those keep
+/// falling through to selection.
+struct TerminalPathTarget: Equatable, Identifiable {
+    enum Base: Equatable {
+        /// Starts at `/` — used verbatim.
+        case absolute
+        /// `~/…` or `$HOME/…` — resolved against the remote home.
+        case home
+        /// Everything else — resolved against the pane's cwd (or home when
+        /// no pane can answer, which the sheet says).
+        case workingDirectory
+    }
+
+    /// The text as pressed, before any cleanup — what COPY copies.
+    var raw: String
+    /// The path with the base marker kept (`~/x` stays `~/x`) and any
+    /// trailing `:line[:column]` suffix removed.
+    var path: String
+    var base: Base
+    /// From a `path:12` / `path:12:5` suffix — compilers and agents cite
+    /// lines constantly, and the viewer scrolls there.
+    var line: Int?
+
+    var id: String { raw }
+
+    /// The path relative to its base, ready for remote resolution:
+    /// absolute stays absolute, home drops the `~/`/`$HOME/` marker,
+    /// working-directory keeps its relative spelling (minus `./`).
+    var relativePart: String {
+        switch base {
+        case .absolute:
+            return path
+        case .home:
+            if path.hasPrefix("~/") { return String(path.dropFirst(2)) }
+            if path.hasPrefix("$HOME/") { return String(path.dropFirst(6)) }
+            return path == "~" || path == "$HOME" ? "" : path
+        case .workingDirectory:
+            if path.hasPrefix("./") { return String(path.dropFirst(2)) }
+            return path
+        }
+    }
+
+    static func resolve(_ raw: String) -> TerminalPathTarget? {
+        var text = raw.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty, text.count <= 1024 else { return nil }
+        // URLs belong to TerminalLink; anything scheme-shaped is not a path.
+        if text.contains("://") { return nil }
+        // Interior whitespace is the prose guard, same rule as
+        // TerminalLink: "see src/foo.ts and lib/bar.rs" must not classify.
+        // Paths with spaces lose this trade — a wrong open costs more.
+        guard !text.contains(where: \.isWhitespace) else { return nil }
+        guard !text.contains(where: { $0.asciiValue.map { $0 < 0x20 } == true })
+        else { return nil }
+
+        // Trailing prose punctuation the matcher can leave on a path.
+        while let last = text.last, ".,;)".contains(last) {
+            text.removeLast()
+        }
+        guard !text.isEmpty else { return nil }
+
+        // `path:12` / `path:12:5` — strip, keep the line.
+        var line: Int?
+        let pieces = text.split(separator: ":", omittingEmptySubsequences: false)
+        if pieces.count >= 2 {
+            let tail = pieces.suffix(2)
+            let numbers = tail.compactMap { Int($0) }
+            if numbers.count == tail.count, pieces.count >= 3, let first = numbers.first {
+                // path:line:column
+                line = first
+                text = pieces.dropLast(2).joined(separator: ":")
+            } else if let only = Int(pieces.last!), pieces.count >= 2 {
+                line = only
+                text = pieces.dropLast().joined(separator: ":")
+            }
+        }
+        guard !text.isEmpty, text != "/" else { return nil }
+        // A colon that survives suffix-stripping is prose ("warning:") or a
+        // scheme-ish shape — a colon is legal in a unix filename, but rare
+        // enough that guessing wrong (and opening the wrong file) costs
+        // more than declining into text selection.
+        guard !text.contains(":") else { return nil }
+        return classified(raw: raw, path: text, line: line)
+    }
+
+    private static func classified(
+        raw: String,
+        path: String,
+        line: Int?
+    ) -> TerminalPathTarget? {
+        if path.hasPrefix("/") {
+            guard !path.hasPrefix("//") else { return nil }
+            return TerminalPathTarget(raw: raw, path: path, base: .absolute, line: line)
+        }
+        if path == "~" || path.hasPrefix("~/") {
+            return TerminalPathTarget(raw: raw, path: path, base: .home, line: line)
+        }
+        if path.hasPrefix("$") {
+            // Only $HOME is knowable from here; other variables live in the
+            // remote's environment and stay unresolved (→ selection).
+            guard path == "$HOME" || path.hasPrefix("$HOME/") else { return nil }
+            return TerminalPathTarget(raw: raw, path: path, base: .home, line: line)
+        }
+        if path.hasPrefix("./") || path.hasPrefix("../") {
+            return TerminalPathTarget(raw: raw, path: path, base: .workingDirectory, line: line)
+        }
+        // Bare relative: needs an interior slash to look like a path at
+        // all ("README" alone is prose the matcher wouldn't send anyway).
+        guard path.contains("/") else { return nil }
+        return TerminalPathTarget(raw: raw, path: path, base: .workingDirectory, line: line)
+    }
+}

--- a/Multiplex/Models/TerminalRoute.swift
+++ b/Multiplex/Models/TerminalRoute.swift
@@ -17,6 +17,12 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
         /// summoned, not restored (`TerminalWindowRoot.syncTabs` strips
         /// viewport tabs whose controller didn't survive the process).
         case viewport(urlString: String)
+        /// The file viewer — the host's files and git diffs as an inline
+        /// tab, the viewport's sibling: no PTY transport of its own record
+        /// (the controller dials SSH for reads), never restored across
+        /// launches (same `syncTabs` strip rule). `path` is only the
+        /// summoning label; the live location belongs to the controller.
+        case fileViewer(path: String)
 
         /// Keeps the pre-directory call shape valid (and mirrors how records
         /// persisted by older builds decode: directory absent → nil).
@@ -39,7 +45,7 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
                 sessionName: name,
                 directory: directory
             )
-        case .shell, .viewport:
+        case .shell, .viewport, .fileViewer:
             return nil
         }
     }
@@ -62,7 +68,7 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
                 command += " -c \(directory.shellQuotedDirectory)"
             }
             return command
-        case .shell, .viewport:
+        case .shell, .viewport, .fileViewer:
             return nil
         }
     }
@@ -72,15 +78,17 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
         case .attach(let name), .create(let name, _): name
         case .shell: "shell"
         case .viewport(let urlString): Self.viewportLabel(urlString)
+        case .fileViewer(let path): Self.fileViewerLabel(path)
         }
     }
 
     /// The tmux session this tab is bound to; nil for a plain shell (which
-    /// has no probe entry, so no agent detection) and for the viewport.
+    /// has no probe entry, so no agent detection) and for the viewport and
+    /// file viewer.
     var sessionName: String? {
         switch mode {
         case .attach(let name), .create(let name, _): name
-        case .shell, .viewport: nil
+        case .shell, .viewport, .fileViewer: nil
         }
     }
 
@@ -88,6 +96,17 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
         if case .viewport = mode { return true }
         return false
     }
+
+    var isFileViewer: Bool {
+        if case .fileViewer = mode { return true }
+        return false
+    }
+
+    /// A tab whose surface is a controller-owned monitor, not a terminal:
+    /// the viewport and the file viewer. These make no responder claim,
+    /// carry no tally dot, wear the slim monitor chrome, and are stripped
+    /// by `syncTabs` when their controller didn't survive the process.
+    var isAuxiliaryPane: Bool { isViewport || isFileViewer }
 
     var viewportURL: URL? {
         guard case .viewport(let urlString) = mode else { return nil }
@@ -102,6 +121,14 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
         guard let url = URL(string: urlString) else { return "⌗" }
         if let port = url.port { return "⌗ \(port)" }
         return "⌗ \(url.host() ?? "page")"
+    }
+
+    /// The file viewer's tab-cell/UMD label: `▤` + the last path component.
+    /// `▤` — U+25A4 SQUARE WITH HORIZONTAL FILL — is the file-viewer mark
+    /// everywhere, the viewport's sibling; a file never wears a tally dot.
+    static func fileViewerLabel(_ path: String) -> String {
+        let name = FileTree.name(of: path)
+        return name.isEmpty ? "▤" : "▤ \(name)"
     }
 }
 

--- a/Multiplex/Models/TerminalRoute.swift
+++ b/Multiplex/Models/TerminalRoute.swift
@@ -127,8 +127,13 @@ struct TerminalRoute: Codable, Hashable, Identifiable {
     /// `▤` — U+25A4 SQUARE WITH HORIZONTAL FILL — is the file-viewer mark
     /// everywhere, the viewport's sibling; a file never wears a tally dot.
     static func fileViewerLabel(_ path: String) -> String {
-        let name = FileTree.name(of: path)
-        return name.isEmpty ? "▤" : "▤ \(name)"
+        fileViewerLabel(name: FileTree.name(of: path))
+    }
+
+    /// The name-based spelling — the live controller labels itself with the
+    /// file on screen, which is not a path. The ▤ mark lives here only.
+    static func fileViewerLabel(name: String) -> String {
+        name.isEmpty ? "▤" : "▤ \(name)"
     }
 }
 

--- a/Multiplex/Services/FileViewerController.swift
+++ b/Multiplex/Services/FileViewerController.swift
@@ -17,7 +17,7 @@ import UIKit
 /// host's control plane, so mosh hosts open viewers the same way.
 @MainActor
 @Observable
-final class FileViewerController {
+final class FileViewerController: AuxiliaryPaneController {
     /// Text render cap: the capped head still renders, under a TRUNCATED
     /// banner. Big enough for every source file that matters; small enough
     /// that highlighting stays interactive.
@@ -56,15 +56,21 @@ final class FileViewerController {
     struct Document: Equatable {
         var path: String
         var size: UInt64
+        /// The render verdict — including binary: a NUL-sniffed text file
+        /// re-classifies to `.binary` here, so header and body always
+        /// agree on what the screen is.
         var kind: FileRenderKind
-        var language: CodeLanguage?
-        var isBinary = false
         var truncated = false
         /// Code (and markdown RAW) render.
         var codeLines: [HighlightedLine] = []
         /// Markdown rendered blocks.
         var markdown: [MarkdownBlock] = []
-        var imageData: Data?
+        /// Decoded once at load — re-decoding megabytes per body
+        /// evaluation is what image views must never do.
+        var image: UIImage?
+        /// The text behind a markdown render, kept so the RAW toggle
+        /// re-renders locally instead of re-downloading the file.
+        var sourceText: String?
         /// From a `path:12` press — the code view scrolls here once.
         var targetLine: Int?
 
@@ -98,13 +104,24 @@ final class FileViewerController {
     private var watchedStamp: SSHConnection.FileStat?
     private var watchTickCount = 0
     /// Markdown RAW toggle — kept across files (a preference, not a mode).
+    /// Re-renders from the text already in hand; flipping a preference
+    /// must not cost a network round trip.
     var markdownRaw = false {
         didSet {
             guard markdownRaw != oldValue,
-                  let document = lastDocument, document.kind == .markdown,
-                  case .document = content
+                  case .document(let document) = content,
+                  document.kind == .markdown
             else { return }
-            Task { await open(path: document.path, line: nil) }
+            contentGeneration += 1
+            let generation = contentGeneration
+            Task {
+                let updated = await Self.renderedMarkdown(document, raw: markdownRaw)
+                guard generation == contentGeneration,
+                      case .document(let still) = content, still.path == updated.path
+                else { return }
+                lastDocument = updated
+                content = .document(updated)
+            }
         }
     }
 
@@ -153,6 +170,8 @@ final class FileViewerController {
         default: rootPath.isEmpty ? "FILES" : FileTree.name(of: rootPath)
         }
     }
+
+    var tabLabel: String { TerminalRoute.fileViewerLabel(name: displayName) }
 
     /// The rail readout: where the screen actually is.
     var railPath: String {
@@ -234,15 +253,16 @@ final class FileViewerController {
             let anchor = resolvedTarget.map { FileTree.parent(of: $0) ?? "/" } ?? base
             await probeGit(at: anchor)
             rootPath = gitRoot ?? anchor
+            // The pressed file is the summons — render it before the
+            // listing and the (possibly seconds-cold) git status; tree
+            // rows and badges fill in quietly behind the document.
+            if let resolvedTarget {
+                await open(path: resolvedTarget, line: target?.line)
+            }
             await list(rootPath)
             expandChain(to: anchor)
             await refreshGitVerdicts()
-
-            if let resolvedTarget {
-                await open(path: resolvedTarget, line: target?.line)
-            } else {
-                content = .idle
-            }
+            if resolvedTarget == nil { content = .idle }
         } catch {
             content = .failure(
                 title: "NO CONNECTION",
@@ -271,20 +291,22 @@ final class FileViewerController {
     /// Returns whether anything actually moved.
     @discardableResult
     private func refreshGitVerdicts() async -> Bool {
+        // Every write below is equality-gated: @Observable has no gate of
+        // its own, an identical assignment still churns every observer,
+        // and this runs on the watch's 5 s tick — an idle repo must cost
+        // the wall nothing.
         guard let gitRoot else {
-            statuses = []
-            shortStat = GitShortStat()
+            if !statuses.isEmpty { statuses = [] }
+            if shortStat != GitShortStat() { shortStat = GitShortStat() }
             return false
         }
         guard let output = try? await withConnection({
             try await $0.exec(GitCommands.watchProbe(root: gitRoot))
         }), let probe = GitCommands.parseWatchProbe(output) else { return false }
-        let changed = probe.branch != branch
-            || probe.statuses != statuses
-            || probe.shortStat != shortStat
-        branch = probe.branch
-        statuses = probe.statuses
-        shortStat = probe.shortStat
+        var changed = false
+        if branch != probe.branch { branch = probe.branch; changed = true }
+        if statuses != probe.statuses { statuses = probe.statuses; changed = true }
+        if shortStat != probe.shortStat { shortStat = probe.shortStat; changed = true }
         return changed
     }
 
@@ -299,16 +321,17 @@ final class FileViewerController {
                 try await $0.listDirectory(atPath: directory)
             }
             treeFailure = nil
-            let entries = listed.map { entry in
-                let typeBits = (entry.permissions ?? 0) & 0o170000
-                return FileTreeEntry(
+            // Sorted at write time: rows() renders straight from storage
+            // (re-sorting per render is ICU work the tree pays on every
+            // body evaluation), and a stable order also keeps the
+            // compare-before-write below honest against server ordering.
+            let entries = FileTree.sorted(listed.map { entry in
+                FileTreeEntry(
                     name: entry.name,
                     path: FileTree.join(directory, entry.name),
-                    isDirectory: typeBits == 0o040000,
-                    isSymlink: typeBits == 0o120000,
-                    size: entry.size
+                    isDirectory: entry.isDirectory
                 )
-            }
+            })
             // Compare before writing: the watch relists on a cadence, and
             // an identical assignment would still churn observers.
             if childrenByPath[directory] != entries {
@@ -391,9 +414,7 @@ final class FileViewerController {
             defer { isBusy = false }
             await probeGit(at: rootPath)
             await refreshGitVerdicts()
-            for directory in [rootPath] + expanded.sorted() {
-                await list(directory)
-            }
+            await relistVisibleDirectories()
             switch content {
             case .document(let document):
                 await open(path: document.path, line: nil)
@@ -430,26 +451,27 @@ final class FileViewerController {
             }
             let document = try await makeDocument(path: path, line: line, stat: stat)
             guard generation == contentGeneration else { return }
-            switch document {
-            case .success(let document):
-                lastDocument = document
-                watchedStamp = stat
-                content = .document(document)
-            case .failure(let title, let message):
-                content = .failure(title: title, message: message)
-            }
+            lastDocument = document
+            watchedStamp = stat
+            content = .document(document)
         } catch {
             guard generation == contentGeneration else { return }
-            content = .failure(
-                title: "CAN'T READ \(name.uppercased())",
-                message: failureMessage(error)
-            )
+            if let refusal = error as? LoadRefusal {
+                content = .failure(title: refusal.title, message: refusal.message)
+            } else {
+                content = .failure(
+                    title: "CAN'T READ \(name.uppercased())",
+                    message: failureMessage(error)
+                )
+            }
         }
     }
 
-    private enum DocumentResult {
-        case success(Document)
-        case failure(title: String, message: String)
+    /// A refusal the pipeline can title itself (the size cap) — one error
+    /// channel: `makeDocument` throws, callers catch into the panel.
+    private struct LoadRefusal: Error {
+        var title: String
+        var message: String
     }
 
     /// The read → classify → parse/highlight pipeline, shared by the loud
@@ -458,7 +480,7 @@ final class FileViewerController {
         path: String,
         line: Int?,
         stat: SSHConnection.FileStat
-    ) async throws -> DocumentResult {
+    ) async throws -> Document {
         let name = FileTree.name(of: path)
         let size = stat.size ?? 0
         var document = Document(path: path, size: size, kind: FileKind.classify(fileName: name))
@@ -466,10 +488,10 @@ final class FileViewerController {
 
         switch document.kind {
         case .binary:
-            document.isBinary = true
+            break
         case .image:
             guard size <= UInt64(Self.imageByteLimit) else {
-                return .failure(
+                throw LoadRefusal(
                     title: "TOO LARGE",
                     message: "\(name) is \(Self.formatBytes(size)) — the viewer renders images up to \(Self.formatBytes(UInt64(Self.imageByteLimit)))."
                 )
@@ -477,33 +499,56 @@ final class FileViewerController {
             let (data, _) = try await withConnection {
                 try await $0.readFile(atPath: path, limit: Self.imageByteLimit)
             }
-            document.imageData = data
+            // Undecodable "image" bytes are binary content by any honest
+            // reading — same verdict as the NUL sniff below.
+            if let image = UIImage(data: data) {
+                document.image = image
+            } else {
+                document.kind = .binary
+            }
         case .markdown, .code:
             let (data, truncated) = try await withConnection {
                 try await $0.readFile(atPath: path, limit: Self.textByteLimit)
             }
             document.truncated = truncated
             if FileKind.looksBinary(data) {
-                document.isBinary = true
+                document.kind = .binary
                 break
             }
-            let text = String(decoding: data, as: UTF8.self)
-            if document.kind == .markdown, !markdownRaw {
-                document.markdown = await Task.detached {
-                    MarkdownDocument.parse(text)
-                }.value
+            let text = await Task.detached { String(decoding: data, as: UTF8.self) }.value
+            if document.kind == .markdown {
+                document.sourceText = text
+                document = await Self.renderedMarkdown(document, raw: markdownRaw)
             } else {
                 let language: CodeLanguage? = {
                     if case .code(let detected) = document.kind { return detected }
-                    return nil // markdown RAW renders plain
+                    return nil
                 }()
-                document.language = language
                 document.codeLines = await Task.detached {
                     CodeHighlighter.highlight(text, language: language)
                 }.value
             }
         }
-        return .success(document)
+        return document
+    }
+
+    /// Markdown renders both ways from the same held text: blocks when
+    /// rendered, plain lines when RAW.
+    private static func renderedMarkdown(_ document: Document, raw: Bool) async -> Document {
+        var document = document
+        guard let text = document.sourceText else { return document }
+        if raw {
+            document.markdown = []
+            document.codeLines = await Task.detached {
+                CodeHighlighter.highlight(text, language: nil)
+            }.value
+        } else {
+            document.codeLines = []
+            document.markdown = await Task.detached {
+                MarkdownDocument.parse(text)
+            }.value
+        }
+        return document
     }
 
     // MARK: Diff
@@ -524,21 +569,27 @@ final class FileViewerController {
         return String(path.dropFirst(gitRoot.count + 1))
     }
 
+    /// Untracked files diff `--no-index /dev/null` (an all-additions
+    /// render); tracked files diff against HEAD. Both spellings live here
+    /// only — the loud diff and the watch's quiet one share it.
+    private func fileDiffCommand(gitRoot: String, path: String) -> String {
+        let relative = relativeToRepo(path) ?? path
+        return badges[path] == .untracked
+            ? GitCommands.untrackedDiff(root: gitRoot, path: relative)
+            : GitCommands.diffFile(root: gitRoot, path: relative)
+    }
+
     func showFileDiff(path: String) async {
         guard let gitRoot else { return }
         contentGeneration += 1
         let generation = contentGeneration
         let name = FileTree.name(of: path)
-        let relative = relativeToRepo(path) ?? path
         content = .loading(label: "DIFF · \(name)")
         // Baseline the stamp now, so the watch compares against the
         // worktree the diff was cut from — not against nothing.
         watchedStamp = try? await withConnection { try await $0.statFile(atPath: path) }
-        let command = badges[path] == .untracked
-            ? GitCommands.untrackedDiff(root: gitRoot, path: relative)
-            : GitCommands.diffFile(root: gitRoot, path: relative)
         await runDiff(
-            command: command,
+            command: fileDiffCommand(gitRoot: gitRoot, path: path),
             scope: .file(path: path),
             emptyLabel: name,
             generation: generation
@@ -592,10 +643,7 @@ final class FileViewerController {
         case .repo:
             command = GitCommands.fullDiff(root: gitRoot)
         case .file(let path):
-            let relative = relativeToRepo(path) ?? path
-            command = badges[path] == .untracked
-                ? GitCommands.untrackedDiff(root: gitRoot, path: relative)
-                : GitCommands.diffFile(root: gitRoot, path: relative)
+            command = fileDiffCommand(gitRoot: gitRoot, path: path)
         }
         guard let output = try? await withConnection({ try await $0.exec(command) })
         else { return }
@@ -609,13 +657,11 @@ final class FileViewerController {
 
     /// The SOURCE chip: back to the document behind a per-file diff.
     func showSource() {
-        if let lastDocument, case .diff(_, .file(let path)) = content,
-           lastDocument.path == path {
+        guard case .diff(_, .file(let path)) = content else { return }
+        if let lastDocument, lastDocument.path == path {
             contentGeneration += 1
             content = .document(lastDocument)
-            return
-        }
-        if case .diff(_, .file(let path)) = content {
+        } else {
             Task { await open(path: path, line: nil) }
         }
     }
@@ -703,10 +749,9 @@ final class FileViewerController {
         switch content {
         case .document(let current):
             guard !stat.isDirectory,
-                  let result = try? await makeDocument(
+                  let document = try? await makeDocument(
                       path: current.path, line: nil, stat: stat
                   ),
-                  case .success(let document) = result,
                   generation == contentGeneration,
                   case .document(let still) = content, still.path == current.path
             else { return }
@@ -725,16 +770,16 @@ final class FileViewerController {
         if let connectionError = error as? SSHConnectionError {
             switch connectionError {
             case .keyPassphraseRequired, .incorrectKeyPassphrase:
+                // The stock copy asks for the passphrase; the viewer has no
+                // prompt to offer, so point at the two places that can
+                // unlock the key instead.
                 return "The host's key is sealed. Set its passphrase in "
                     + "Host Settings, or open a terminal to this host first."
-            case .missingCredentials:
-                return "No credentials for \(host.name) — check Host Settings."
-            case .connectFailed(let reason):
-                return reason
             case .notConnected:
-                return "The connection dropped. REFRESH dials again."
-            case .unsupportedKey:
-                return "The host's key format isn't supported."
+                return connectionError.userMessage(host: host) + " REFRESH dials again."
+            case .missingCredentials, .unsupportedKey, .connectFailed:
+                // One copy source for connection failures, app-wide.
+                return connectionError.userMessage(host: host)
             }
         }
         let message = "\(error)"

--- a/Multiplex/Services/FileViewerController.swift
+++ b/Multiplex/Services/FileViewerController.swift
@@ -1,0 +1,567 @@
+import Citadel
+import Foundation
+import Observation
+
+/// One file-viewer tab's state: its own SSH connection (dialed lazily,
+/// redialed per operation after suspension — request/response needs no
+/// resume policy), the tree, the git verdicts, and whatever the content
+/// screen is showing. A value sibling of `ViewportController`: lives only
+/// in `TerminalWorkspace` memory (summoned, not restored), never claims
+/// terminal focus, and has no send path into any terminal.
+///
+/// Why its own connection: the probe connection belongs to the deck's
+/// lifecycle (a disabled host must not be revived by a viewer tab), and the
+/// summoning tab's transport moves away from this tab on merge/split — a
+/// tab owning its transport is the app's architecture. SSH remains every
+/// host's control plane, so mosh hosts open viewers the same way.
+@MainActor
+@Observable
+final class FileViewerController {
+    /// Text render cap: the capped head still renders, under a TRUNCATED
+    /// banner. Big enough for every source file that matters; small enough
+    /// that highlighting stays interactive.
+    static let textByteLimit = 1_500_000
+    static let imageByteLimit = 12_000_000
+
+    let tabID: UUID
+    private let host: Host
+    var hostName: String { host.name }
+
+    /// The pane cwd at summon time (absolute), when a pane could answer.
+    private let startDirectory: String?
+    /// The pressed path this tab was summoned to show, when it was.
+    private let target: TerminalPathTarget?
+
+    init(
+        tabID: UUID,
+        host: Host,
+        startDirectory: String?,
+        target: TerminalPathTarget?
+    ) {
+        self.tabID = tabID
+        self.host = host
+        self.startDirectory = startDirectory
+        self.target = target
+    }
+
+    // MARK: Content
+
+    struct Document: Equatable {
+        var path: String
+        var size: UInt64
+        var kind: FileRenderKind
+        var language: CodeLanguage?
+        var isBinary = false
+        var truncated = false
+        /// Code (and markdown RAW) render.
+        var codeLines: [HighlightedLine] = []
+        /// Markdown rendered blocks.
+        var markdown: [MarkdownBlock] = []
+        var imageData: Data?
+        /// From a `path:12` press — the code view scrolls here once.
+        var targetLine: Int?
+
+        var name: String { FileTree.name(of: path) }
+    }
+
+    enum DiffScope: Equatable {
+        case file(path: String)
+        case repo
+    }
+
+    enum Content {
+        /// Nothing selected yet — the tree is the subject.
+        case idle
+        case loading(label: String)
+        case document(Document)
+        case diff(GitDiff, scope: DiffScope)
+        case failure(title: String, message: String)
+    }
+
+    private(set) var content: Content = .idle
+    /// The document behind a per-file DIFF, so SOURCE flips back without a
+    /// round trip.
+    private(set) var lastDocument: Document?
+    /// Markdown RAW toggle — kept across files (a preference, not a mode).
+    var markdownRaw = false {
+        didSet {
+            guard markdownRaw != oldValue,
+                  let document = lastDocument, document.kind == .markdown,
+                  case .document = content
+            else { return }
+            Task { await open(path: document.path, line: nil) }
+        }
+    }
+
+    // MARK: Tree
+
+    private(set) var rootPath = ""
+    private(set) var homePath: String?
+    private(set) var gitRoot: String?
+    private(set) var branch: String?
+    private(set) var shortStat = GitShortStat()
+    private(set) var statuses: [GitFileStatus] = []
+    private(set) var childrenByPath: [String: [FileTreeEntry]] = [:]
+    private(set) var expanded: Set<String> = []
+    private(set) var pendingListings: Set<String> = []
+    var changedFilter = false
+    private(set) var treeFailure: String?
+    private(set) var isBusy = false
+
+    var badges: [String: GitFileStatus.Badge] {
+        guard let gitRoot else { return [:] }
+        return FileTree.badges(statuses: statuses, repoRoot: gitRoot)
+    }
+
+    var treeRows: [FileTree.Row] {
+        if changedFilter, let gitRoot {
+            return FileTree.changedRows(statuses: statuses, repoRoot: gitRoot)
+        }
+        let changedDirectories = gitRoot.map {
+            FileTree.changedDirectories(statuses: statuses, repoRoot: $0)
+        } ?? []
+        return FileTree.rows(
+            root: rootPath,
+            children: childrenByPath,
+            expanded: expanded,
+            badges: badges,
+            changedDirectories: changedDirectories
+        )
+    }
+
+    /// The tab cell / UMD label: the file on screen, else the room.
+    var displayName: String {
+        switch content {
+        case .document(let document): document.name
+        case .diff(_, .repo): "DIFF"
+        case .diff(_, .file(let path)): FileTree.name(of: path)
+        default: rootPath.isEmpty ? "FILES" : FileTree.name(of: rootPath)
+        }
+    }
+
+    /// The rail readout: where the screen actually is.
+    var railPath: String {
+        switch content {
+        case .document(let document): document.path
+        case .diff(_, .file(let path)): path
+        case .diff(_, .repo): gitRoot ?? rootPath
+        default: rootPath
+        }
+    }
+
+    // MARK: Connection
+
+    @ObservationIgnored private var connection: SSHConnection?
+
+    private func liveConnection() async throws -> (SSHConnection, fresh: Bool) {
+        if let connection { return (connection, false) }
+        let secrets = await HostSecrets.loadOffMain(for: host)
+        let dialed = SSHConnection(host: host, secrets: secrets)
+        try await dialed.connect()
+        connection = dialed
+        return (dialed, true)
+    }
+
+    /// Run one operation, redialing once when a *reused* connection turns
+    /// out to be a suspension corpse. An SFTP status error means the server
+    /// answered — never a reason to redial.
+    private func withConnection<T: Sendable>(
+        _ body: @Sendable (SSHConnection) async throws -> T
+    ) async throws -> T {
+        let (link, fresh) = try await liveConnection()
+        do {
+            return try await body(link)
+        } catch {
+            guard !fresh, !(error is SFTPError), !(error is CancellationError)
+            else { throw error }
+            connection = nil
+            Task { await link.close() }
+            let (redialed, _) = try await liveConnection()
+            return try await body(redialed)
+        }
+    }
+
+    func shutdown() {
+        let dying = connection
+        connection = nil
+        Task { await dying?.close() }
+    }
+
+    // MARK: Boot
+
+    /// One-shot boot from the pane's `.task`: resolve the anchor, probe
+    /// git, list the tree, open the pressed file if there is one.
+    func start() async {
+        guard rootPath.isEmpty else { return }
+        isBusy = true
+        defer { isBusy = false }
+        content = .loading(label: target?.path ?? startDirectory ?? "~")
+        do {
+            let home = try await withConnection { try await $0.remoteHomeDirectory() }
+            homePath = home
+            let base = startDirectory ?? home
+
+            var resolvedTarget: String?
+            if let target {
+                let joined: String
+                switch target.base {
+                case .absolute: joined = target.path
+                case .home: joined = FileTree.join(home, target.relativePart)
+                case .workingDirectory: joined = FileTree.join(base, target.relativePart)
+                }
+                // Canonicalize ../ and symlinked segments where the server
+                // cooperates; the joined spelling is the honest fallback.
+                resolvedTarget = (try? await withConnection {
+                    try await $0.canonicalPath(atPath: joined)
+                }) ?? joined
+            }
+
+            let anchor = resolvedTarget.map { FileTree.parent(of: $0) ?? "/" } ?? base
+            await probeGit(at: anchor)
+            rootPath = gitRoot ?? anchor
+            await list(rootPath)
+            expandChain(to: anchor)
+            await refreshGitVerdicts()
+
+            if let resolvedTarget {
+                await open(path: resolvedTarget, line: target?.line)
+            } else {
+                content = .idle
+            }
+        } catch {
+            content = .failure(
+                title: "NO CONNECTION",
+                message: failureMessage(error)
+            )
+        }
+    }
+
+    // MARK: Git
+
+    private func probeGit(at path: String) async {
+        gitRoot = nil
+        branch = nil
+        guard let output = try? await withConnection({
+            try await $0.exec(GitCommands.repoProbe(path: path))
+        }) else { return }
+        let (body, exit) = GitCommands.splitExit(output)
+        guard exit == 0 else { return }
+        let parsed = GitCommands.parseRepoProbe(body: body)
+        gitRoot = parsed.toplevel
+        branch = parsed.branch
+    }
+
+    private func refreshGitVerdicts() async {
+        guard let gitRoot else {
+            statuses = []
+            shortStat = GitShortStat()
+            return
+        }
+        if let output = try? await withConnection({
+            try await $0.exec(GitCommands.status(root: gitRoot))
+        }) {
+            let (body, exit) = GitCommands.splitExit(output)
+            statuses = exit == 0 ? GitFileStatus.parse(porcelainZ: body) : []
+        }
+        if let output = try? await withConnection({
+            try await $0.exec(GitCommands.shortstat(root: gitRoot))
+        }) {
+            let (body, exit) = GitCommands.splitExit(output)
+            shortStat = exit == 0 ? GitShortStat.parse(body) : GitShortStat()
+        }
+    }
+
+    // MARK: Tree operations
+
+    private func list(_ directory: String) async {
+        guard !pendingListings.contains(directory) else { return }
+        pendingListings.insert(directory)
+        defer { pendingListings.remove(directory) }
+        do {
+            let listed = try await withConnection {
+                try await $0.listDirectory(atPath: directory)
+            }
+            treeFailure = nil
+            childrenByPath[directory] = listed.map { entry in
+                let typeBits = (entry.permissions ?? 0) & 0o170000
+                return FileTreeEntry(
+                    name: entry.name,
+                    path: FileTree.join(directory, entry.name),
+                    isDirectory: typeBits == 0o040000,
+                    isSymlink: typeBits == 0o120000,
+                    size: entry.size
+                )
+            }
+        } catch {
+            treeFailure = failureMessage(error)
+        }
+    }
+
+    /// True when `path` lives under `directory` (or is it) — a component-
+    /// boundary check, because "/repo2".hasPrefix("/repo") lies.
+    private static func path(_ path: String, isUnder directory: String) -> Bool {
+        path == directory || directory == "/" || path.hasPrefix(directory + "/")
+    }
+
+    /// Expand every directory between the root and `path`, listing as
+    /// needed — how a pressed file's row becomes visible.
+    private func expandChain(to path: String) {
+        var chain: [String] = []
+        var cursor: String? = path
+        while let current = cursor, current != rootPath,
+              Self.path(current, isUnder: rootPath) {
+            chain.append(current)
+            cursor = FileTree.parent(of: current)
+        }
+        guard cursor == rootPath else { return }
+        for directory in chain.reversed() {
+            expanded.insert(directory)
+            Task { await list(directory) }
+        }
+    }
+
+    func toggleExpand(_ entry: FileTreeEntry) {
+        guard entry.isDirectory else { return }
+        if expanded.contains(entry.path) {
+            expanded.remove(entry.path)
+        } else {
+            expanded.insert(entry.path)
+            if childrenByPath[entry.path] == nil {
+                Task { await list(entry.path) }
+            }
+        }
+    }
+
+    func select(_ row: FileTree.Row) {
+        if row.entry.isDirectory {
+            toggleExpand(row.entry)
+            return
+        }
+        // A deleted file has no working-tree bytes — its diff IS the file.
+        if badges[row.entry.path] == .deleted {
+            Task { await showFileDiff(path: row.entry.path) }
+            return
+        }
+        Task { await open(path: row.entry.path, line: nil) }
+    }
+
+    /// The tree header's UP chip: hoist the root one directory.
+    func hoistRoot() {
+        guard let parent = FileTree.parent(of: rootPath) else { return }
+        let previousRoot = rootPath
+        rootPath = parent
+        expanded.insert(previousRoot)
+        Task {
+            if childrenByPath[parent] == nil { await list(parent) }
+            // Leaving the repo's roof means the git verdicts no longer
+            // describe the root on screen; a new probe answers honestly.
+            if let gitRoot, !Self.path(parent, isUnder: gitRoot) {
+                await probeGit(at: parent)
+                await refreshGitVerdicts()
+            }
+        }
+    }
+
+    func refresh() {
+        guard !isBusy else { return }
+        Task {
+            isBusy = true
+            defer { isBusy = false }
+            await probeGit(at: rootPath)
+            await refreshGitVerdicts()
+            for directory in [rootPath] + expanded.sorted() {
+                await list(directory)
+            }
+            switch content {
+            case .document(let document):
+                await open(path: document.path, line: nil)
+            case .diff(_, .file(let path)):
+                await showFileDiff(path: path)
+            case .diff(_, .repo):
+                await showRepoDiff()
+            default:
+                break
+            }
+        }
+    }
+
+    // MARK: Opening files
+
+    func open(path: String, line: Int?) async {
+        let name = FileTree.name(of: path)
+        content = .loading(label: name)
+        do {
+            let stat = try await withConnection { try await $0.statFile(atPath: path) }
+            if stat.isDirectory {
+                // A directory "opens" in the tree, not the screen. The
+                // phantom child makes expandChain include `path` itself.
+                if Self.path(path, isUnder: rootPath) {
+                    expandChain(to: FileTree.join(path, "."))
+                } else {
+                    rootPath = path
+                    await list(path)
+                }
+                content = .idle
+                return
+            }
+            let size = stat.size ?? 0
+            var document = Document(path: path, size: size, kind: FileKind.classify(fileName: name))
+            document.targetLine = line
+
+            switch document.kind {
+            case .binary:
+                document.isBinary = true
+            case .image:
+                guard size <= UInt64(Self.imageByteLimit) else {
+                    content = .failure(
+                        title: "TOO LARGE",
+                        message: "\(name) is \(Self.formatBytes(size)) — the viewer renders images up to \(Self.formatBytes(UInt64(Self.imageByteLimit)))."
+                    )
+                    return
+                }
+                let (data, _) = try await withConnection {
+                    try await $0.readFile(atPath: path, limit: Self.imageByteLimit)
+                }
+                document.imageData = data
+            case .markdown, .code:
+                let (data, truncated) = try await withConnection {
+                    try await $0.readFile(atPath: path, limit: Self.textByteLimit)
+                }
+                document.truncated = truncated
+                if FileKind.looksBinary(data) {
+                    document.isBinary = true
+                    break
+                }
+                let text = String(decoding: data, as: UTF8.self)
+                if document.kind == .markdown, !markdownRaw {
+                    document.markdown = await Task.detached {
+                        MarkdownDocument.parse(text)
+                    }.value
+                } else {
+                    let language: CodeLanguage? = {
+                        if case .code(let detected) = document.kind { return detected }
+                        return nil // markdown RAW renders plain
+                    }()
+                    document.language = language
+                    document.codeLines = await Task.detached {
+                        CodeHighlighter.highlight(text, language: language)
+                    }.value
+                }
+            }
+            lastDocument = document
+            content = .document(document)
+        } catch {
+            content = .failure(
+                title: "CAN'T READ \(name.uppercased())",
+                message: failureMessage(error)
+            )
+        }
+    }
+
+    // MARK: Diff
+
+    /// SOURCE | DIFF applies when git has a verdict for the file on screen.
+    /// Badges key by absolute path, and both content cases carry one.
+    var documentDiffBadge: GitFileStatus.Badge? {
+        guard gitRoot != nil else { return nil }
+        switch content {
+        case .document(let document): return badges[document.path]
+        case .diff(_, .file(let path)): return badges[path]
+        default: return nil
+        }
+    }
+
+    private func relativeToRepo(_ path: String) -> String? {
+        guard let gitRoot, path.hasPrefix(gitRoot + "/") else { return nil }
+        return String(path.dropFirst(gitRoot.count + 1))
+    }
+
+    func showFileDiff(path: String) async {
+        guard let gitRoot else { return }
+        let name = FileTree.name(of: path)
+        let relative = relativeToRepo(path) ?? path
+        content = .loading(label: "DIFF · \(name)")
+        let command = badges[path] == .untracked
+            ? GitCommands.untrackedDiff(root: gitRoot, path: relative)
+            : GitCommands.diffFile(root: gitRoot, path: relative)
+        await runDiff(command: command, scope: .file(path: path), emptyLabel: name)
+    }
+
+    func showRepoDiff() async {
+        guard let gitRoot else { return }
+        content = .loading(label: "DIFF")
+        await runDiff(
+            command: GitCommands.fullDiff(root: gitRoot),
+            scope: .repo,
+            emptyLabel: FileTree.name(of: gitRoot)
+        )
+    }
+
+    private func runDiff(command: String, scope: DiffScope, emptyLabel: String) async {
+        do {
+            let output = try await withConnection { try await $0.exec(command) }
+            let (body, _) = GitCommands.splitExit(output)
+            // --no-index exits 1 whenever sides differ; the body is the
+            // verdict that matters.
+            let diff = await Task.detached { GitDiff.parse(body) }.value
+            content = .diff(diff, scope: scope)
+        } catch {
+            content = .failure(
+                title: "CAN'T DIFF \(emptyLabel.uppercased())",
+                message: failureMessage(error)
+            )
+        }
+    }
+
+    /// The SOURCE chip: back to the document behind a per-file diff.
+    func showSource() {
+        if let lastDocument, case .diff(_, .file(let path)) = content,
+           lastDocument.path == path {
+            content = .document(lastDocument)
+            return
+        }
+        if case .diff(_, .file(let path)) = content {
+            Task { await open(path: path, line: nil) }
+        }
+    }
+
+    // MARK: Failure copy
+
+    private func failureMessage(_ error: Error) -> String {
+        if let connectionError = error as? SSHConnectionError {
+            switch connectionError {
+            case .keyPassphraseRequired, .incorrectKeyPassphrase:
+                return "The host's key is sealed. Set its passphrase in "
+                    + "Host Settings, or open a terminal to this host first."
+            case .missingCredentials:
+                return "No credentials for \(host.name) — check Host Settings."
+            case .connectFailed(let reason):
+                return reason
+            case .notConnected:
+                return "The connection dropped. REFRESH dials again."
+            case .unsupportedKey:
+                return "The host's key format isn't supported."
+            }
+        }
+        let message = "\(error)"
+        if message.localizedCaseInsensitiveContains("no such file") {
+            return "The host says there is no such file."
+        }
+        if message.localizedCaseInsensitiveContains("permission denied") {
+            return "The host refused: permission denied."
+        }
+        return message
+    }
+
+    static func formatBytes(_ bytes: UInt64) -> String {
+        let units = ["B", "KB", "MB", "GB"]
+        var value = Double(bytes)
+        var unit = 0
+        while value >= 1000, unit < units.count - 1 {
+            value /= 1000
+            unit += 1
+        }
+        let digits = value >= 100 || unit == 0 ? 0 : 1
+        return String(format: "%.\(digits)f %@", value, units[unit])
+    }
+}

--- a/Multiplex/Services/FileViewerController.swift
+++ b/Multiplex/Services/FileViewerController.swift
@@ -32,6 +32,11 @@ final class FileViewerController {
     private let startDirectory: String?
     /// The pressed path this tab was summoned to show, when it was.
     private let target: TerminalPathTarget?
+    /// True when the tab was summoned to BROWSE (+ TAB ▸ File Viewer)
+    /// rather than to show a specific pressed file — the tree is the
+    /// subject until a file is chosen, so the compact drawer opens itself
+    /// and picking the first file costs one tap, not two.
+    let opensBrowsing: Bool
 
     init(
         tabID: UUID,
@@ -43,6 +48,7 @@ final class FileViewerController {
         self.host = host
         self.startDirectory = startDirectory
         self.target = target
+        self.opensBrowsing = target == nil
     }
 
     // MARK: Content

--- a/Multiplex/Services/FileViewerController.swift
+++ b/Multiplex/Services/FileViewerController.swift
@@ -1,6 +1,7 @@
 import Citadel
 import Foundation
 import Observation
+import UIKit
 
 /// One file-viewer tab's state: its own SSH connection (dialed lazily,
 /// redialed per operation after suspension — request/response needs no
@@ -82,6 +83,14 @@ final class FileViewerController {
     /// The document behind a per-file DIFF, so SOURCE flips back without a
     /// round trip.
     private(set) var lastDocument: Document?
+    /// Bumped by every user-driven content change (open, diff, source,
+    /// refresh) — a quiet watch update finishing late must never clobber
+    /// what the person navigated to since.
+    private var contentGeneration = 0
+    /// (size, mtime) of the path the watch is minding — the open document,
+    /// or the worktree side of a per-file diff.
+    private var watchedStamp: SSHConnection.FileStat?
+    private var watchTickCount = 0
     /// Markdown RAW toggle — kept across files (a preference, not a mode).
     var markdownRaw = false {
         didSet {
@@ -251,24 +260,26 @@ final class FileViewerController {
         branch = parsed.branch
     }
 
-    private func refreshGitVerdicts() async {
+    /// One `watchProbe` round trip refreshes branch, statuses, and the ±
+    /// counts together — the refresh path and the watch tick share it.
+    /// Returns whether anything actually moved.
+    @discardableResult
+    private func refreshGitVerdicts() async -> Bool {
         guard let gitRoot else {
             statuses = []
             shortStat = GitShortStat()
-            return
+            return false
         }
-        if let output = try? await withConnection({
-            try await $0.exec(GitCommands.status(root: gitRoot))
-        }) {
-            let (body, exit) = GitCommands.splitExit(output)
-            statuses = exit == 0 ? GitFileStatus.parse(porcelainZ: body) : []
-        }
-        if let output = try? await withConnection({
-            try await $0.exec(GitCommands.shortstat(root: gitRoot))
-        }) {
-            let (body, exit) = GitCommands.splitExit(output)
-            shortStat = exit == 0 ? GitShortStat.parse(body) : GitShortStat()
-        }
+        guard let output = try? await withConnection({
+            try await $0.exec(GitCommands.watchProbe(root: gitRoot))
+        }), let probe = GitCommands.parseWatchProbe(output) else { return false }
+        let changed = probe.branch != branch
+            || probe.statuses != statuses
+            || probe.shortStat != shortStat
+        branch = probe.branch
+        statuses = probe.statuses
+        shortStat = probe.shortStat
+        return changed
     }
 
     // MARK: Tree operations
@@ -282,7 +293,7 @@ final class FileViewerController {
                 try await $0.listDirectory(atPath: directory)
             }
             treeFailure = nil
-            childrenByPath[directory] = listed.map { entry in
+            let entries = listed.map { entry in
                 let typeBits = (entry.permissions ?? 0) & 0o170000
                 return FileTreeEntry(
                     name: entry.name,
@@ -291,6 +302,11 @@ final class FileViewerController {
                     isSymlink: typeBits == 0o120000,
                     size: entry.size
                 )
+            }
+            // Compare before writing: the watch relists on a cadence, and
+            // an identical assignment would still churn observers.
+            if childrenByPath[directory] != entries {
+                childrenByPath[directory] = entries
             }
         } catch {
             treeFailure = failureMessage(error)
@@ -389,6 +405,8 @@ final class FileViewerController {
 
     func open(path: String, line: Int?) async {
         let name = FileTree.name(of: path)
+        contentGeneration += 1
+        let generation = contentGeneration
         content = .loading(label: name)
         do {
             let stat = try await withConnection { try await $0.statFile(atPath: path) }
@@ -401,61 +419,85 @@ final class FileViewerController {
                     rootPath = path
                     await list(path)
                 }
-                content = .idle
+                if generation == contentGeneration { content = .idle }
                 return
             }
-            let size = stat.size ?? 0
-            var document = Document(path: path, size: size, kind: FileKind.classify(fileName: name))
-            document.targetLine = line
-
-            switch document.kind {
-            case .binary:
-                document.isBinary = true
-            case .image:
-                guard size <= UInt64(Self.imageByteLimit) else {
-                    content = .failure(
-                        title: "TOO LARGE",
-                        message: "\(name) is \(Self.formatBytes(size)) — the viewer renders images up to \(Self.formatBytes(UInt64(Self.imageByteLimit)))."
-                    )
-                    return
-                }
-                let (data, _) = try await withConnection {
-                    try await $0.readFile(atPath: path, limit: Self.imageByteLimit)
-                }
-                document.imageData = data
-            case .markdown, .code:
-                let (data, truncated) = try await withConnection {
-                    try await $0.readFile(atPath: path, limit: Self.textByteLimit)
-                }
-                document.truncated = truncated
-                if FileKind.looksBinary(data) {
-                    document.isBinary = true
-                    break
-                }
-                let text = String(decoding: data, as: UTF8.self)
-                if document.kind == .markdown, !markdownRaw {
-                    document.markdown = await Task.detached {
-                        MarkdownDocument.parse(text)
-                    }.value
-                } else {
-                    let language: CodeLanguage? = {
-                        if case .code(let detected) = document.kind { return detected }
-                        return nil // markdown RAW renders plain
-                    }()
-                    document.language = language
-                    document.codeLines = await Task.detached {
-                        CodeHighlighter.highlight(text, language: language)
-                    }.value
-                }
+            let document = try await makeDocument(path: path, line: line, stat: stat)
+            guard generation == contentGeneration else { return }
+            switch document {
+            case .success(let document):
+                lastDocument = document
+                watchedStamp = stat
+                content = .document(document)
+            case .failure(let title, let message):
+                content = .failure(title: title, message: message)
             }
-            lastDocument = document
-            content = .document(document)
         } catch {
+            guard generation == contentGeneration else { return }
             content = .failure(
                 title: "CAN'T READ \(name.uppercased())",
                 message: failureMessage(error)
             )
         }
+    }
+
+    private enum DocumentResult {
+        case success(Document)
+        case failure(title: String, message: String)
+    }
+
+    /// The read → classify → parse/highlight pipeline, shared by the loud
+    /// open above and the watch's quiet rebuild.
+    private func makeDocument(
+        path: String,
+        line: Int?,
+        stat: SSHConnection.FileStat
+    ) async throws -> DocumentResult {
+        let name = FileTree.name(of: path)
+        let size = stat.size ?? 0
+        var document = Document(path: path, size: size, kind: FileKind.classify(fileName: name))
+        document.targetLine = line
+
+        switch document.kind {
+        case .binary:
+            document.isBinary = true
+        case .image:
+            guard size <= UInt64(Self.imageByteLimit) else {
+                return .failure(
+                    title: "TOO LARGE",
+                    message: "\(name) is \(Self.formatBytes(size)) — the viewer renders images up to \(Self.formatBytes(UInt64(Self.imageByteLimit)))."
+                )
+            }
+            let (data, _) = try await withConnection {
+                try await $0.readFile(atPath: path, limit: Self.imageByteLimit)
+            }
+            document.imageData = data
+        case .markdown, .code:
+            let (data, truncated) = try await withConnection {
+                try await $0.readFile(atPath: path, limit: Self.textByteLimit)
+            }
+            document.truncated = truncated
+            if FileKind.looksBinary(data) {
+                document.isBinary = true
+                break
+            }
+            let text = String(decoding: data, as: UTF8.self)
+            if document.kind == .markdown, !markdownRaw {
+                document.markdown = await Task.detached {
+                    MarkdownDocument.parse(text)
+                }.value
+            } else {
+                let language: CodeLanguage? = {
+                    if case .code(let detected) = document.kind { return detected }
+                    return nil // markdown RAW renders plain
+                }()
+                document.language = language
+                document.codeLines = await Task.detached {
+                    CodeHighlighter.highlight(text, language: language)
+                }.value
+            }
+        }
+        return .success(document)
     }
 
     // MARK: Diff
@@ -478,34 +520,55 @@ final class FileViewerController {
 
     func showFileDiff(path: String) async {
         guard let gitRoot else { return }
+        contentGeneration += 1
+        let generation = contentGeneration
         let name = FileTree.name(of: path)
         let relative = relativeToRepo(path) ?? path
         content = .loading(label: "DIFF · \(name)")
+        // Baseline the stamp now, so the watch compares against the
+        // worktree the diff was cut from — not against nothing.
+        watchedStamp = try? await withConnection { try await $0.statFile(atPath: path) }
         let command = badges[path] == .untracked
             ? GitCommands.untrackedDiff(root: gitRoot, path: relative)
             : GitCommands.diffFile(root: gitRoot, path: relative)
-        await runDiff(command: command, scope: .file(path: path), emptyLabel: name)
+        await runDiff(
+            command: command,
+            scope: .file(path: path),
+            emptyLabel: name,
+            generation: generation
+        )
     }
 
     func showRepoDiff() async {
         guard let gitRoot else { return }
+        contentGeneration += 1
+        let generation = contentGeneration
+        watchedStamp = nil
         content = .loading(label: "DIFF")
         await runDiff(
             command: GitCommands.fullDiff(root: gitRoot),
             scope: .repo,
-            emptyLabel: FileTree.name(of: gitRoot)
+            emptyLabel: FileTree.name(of: gitRoot),
+            generation: generation
         )
     }
 
-    private func runDiff(command: String, scope: DiffScope, emptyLabel: String) async {
+    private func runDiff(
+        command: String,
+        scope: DiffScope,
+        emptyLabel: String,
+        generation: Int
+    ) async {
         do {
             let output = try await withConnection { try await $0.exec(command) }
             let (body, _) = GitCommands.splitExit(output)
             // --no-index exits 1 whenever sides differ; the body is the
             // verdict that matters.
             let diff = await Task.detached { GitDiff.parse(body) }.value
+            guard generation == contentGeneration else { return }
             content = .diff(diff, scope: scope)
         } catch {
+            guard generation == contentGeneration else { return }
             content = .failure(
                 title: "CAN'T DIFF \(emptyLabel.uppercased())",
                 message: failureMessage(error)
@@ -513,15 +576,140 @@ final class FileViewerController {
         }
     }
 
+    /// The watch's diff refresh: recompute whatever diff is on screen and
+    /// swap it in place — no .loading, no scroll reset, and a stale result
+    /// (the person navigated meanwhile) is dropped on the floor.
+    private func refreshDiffQuietly(generation: Int) async {
+        guard let gitRoot, case .diff(_, let scope) = content else { return }
+        let command: String
+        switch scope {
+        case .repo:
+            command = GitCommands.fullDiff(root: gitRoot)
+        case .file(let path):
+            let relative = relativeToRepo(path) ?? path
+            command = badges[path] == .untracked
+                ? GitCommands.untrackedDiff(root: gitRoot, path: relative)
+                : GitCommands.diffFile(root: gitRoot, path: relative)
+        }
+        guard let output = try? await withConnection({ try await $0.exec(command) })
+        else { return }
+        let (body, _) = GitCommands.splitExit(output)
+        let diff = await Task.detached { GitDiff.parse(body) }.value
+        guard generation == contentGeneration,
+              case .diff(_, let still) = content, still == scope
+        else { return }
+        content = .diff(diff, scope: scope)
+    }
+
     /// The SOURCE chip: back to the document behind a per-file diff.
     func showSource() {
         if let lastDocument, case .diff(_, .file(let path)) = content,
            lastDocument.path == path {
+            contentGeneration += 1
             content = .document(lastDocument)
             return
         }
         if case .diff(_, .file(let path)) = content {
             Task { await open(path: path, line: nil) }
+        }
+    }
+
+    // MARK: Watch
+
+    /// Run by the pane while this tab is the window's ACTIVE tab — the
+    /// deck's own cadence and gates: a 5 s tick, network work only while
+    /// the app is frontmost-active, and an obscured tab ticks not at all
+    /// (the pane's task cancels). Each tick costs one git round trip
+    /// (`watchProbe`) plus one stat on the watched path; everything it
+    /// learns lands as a quiet swap — no .loading, no scroll reset.
+    func watchWhileActive() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled else { return }
+            await watchTick()
+        }
+    }
+
+    /// The path whose bytes the current screen shows: the open document,
+    /// or the worktree side of a per-file diff. Repo diffs and idle
+    /// screens watch git state alone.
+    private var watchedContentPath: String? {
+        switch content {
+        case .document(let document): return document.path
+        case .diff(_, .file(let path)): return path
+        default: return nil
+        }
+    }
+
+    private func watchTick() async {
+        guard UIApplication.shared.applicationState == .active,
+              !isBusy, !rootPath.isEmpty else { return }
+        if case .loading = content { return }
+        watchTickCount += 1
+        let generation = contentGeneration
+
+        var gitChanged = false
+        if gitRoot != nil {
+            gitChanged = await refreshGitVerdicts()
+        }
+        if gitChanged {
+            await relistVisibleDirectories()
+            await refreshDiffQuietly(generation: generation)
+        } else if watchTickCount.isMultiple(of: 3) {
+            // Ignored files and non-repo directories change without a
+            // porcelain verdict; a slower sweep keeps the tree honest.
+            await relistVisibleDirectories()
+        }
+
+        guard generation == contentGeneration,
+              let path = watchedContentPath else { return }
+        do {
+            let stat = try await withConnection { try await $0.statFile(atPath: path) }
+            guard stat != watchedStamp else { return }
+            watchedStamp = stat
+            await reloadWatchedContent(generation: generation, stat: stat)
+        } catch {
+            // A transport blip must not tear the screen down; only the
+            // server's own verdict that the file is gone is worth acting
+            // on, and only for a document (a deleted file's diff IS the
+            // record of the deletion).
+            if error is SFTPError,
+               generation == contentGeneration,
+               case .document(let document) = content {
+                content = .failure(
+                    title: "FILE GONE",
+                    message: "The host says \(document.name) no longer exists."
+                )
+            }
+        }
+    }
+
+    private func relistVisibleDirectories() async {
+        for directory in Set([rootPath]).union(expanded).sorted() {
+            await list(directory)
+        }
+    }
+
+    private func reloadWatchedContent(
+        generation: Int,
+        stat: SSHConnection.FileStat
+    ) async {
+        switch content {
+        case .document(let current):
+            guard !stat.isDirectory,
+                  let result = try? await makeDocument(
+                      path: current.path, line: nil, stat: stat
+                  ),
+                  case .success(let document) = result,
+                  generation == contentGeneration,
+                  case .document(let still) = content, still.path == current.path
+            else { return }
+            lastDocument = document
+            content = .document(document)
+        case .diff:
+            await refreshDiffQuietly(generation: generation)
+        default:
+            break
         }
     }
 

--- a/Multiplex/Services/GitCommands.swift
+++ b/Multiplex/Services/GitCommands.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Command builders for the file viewer's git reads — pure string assembly,
+/// unit-tested, same discipline as `TmuxProbe`: every path rides as one
+/// shell-quoted argv, stderr is silenced, and the command always exits 0
+/// (Citadel's `executeCommand` throws on a nonzero exit) while the REAL
+/// exit code trails the output behind a sentinel, so "not a repo" and
+/// "empty diff" stay distinguishable.
+///
+/// `-c core.quotepath=false` keeps non-ASCII paths as raw UTF-8 instead of
+/// octal escapes; controls still quote, which `GitDiffFile.unquote` handles.
+/// `--no-ext-diff` ensures a host's configured diff tool can never run under
+/// an app-initiated read.
+enum GitCommands {
+    static let exitSentinel = "\nMPXFV_EXIT:"
+
+    /// `(body, exitCode)` from a sentinel-tailed command's output. The
+    /// sentinel is the final thing the command prints, so the LAST
+    /// occurrence is always ours; a missing sentinel reports nil (the exec
+    /// channel itself failed mid-stream).
+    static func splitExit(_ output: String) -> (body: String, exit: Int?) {
+        if let range = output.range(of: exitSentinel, options: .backwards) {
+            let code = Int(
+                output[range.upperBound...]
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            return (String(output[..<range.lowerBound]), code)
+        }
+        // An empty body puts the sentinel — minus its leading newline — at
+        // the very start.
+        let bare = String(exitSentinel.dropFirst())
+        if output.hasPrefix(bare) {
+            let code = Int(
+                output.dropFirst(bare.count)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            return ("", code)
+        }
+        return (output, nil)
+    }
+
+    private static func tailed(_ command: String) -> String {
+        TmuxProbe.pathPrefix + command + " 2>/dev/null; printf '\\nMPXFV_EXIT:%s' \"$?\""
+    }
+
+    private static func git(_ root: String, _ arguments: String) -> String {
+        "git -C \(root.shellQuoted) -c core.quotepath=false \(arguments)"
+    }
+
+    /// Repo root and branch in one round trip. The two queries are
+    /// independently silenced on purpose: an unborn HEAD (fresh repo, no
+    /// commit yet) fails `--abbrev-ref HEAD` while `--show-toplevel` still
+    /// answers, and the toplevel is the verdict that matters. Body line 1 is
+    /// the toplevel, line 2 is `MPXFV_BR:<branch>`; exit ≠ 0 means "not
+    /// inside a work tree".
+    static let branchSentinel = "MPXFV_BR:"
+
+    static func repoProbe(path: String) -> String {
+        let quoted = path.shellQuoted
+        return TmuxProbe.pathPrefix
+            + "t=$(git -C \(quoted) rev-parse --show-toplevel 2>/dev/null); s=$?; "
+            + "b=$(git -C \(quoted) rev-parse --abbrev-ref HEAD 2>/dev/null); "
+            + "printf '%s\\n\(branchSentinel)%s' \"$t\" \"$b\"; "
+            + "printf '\\nMPXFV_EXIT:%s' \"$s\""
+    }
+
+    /// `(toplevel, branch)` out of `repoProbe`'s body. Branch is nil when
+    /// empty (unborn HEAD) or `HEAD` (detached — the header shows the word
+    /// only when git itself would).
+    static func parseRepoProbe(body: String) -> (toplevel: String?, branch: String?) {
+        var toplevel: String?
+        var branch: String?
+        for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+            if line.hasPrefix(branchSentinel) {
+                let value = String(line.dropFirst(branchSentinel.count))
+                branch = value.isEmpty ? nil : value
+            } else if toplevel == nil, line.hasPrefix("/") {
+                toplevel = String(line)
+            }
+        }
+        return (toplevel, branch)
+    }
+
+    static func status(root: String) -> String {
+        tailed(git(root, "status --porcelain=v1 -z --untracked-files=normal"))
+    }
+
+    /// The tree header's ± counts. `HEAD --` so staged and unstaged changes
+    /// both count; prints nothing on a clean tree.
+    static func shortstat(root: String) -> String {
+        tailed(git(root, "diff --shortstat --no-ext-diff HEAD --"))
+    }
+
+    /// One file's uncommitted changes (staged + unstaged) vs HEAD.
+    static func diffFile(root: String, path: String) -> String {
+        tailed(git(root, "diff --no-color --no-ext-diff HEAD -- \(path.shellQuoted)"))
+    }
+
+    /// The whole working tree vs HEAD — the review surface.
+    static func fullDiff(root: String) -> String {
+        tailed(git(root, "diff --no-color --no-ext-diff HEAD --"))
+    }
+
+    /// An untracked file rendered as an all-additions diff. `--no-index`
+    /// exits 1 whenever the sides differ — routine here, which is exactly
+    /// why the sentinel carries the code instead of the channel failing.
+    static func untrackedDiff(root: String, path: String) -> String {
+        tailed(git(root, "diff --no-color --no-ext-diff --no-index -- /dev/null \(path.shellQuoted)"))
+    }
+}

--- a/Multiplex/Services/GitCommands.swift
+++ b/Multiplex/Services/GitCommands.swift
@@ -12,7 +12,13 @@ import Foundation
 /// `--no-ext-diff` ensures a host's configured diff tool can never run under
 /// an app-initiated read.
 enum GitCommands {
-    static let exitSentinel = "\nMPXFV_EXIT:"
+    /// Every sentinel is spelled ONCE as a bare token and interpolated into
+    /// both the builders and the parser-side constants — a hand-respelled
+    /// copy desynchronizing them would read as "channel failed" at runtime.
+    private static let exitToken = "MPXFV_EXIT:"
+    private static let statToken = "MPXFV_STAT:"
+
+    static let exitSentinel = "\n" + exitToken
 
     /// `(body, exitCode)` from a sentinel-tailed command's output. The
     /// sentinel is the final thing the command prints, so the LAST
@@ -40,7 +46,7 @@ enum GitCommands {
     }
 
     private static func tailed(_ command: String) -> String {
-        TmuxProbe.pathPrefix + command + " 2>/dev/null; printf '\\nMPXFV_EXIT:%s' \"$?\""
+        TmuxProbe.pathPrefix + command + " 2>/dev/null; printf '\\n\(exitToken)%s' \"$?\""
     }
 
     private static func git(_ root: String, _ arguments: String) -> String {
@@ -61,7 +67,7 @@ enum GitCommands {
             + "t=$(git -C \(quoted) rev-parse --show-toplevel 2>/dev/null); s=$?; "
             + "b=$(git -C \(quoted) rev-parse --abbrev-ref HEAD 2>/dev/null); "
             + "printf '%s\\n\(branchSentinel)%s' \"$t\" \"$b\"; "
-            + "printf '\\nMPXFV_EXIT:%s' \"$s\""
+            + "printf '\\n\(exitToken)%s' \"$s\""
     }
 
     /// `(toplevel, branch)` out of `repoProbe`'s body. Branch is nil when
@@ -81,16 +87,12 @@ enum GitCommands {
         return (toplevel, branch)
     }
 
-    static func status(root: String) -> String {
-        tailed(git(root, "status --porcelain=v1 -z --untracked-files=normal"))
-    }
-
-    /// The watch tick's whole git read in ONE round trip — branch, porcelain
-    /// status, and shortstat, sentinel-framed (the deck's one-exec probe
-    /// discipline; a 5 s cadence must not cost three channel setups).
+    /// The whole git read — branch, porcelain status, and shortstat — in ONE
+    /// round trip, sentinel-framed (the deck's one-exec probe discipline; the
+    /// watch's 5 s cadence must not cost three channel setups).
     /// Layout: `MPXFV_BR:<branch>\n<status -z bytes>\nMPXFV_STAT:<shortstat>`
     /// then the usual exit sentinel carrying the STATUS command's code.
-    static let watchStatSentinel = "\nMPXFV_STAT:"
+    static let watchStatSentinel = "\n" + statToken
 
     static func watchProbe(root: String) -> String {
         let quoted = root.shellQuoted
@@ -99,9 +101,9 @@ enum GitCommands {
             + "\"$(git -C \(quoted) rev-parse --abbrev-ref HEAD 2>/dev/null)\"; "
             + "git -C \(quoted) -c core.quotepath=false status --porcelain=v1 -z"
             + " --untracked-files=normal 2>/dev/null; s=$?; "
-            + "printf '\\nMPXFV_STAT:'; "
+            + "printf '\\n\(statToken)'; "
             + "git -C \(quoted) diff --shortstat --no-ext-diff HEAD -- 2>/dev/null; "
-            + "printf '\\nMPXFV_EXIT:%s' \"$s\""
+            + "printf '\\n\(exitToken)%s' \"$s\""
     }
 
     struct WatchProbe: Equatable {
@@ -129,12 +131,6 @@ enum GitCommands {
             statuses: GitFileStatus.parse(porcelainZ: String(statusBytes)),
             shortStat: shortStat
         )
-    }
-
-    /// The tree header's ± counts. `HEAD --` so staged and unstaged changes
-    /// both count; prints nothing on a clean tree.
-    static func shortstat(root: String) -> String {
-        tailed(git(root, "diff --shortstat --no-ext-diff HEAD --"))
     }
 
     /// One file's uncommitted changes (staged + unstaged) vs HEAD.

--- a/Multiplex/Services/GitCommands.swift
+++ b/Multiplex/Services/GitCommands.swift
@@ -85,6 +85,52 @@ enum GitCommands {
         tailed(git(root, "status --porcelain=v1 -z --untracked-files=normal"))
     }
 
+    /// The watch tick's whole git read in ONE round trip — branch, porcelain
+    /// status, and shortstat, sentinel-framed (the deck's one-exec probe
+    /// discipline; a 5 s cadence must not cost three channel setups).
+    /// Layout: `MPXFV_BR:<branch>\n<status -z bytes>\nMPXFV_STAT:<shortstat>`
+    /// then the usual exit sentinel carrying the STATUS command's code.
+    static let watchStatSentinel = "\nMPXFV_STAT:"
+
+    static func watchProbe(root: String) -> String {
+        let quoted = root.shellQuoted
+        return TmuxProbe.pathPrefix
+            + "printf '\(branchSentinel)%s\\n' "
+            + "\"$(git -C \(quoted) rev-parse --abbrev-ref HEAD 2>/dev/null)\"; "
+            + "git -C \(quoted) -c core.quotepath=false status --porcelain=v1 -z"
+            + " --untracked-files=normal 2>/dev/null; s=$?; "
+            + "printf '\\nMPXFV_STAT:'; "
+            + "git -C \(quoted) diff --shortstat --no-ext-diff HEAD -- 2>/dev/null; "
+            + "printf '\\nMPXFV_EXIT:%s' \"$s\""
+    }
+
+    struct WatchProbe: Equatable {
+        var branch: String?
+        var statuses: [GitFileStatus]
+        var shortStat: GitShortStat
+    }
+
+    /// nil when the status command failed (not a repo anymore, git gone).
+    /// Both sentinels are matched from the back — they are the last things
+    /// printed, and a -z filename could theoretically embed lookalikes.
+    static func parseWatchProbe(_ output: String) -> WatchProbe? {
+        let (body, exit) = splitExit(output)
+        guard exit == 0 else { return nil }
+        guard let statRange = body.range(of: watchStatSentinel, options: .backwards)
+        else { return nil }
+        let shortStat = GitShortStat.parse(String(body[statRange.upperBound...]))
+        let head = body[..<statRange.lowerBound]
+        guard head.hasPrefix(branchSentinel) else { return nil }
+        let afterSentinel = head.dropFirst(branchSentinel.count)
+        let branchLine = afterSentinel.prefix(while: { $0 != "\n" })
+        let statusBytes = afterSentinel.dropFirst(branchLine.count).dropFirst()
+        return WatchProbe(
+            branch: branchLine.isEmpty ? nil : String(branchLine),
+            statuses: GitFileStatus.parse(porcelainZ: String(statusBytes)),
+            shortStat: shortStat
+        )
+    }
+
     /// The tree header's ± counts. `HEAD --` so staged and unstaged changes
     /// both count; prints nothing on a clean tree.
     static func shortstat(root: String) -> String {

--- a/Multiplex/Services/SSHConnection.swift
+++ b/Multiplex/Services/SSHConnection.swift
@@ -484,6 +484,101 @@ actor SSHConnection {
         }
     }
 
+    // MARK: SFTP (file viewer)
+
+    /// One remote directory entry as SFTP reported it — a transport-side
+    /// value so Citadel types never cross into Models. `permissions` carry
+    /// the S_IFMT type bits; readdir has lstat semantics, so a symlink
+    /// reports itself (the viewer stats on select to follow it).
+    struct DirectoryEntry: Sendable {
+        var name: String
+        var size: UInt64?
+        var permissions: UInt32?
+    }
+
+    struct FileStat: Sendable {
+        var size: UInt64?
+        var permissions: UInt32?
+
+        var isDirectory: Bool {
+            permissions.map { ($0 & 0o170000) == 0o040000 } ?? false
+        }
+    }
+
+    func listDirectory(atPath path: String) async throws -> [DirectoryEntry] {
+        guard let client else { throw SSHConnectionError.notConnected }
+        return try await client.withSFTP { sftp in
+            var entries: [DirectoryEntry] = []
+            for name in try await sftp.listDirectory(atPath: path) {
+                for component in name.components {
+                    let filename = component.filename
+                    guard filename != "." && filename != ".." else { continue }
+                    entries.append(DirectoryEntry(
+                        name: filename,
+                        size: component.attributes.size,
+                        permissions: component.attributes.permissions
+                    ))
+                }
+            }
+            return entries
+        }
+    }
+
+    /// SFTP `stat` — follows symlinks, which is exactly what selecting a
+    /// tree row needs (a linked directory navigates, a linked file opens).
+    func statFile(atPath path: String) async throws -> FileStat {
+        guard let client else { throw SSHConnectionError.notConnected }
+        return try await client.withSFTP { sftp in
+            let attributes = try await sftp.getAttributes(at: path)
+            return FileStat(size: attributes.size, permissions: attributes.permissions)
+        }
+    }
+
+    func canonicalPath(atPath path: String) async throws -> String {
+        guard let client else { throw SSHConnectionError.notConnected }
+        return try await client.withSFTP { sftp in
+            try await sftp.getRealPath(atPath: path)
+        }
+    }
+
+    /// Read up to `limit` bytes. One SFTP READ is server-capped (commonly
+    /// 32–64 KB), so this loops chunks; an empty chunk is EOF. `truncated`
+    /// reports whether the file continued past the limit.
+    func readFile(
+        atPath path: String,
+        limit: Int
+    ) async throws -> (data: Data, truncated: Bool) {
+        guard let client else { throw SSHConnectionError.notConnected }
+        return try await client.withSFTP { sftp in
+            let file = try await sftp.openFile(filePath: path, flags: .read)
+            do {
+                var data = Data()
+                let chunkSize: UInt32 = 128 * 1024
+                var truncated = false
+                while data.count <= limit {
+                    var buffer = try await file.read(
+                        from: UInt64(data.count),
+                        length: chunkSize
+                    )
+                    guard buffer.readableBytes > 0 else { break }
+                    if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+                        data.append(contentsOf: bytes)
+                    }
+                    if data.count > limit {
+                        data = data.prefix(limit)
+                        truncated = true
+                        break
+                    }
+                }
+                try await file.close()
+                return (data, truncated)
+            } catch {
+                try? await file.close()
+                throw error
+            }
+        }
+    }
+
     // MARK: Interactive PTY shell
 
     /// Opens a PTY'd login shell. When `command` is set (tmux attach/create),

--- a/Multiplex/Services/SSHConnection.swift
+++ b/Multiplex/Services/SSHConnection.swift
@@ -496,9 +496,12 @@ actor SSHConnection {
         var permissions: UInt32?
     }
 
-    struct FileStat: Sendable {
+    struct FileStat: Sendable, Equatable {
         var size: UInt64?
         var permissions: UInt32?
+        /// SFTP v3 mtime is whole seconds — good enough for the viewer's
+        /// change watch (paired with size).
+        var modified: Date?
 
         var isDirectory: Bool {
             permissions.map { ($0 & 0o170000) == 0o040000 } ?? false
@@ -530,7 +533,11 @@ actor SSHConnection {
         guard let client else { throw SSHConnectionError.notConnected }
         return try await client.withSFTP { sftp in
             let attributes = try await sftp.getAttributes(at: path)
-            return FileStat(size: attributes.size, permissions: attributes.permissions)
+            return FileStat(
+                size: attributes.size,
+                permissions: attributes.permissions,
+                modified: attributes.accessModificationTime?.modificationTime
+            )
         }
     }
 

--- a/Multiplex/Services/SSHConnection.swift
+++ b/Multiplex/Services/SSHConnection.swift
@@ -492,8 +492,9 @@ actor SSHConnection {
     /// reports itself (the viewer stats on select to follow it).
     struct DirectoryEntry: Sendable {
         var name: String
-        var size: UInt64?
         var permissions: UInt32?
+
+        var isDirectory: Bool { isDirectoryMode(permissions) }
     }
 
     struct FileStat: Sendable, Equatable {
@@ -503,9 +504,12 @@ actor SSHConnection {
         /// change watch (paired with size).
         var modified: Date?
 
-        var isDirectory: Bool {
-            permissions.map { ($0 & 0o170000) == 0o040000 } ?? false
-        }
+        var isDirectory: Bool { isDirectoryMode(permissions) }
+    }
+
+    /// The one S_IFMT read — both entry types answer through it.
+    private static func isDirectoryMode(_ permissions: UInt32?) -> Bool {
+        permissions.map { ($0 & 0o170000) == 0o040000 } ?? false
     }
 
     func listDirectory(atPath path: String) async throws -> [DirectoryEntry] {
@@ -518,7 +522,6 @@ actor SSHConnection {
                     guard filename != "." && filename != ".." else { continue }
                     entries.append(DirectoryEntry(
                         name: filename,
-                        size: component.attributes.size,
                         permissions: component.attributes.permissions
                     ))
                 }
@@ -549,8 +552,12 @@ actor SSHConnection {
     }
 
     /// Read up to `limit` bytes. One SFTP READ is server-capped (commonly
-    /// 32–64 KB), so this loops chunks; an empty chunk is EOF. `truncated`
-    /// reports whether the file continued past the limit.
+    /// 32–64 KB) and costs a full round trip, so chunks at precomputed
+    /// offsets are requested concurrently — request IDs are per-call and
+    /// outstanding READs on one handle are protocol-legal (OpenSSH's own
+    /// sftp client keeps dozens in flight); a serialized walk pays
+    /// size ÷ grant round trips, seconds of latency on a megabyte file.
+    /// `truncated` reports whether the file continued past the limit.
     func readFile(
         atPath path: String,
         limit: Int
@@ -559,31 +566,88 @@ actor SSHConnection {
         return try await client.withSFTP { sftp in
             let file = try await sftp.openFile(filePath: path, flags: .read)
             do {
-                var data = Data()
-                let chunkSize: UInt32 = 128 * 1024
-                var truncated = false
-                while data.count <= limit {
-                    var buffer = try await file.read(
-                        from: UInt64(data.count),
-                        length: chunkSize
-                    )
-                    guard buffer.readableBytes > 0 else { break }
-                    if let bytes = buffer.readBytes(length: buffer.readableBytes) {
-                        data.append(contentsOf: bytes)
-                    }
-                    if data.count > limit {
-                        data = data.prefix(limit)
-                        truncated = true
-                        break
-                    }
-                }
+                let size = try await file.readAttributes().size
+                let result = try await Self.readChunks(of: file, size: size, limit: limit)
                 try await file.close()
-                return (data, truncated)
+                return result
             } catch {
                 try? await file.close()
                 throw error
             }
         }
+    }
+
+    private static let readChunkSize = 128 * 1024
+    private static let readsInFlight = 6
+
+    /// Fill one fixed slice: loops because a single READ may legally return
+    /// less than asked. A short result means EOF landed inside the slice.
+    private static func readChunk(
+        _ file: SFTPFile, offset: Int, length: Int
+    ) async throws -> Data {
+        var data = Data()
+        while data.count < length {
+            var buffer = try await file.read(
+                from: UInt64(offset + data.count),
+                length: UInt32(length - data.count)
+            )
+            guard buffer.readableBytes > 0,
+                  let piece = buffer.readData(length: buffer.readableBytes)
+            else { break }
+            data.append(piece)
+        }
+        return data
+    }
+
+    /// `limit + 1` is the read target — the one extra byte answers "did the
+    /// file continue?" without reading the rest. With the server-reported
+    /// size in hand the chunk plan is fixed up front and a bounded window
+    /// keeps `readsInFlight` requests going; assembly stops at the first
+    /// short chunk (the file shrank underneath us — the watch's next stat
+    /// reconciles). A server that reports no size gets the sequential walk.
+    private static func readChunks(
+        of file: SFTPFile, size: UInt64?, limit: Int
+    ) async throws -> (data: Data, truncated: Bool) {
+        let wanted = limit + 1
+        var data = Data()
+        if let size {
+            let total = Int(min(size, UInt64(wanted)))
+            let offsets = Array(stride(from: 0, to: total, by: readChunkSize))
+            var chunks = [Data?](repeating: nil, count: offsets.count)
+            try await withThrowingTaskGroup(of: (Int, Data).self) { group in
+                var next = 0
+                func addNext() {
+                    let offset = offsets[next]
+                    let length = min(readChunkSize, total - offset)
+                    let index = next
+                    group.addTask {
+                        (index, try await readChunk(file, offset: offset, length: length))
+                    }
+                    next += 1
+                }
+                while next < offsets.count, next < readsInFlight { addNext() }
+                while let (index, chunk) = try await group.next() {
+                    chunks[index] = chunk
+                    if next < offsets.count { addNext() }
+                }
+            }
+            for (index, chunk) in chunks.enumerated() {
+                guard let chunk else { break }
+                data.append(chunk)
+                let planned = min(readChunkSize, total - offsets[index])
+                if chunk.count < planned { break }
+            }
+        } else {
+            while data.count < wanted {
+                let length = min(readChunkSize, wanted - data.count)
+                let chunk = try await readChunk(file, offset: data.count, length: length)
+                data.append(chunk)
+                if chunk.count < length { break }
+            }
+        }
+        let truncated = data.count > limit
+        if truncated { data = data.prefix(limit) }
+        return (data, truncated)
     }
 
     // MARK: Interactive PTY shell

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -157,6 +157,10 @@ final class TerminalSessionController {
     /// pane never opens one straight from the gesture: the target is remote
     /// output, so the destination is shown first (see `TerminalLink`).
     private(set) var pendingLink: TerminalLink?
+    /// A filesystem path activated the same way, awaiting the file-viewer
+    /// confirmation — the path twin of `pendingLink` (see
+    /// `TerminalPathTarget`). Same discipline: shown, never followed.
+    private(set) var pendingPath: TerminalPathTarget?
 
     #if !os(visionOS)
     /// The rail's dictation key, from the pane's side: LISTENING while the
@@ -1408,16 +1412,24 @@ final class TerminalSessionController {
     // MARK: Links
 
     /// A link the terminal resolved under a tap or long press. Returns
-    /// whether this pane claims the gesture — declining lets it fall through
-    /// to selection, which is what a filesystem path (implicit detection
-    /// matches those too) must keep doing.
+    /// whether this pane claims the gesture. URLs confirm through the link
+    /// sheet; path-shaped text (implicit detection matches those too) now
+    /// confirms through the file-viewer sheet instead of falling to
+    /// selection; only what neither resolver accepts ($VAR/…, colon prose)
+    /// still declines into text selection.
     func activateLink(_ target: String) -> Bool {
         // The jump search owns the pane's input while it pages and its veil
         // covers the text being pressed — same rule as a drop.
         if case .finding = historyJump { return false }
-        guard let link = TerminalLink.resolve(target) else { return false }
-        pendingLink = link
-        return true
+        if let link = TerminalLink.resolve(target) {
+            pendingLink = link
+            return true
+        }
+        if let path = TerminalPathTarget.resolve(target) {
+            pendingPath = path
+            return true
+        }
+        return false
     }
 
     /// Hands the confirmed target to the system. Only an allowlisted scheme
@@ -1439,6 +1451,30 @@ final class TerminalSessionController {
 
     func dismissPendingLink() {
         pendingLink = nil
+    }
+
+    func copyPendingPath() {
+        guard let path = pendingPath else { return }
+        UIPasteboard.general.string = path.raw
+        pendingPath = nil
+    }
+
+    func dismissPendingPath() {
+        pendingPath = nil
+    }
+
+    /// The pane's cwd for the file viewer's anchor — the same `list-panes`
+    /// truth drops resolve (the first `/`-prefixed line; the MULTIPLEX_GIT
+    /// marker is ignored here). nil when no pane can answer: a plain shell,
+    /// a mosh tab (no exec surface), or a dead transport.
+    func paneWorkingDirectory() async -> String? {
+        guard let sessionName = route.sessionName, let connection else { return nil }
+        let output = (try? await connection.exec(
+            TmuxProbe.dropDestinationCommand(sessionName: sessionName)
+        )) ?? ""
+        return output.split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { $0.hasPrefix("/") }
     }
 
     // MARK: Actions

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -153,14 +153,26 @@ final class TerminalSessionController {
     private(set) var dropState: DropState?
     private var dropTask: Task<Void, Never>?
     private var dropClearTask: Task<Void, Never>?
-    /// A link the user activated in this pane, awaiting confirmation. The
-    /// pane never opens one straight from the gesture: the target is remote
-    /// output, so the destination is shown first (see `TerminalLink`).
-    private(set) var pendingLink: TerminalLink?
-    /// A filesystem path activated the same way, awaiting the file-viewer
-    /// confirmation — the path twin of `pendingLink` (see
-    /// `TerminalPathTarget`). Same discipline: shown, never followed.
-    private(set) var pendingPath: TerminalPathTarget?
+    /// The target the user activated in this pane, awaiting confirmation.
+    /// The pane never opens one straight from the gesture: the target is
+    /// remote output, so the destination is shown first (see `TerminalLink`
+    /// / `TerminalPathTarget`). ONE slot for both kinds — the link sheet and
+    /// the path sheet structurally cannot contend for the same press.
+    private enum PendingActivation {
+        case link(TerminalLink)
+        case path(TerminalPathTarget)
+    }
+    private var pendingActivation: PendingActivation?
+
+    var pendingLink: TerminalLink? {
+        if case .link(let link) = pendingActivation { return link }
+        return nil
+    }
+
+    var pendingPath: TerminalPathTarget? {
+        if case .path(let path) = pendingActivation { return path }
+        return nil
+    }
 
     #if !os(visionOS)
     /// The rail's dictation key, from the pane's side: LISTENING while the
@@ -1385,10 +1397,9 @@ final class TerminalSessionController {
             let output = (try? await connection.exec(
                 TmuxProbe.dropDestinationCommand(sessionName: sessionName)
             )) ?? ""
-            let lines = output.split(separator: "\n")
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-            if let path = lines.first(where: { $0.hasPrefix("/") }) {
-                if lines.contains("MULTIPLEX_GIT") {
+            let destination = TmuxProbe.parseDropDestination(output)
+            if let path = destination.cwd {
+                if destination.insideGitWorktree {
                     return DropDestination(
                         directory: path + "/" + DropText.dropsDirectoryName,
                         typedPrefix: DropText.dropsDirectoryName + "/",
@@ -1422,11 +1433,11 @@ final class TerminalSessionController {
         // covers the text being pressed — same rule as a drop.
         if case .finding = historyJump { return false }
         if let link = TerminalLink.resolve(target) {
-            pendingLink = link
+            pendingActivation = .link(link)
             return true
         }
         if let path = TerminalPathTarget.resolve(target) {
-            pendingPath = path
+            pendingActivation = .path(path)
             return true
         }
         return false
@@ -1437,7 +1448,7 @@ final class TerminalSessionController {
     /// offers OPEN for `.openable`.
     func openPendingLink() {
         guard let url = pendingLink?.openableURL else { return }
-        pendingLink = nil
+        pendingActivation = nil
         UIApplication.shared.open(url)
     }
 
@@ -1446,21 +1457,21 @@ final class TerminalSessionController {
     func copyPendingLink() {
         guard let link = pendingLink else { return }
         UIPasteboard.general.string = link.raw
-        pendingLink = nil
+        pendingActivation = nil
     }
 
     func dismissPendingLink() {
-        pendingLink = nil
+        if case .link = pendingActivation { pendingActivation = nil }
     }
 
     func copyPendingPath() {
         guard let path = pendingPath else { return }
         UIPasteboard.general.string = path.raw
-        pendingPath = nil
+        pendingActivation = nil
     }
 
     func dismissPendingPath() {
-        pendingPath = nil
+        if case .path = pendingActivation { pendingActivation = nil }
     }
 
     /// The pane's cwd for the file viewer's anchor — the same `list-panes`
@@ -1472,9 +1483,7 @@ final class TerminalSessionController {
         let output = (try? await connection.exec(
             TmuxProbe.dropDestinationCommand(sessionName: sessionName)
         )) ?? ""
-        return output.split(separator: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .first { $0.hasPrefix("/") }
+        return TmuxProbe.parseDropDestination(output).cwd
     }
 
     // MARK: Actions

--- a/Multiplex/Services/TerminalWorkspace.swift
+++ b/Multiplex/Services/TerminalWorkspace.swift
@@ -2,6 +2,22 @@ import Foundation
 import Observation
 import UIKit
 
+/// What every auxiliary (non-terminal) pane controller owes the window
+/// system: a live tab label and a teardown. Construction stays per-type —
+/// a viewport takes an admitted offer, a file viewer a start directory —
+/// but lookup, label, and close dispatch through this one seam, so
+/// `syncTabs`' restored-corpse strip, the tab strip's titles, and
+/// `closeTab` don't grow per-type branches when the next auxiliary pane
+/// type arrives (missing the strip branch would leave an invisible zombie
+/// tab; missing close would leak the pane's resources).
+@MainActor
+protocol AuxiliaryPaneController: AnyObject {
+    /// The live tab-cell/UMD label (mark + subject) — follows what the pane
+    /// is showing NOW, where the route only knows the summons.
+    var tabLabel: String { get }
+    func shutdown()
+}
+
 /// App-wide terminal state that outlives any single window scene:
 ///
 /// - **Controllers** are keyed by tab id and owned here, not by window views,
@@ -79,39 +95,27 @@ final class TerminalWorkspace {
         controllers[tabID]
     }
 
-    // MARK: Viewport controllers (one per ⌗ tab)
+    // MARK: Auxiliary controllers (one per ⌗ / ▤ tab)
 
-    /// Transport-less controllers for viewport tabs, keyed like terminal
-    /// controllers so merge/split re-parent the live page the same way.
-    /// Deliberately in-memory only — this dictionary *is* the viewport's
-    /// no-persistence rule: `TerminalWindowRoot.syncTabs` strips any viewport
-    /// tab it cannot find here, which is exactly a tab restored from a dead
-    /// process. Summoned, not restored.
-    private var viewportControllers: [UUID: ViewportController] = [:]
+    /// Transport-less controllers for auxiliary tabs, keyed like terminal
+    /// controllers so merge/split re-parent the live pane the same way.
+    /// Deliberately in-memory only — this dictionary *is* the auxiliary
+    /// no-persistence rule: `TerminalWindowRoot.syncTabs` strips any
+    /// auxiliary tab it cannot find here, which is exactly a tab restored
+    /// from a dead process. Summoned, not restored.
+    private var auxiliaryControllers: [UUID: any AuxiliaryPaneController] = [:]
 
     /// Register the controller BEFORE the tab enters any route — the strip
-    /// above runs on every tabs change, and a viewport tab that arrives
+    /// above runs on every tabs change, and an auxiliary tab that arrives
     /// without its controller is indistinguishable from a restored corpse.
     func openViewport(tab: TerminalRoute, offer: ViewportOffer, host: Host) {
-        guard tab.isViewport, viewportControllers[tab.id] == nil else { return }
-        viewportControllers[tab.id] = ViewportController(
+        guard tab.isViewport, auxiliaryControllers[tab.id] == nil else { return }
+        auxiliaryControllers[tab.id] = ViewportController(
             tabID: tab.id,
             offer: offer,
             host: host
         )
     }
-
-    func viewportController(for tabID: UUID) -> ViewportController? {
-        viewportControllers[tabID]
-    }
-
-    // MARK: File-viewer controllers (one per ▤ tab)
-
-    /// Same lifecycle as viewport controllers: in-memory only (this
-    /// dictionary IS the no-persistence rule), registered BEFORE the tab
-    /// enters any route so `syncTabs` never mistakes a fresh summon for a
-    /// restored corpse.
-    private var fileViewerControllers: [UUID: FileViewerController] = [:]
 
     func openFileViewer(
         tab: TerminalRoute,
@@ -119,8 +123,8 @@ final class TerminalWorkspace {
         startDirectory: String?,
         target: TerminalPathTarget?
     ) {
-        guard tab.isFileViewer, fileViewerControllers[tab.id] == nil else { return }
-        fileViewerControllers[tab.id] = FileViewerController(
+        guard tab.isFileViewer, auxiliaryControllers[tab.id] == nil else { return }
+        auxiliaryControllers[tab.id] = FileViewerController(
             tabID: tab.id,
             host: host,
             startDirectory: startDirectory,
@@ -128,17 +132,26 @@ final class TerminalWorkspace {
         )
     }
 
-    func fileViewerController(for tabID: UUID) -> FileViewerController? {
-        fileViewerControllers[tabID]
+    /// The general question — "does this auxiliary tab have a live pane,
+    /// and what does it call itself" — for the strip and the tab titles.
+    func auxiliaryController(for tabID: UUID) -> (any AuxiliaryPaneController)? {
+        auxiliaryControllers[tabID]
     }
 
-    /// Close a tab for real: detach the SSH channel (or shut the viewport's
-    /// web view / file viewer's connection down) and drop the controller.
-    /// Never called when a tab merely moves.
+    func viewportController(for tabID: UUID) -> ViewportController? {
+        auxiliaryControllers[tabID] as? ViewportController
+    }
+
+    func fileViewerController(for tabID: UUID) -> FileViewerController? {
+        auxiliaryControllers[tabID] as? FileViewerController
+    }
+
+    /// Close a tab for real: detach the SSH channel (or shut the auxiliary
+    /// pane down) and drop the controller. Never called when a tab merely
+    /// moves.
     func closeTab(_ tabID: UUID) {
         controllers.removeValue(forKey: tabID)?.detach()
-        viewportControllers.removeValue(forKey: tabID)?.shutdown()
-        fileViewerControllers.removeValue(forKey: tabID)?.shutdown()
+        auxiliaryControllers.removeValue(forKey: tabID)?.shutdown()
     }
 
     func resumeConnectionsWaitingForKeyPassphrase(hostID: UUID) {

--- a/Multiplex/Services/TerminalWorkspace.swift
+++ b/Multiplex/Services/TerminalWorkspace.swift
@@ -105,12 +105,40 @@ final class TerminalWorkspace {
         viewportControllers[tabID]
     }
 
+    // MARK: File-viewer controllers (one per ▤ tab)
+
+    /// Same lifecycle as viewport controllers: in-memory only (this
+    /// dictionary IS the no-persistence rule), registered BEFORE the tab
+    /// enters any route so `syncTabs` never mistakes a fresh summon for a
+    /// restored corpse.
+    private var fileViewerControllers: [UUID: FileViewerController] = [:]
+
+    func openFileViewer(
+        tab: TerminalRoute,
+        host: Host,
+        startDirectory: String?,
+        target: TerminalPathTarget?
+    ) {
+        guard tab.isFileViewer, fileViewerControllers[tab.id] == nil else { return }
+        fileViewerControllers[tab.id] = FileViewerController(
+            tabID: tab.id,
+            host: host,
+            startDirectory: startDirectory,
+            target: target
+        )
+    }
+
+    func fileViewerController(for tabID: UUID) -> FileViewerController? {
+        fileViewerControllers[tabID]
+    }
+
     /// Close a tab for real: detach the SSH channel (or shut the viewport's
-    /// web view down) and drop the controller. Never called when a tab
-    /// merely moves.
+    /// web view / file viewer's connection down) and drop the controller.
+    /// Never called when a tab merely moves.
     func closeTab(_ tabID: UUID) {
         controllers.removeValue(forKey: tabID)?.detach()
         viewportControllers.removeValue(forKey: tabID)?.shutdown()
+        fileViewerControllers.removeValue(forKey: tabID)?.shutdown()
     }
 
     func resumeConnectionsWaitingForKeyPassphrase(hostID: UUID) {

--- a/Multiplex/Services/TmuxProbe.swift
+++ b/Multiplex/Services/TmuxProbe.swift
@@ -383,7 +383,24 @@ enum TmuxProbe {
             + "printf '%s\\n' \"$p\"; "
             + "if [ -n \"$p\" ] && command -v git >/dev/null 2>&1"
             + " && [ \"$(git -C \"$p\" rev-parse --is-inside-work-tree 2>/dev/null)\" = true ]; "
-            + "then echo MULTIPLEX_GIT; fi"
+            + "then echo \(gitWorktreeMarker); fi"
+    }
+
+    private static let gitWorktreeMarker = "MULTIPLEX_GIT"
+
+    /// `dropDestinationCommand` output → the active pane's cwd (the first
+    /// `/`-prefixed line; nil when no pane answered) and whether it sits
+    /// inside a git worktree. Shared by file drops and the file viewer's
+    /// cwd anchor — the wire format has exactly one parser.
+    static func parseDropDestination(
+        _ output: String
+    ) -> (cwd: String?, insideGitWorktree: Bool) {
+        let lines = output.split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        return (
+            lines.first { $0.hasPrefix("/") },
+            lines.contains(gitWorktreeMarker)
+        )
     }
 
     // MARK: - New sessions (the window's + TAB button, the deck tile's quick options)

--- a/Multiplex/Services/ViewportController.swift
+++ b/Multiplex/Services/ViewportController.swift
@@ -19,7 +19,7 @@ import WebKit
 /// restored") falls out of their absence after a relaunch.
 @MainActor
 @Observable
-final class ViewportController {
+final class ViewportController: AuxiliaryPaneController {
     let tabID: UUID
     /// The confirmation that admitted this page.
     let offer: ViewportOffer
@@ -128,6 +128,8 @@ final class ViewportController {
     /// The rail's readout: current host emphasized by the view; falls back
     /// to the confirmed offer before the first commit.
     var displayURL: URL { currentURL ?? offer.url }
+
+    var tabLabel: String { TerminalRoute.viewportLabel(displayURL.absoluteString) }
 
     func reload() {
         failure = nil

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -284,17 +284,7 @@ struct FileViewerPane: View {
     private func imageBody(_ document: FileViewerController.Document, data: Data) -> some View {
         Group {
             if let image = UIImage(data: data) {
-                ScrollView([.vertical, .horizontal]) {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(
-                            maxWidth: max(80, min(image.size.width, 1600)),
-                            maxHeight: max(80, min(image.size.height, 1600))
-                        )
-                        .padding(18)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                FileViewerImageView(image: image)
             } else {
                 failurePanel(
                     title: "CAN'T DECODE",
@@ -488,6 +478,107 @@ enum CodePalette {
             result = AttributedString(" ")
         }
         return result
+    }
+}
+
+// MARK: - Image view
+
+/// Fit-to-screen with pinch zoom. 1 = aspect-fit inside the visible
+/// screen; pinch scales 0.25–8× around that baseline (double-tap toggles
+/// fit ↔ 2×), and the surrounding ScrollView owns panning once the image
+/// outgrows the viewport. The zoom readout is TALLY state — captioned,
+/// tappable to reset — and appears only away from fit.
+private struct FileViewerImageView: View {
+    let image: UIImage
+
+    @State private var zoom: CGFloat = 1
+    /// Transient pinch factor; committed into `zoom` when the gesture ends.
+    @State private var pinch: CGFloat = 1
+
+    private static let range: ClosedRange<CGFloat> = 0.25...8
+
+    var body: some View {
+        GeometryReader { geometry in
+            let fitted = fittedSize(in: geometry.size)
+            let scale = min(max(zoom * pinch, Self.range.lowerBound), Self.range.upperBound)
+            ScrollView([.vertical, .horizontal], showsIndicators: false) {
+                Image(uiImage: image)
+                    .resizable()
+                    .frame(
+                        width: fitted.width * scale,
+                        height: fitted.height * scale
+                    )
+                    // Centers the image while it is smaller than the
+                    // viewport; once it outgrows it, these floors are inert
+                    // and the scroll view pans.
+                    .frame(
+                        minWidth: geometry.size.width,
+                        minHeight: geometry.size.height
+                    )
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            // Simultaneous, or the scroll view's pan starves the pinch.
+            .simultaneousGesture(magnify)
+            .onTapGesture(count: 2) {
+                withAnimation(.easeOut(duration: 0.18)) {
+                    zoom = zoom == 1 ? 2 : 1
+                }
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if scale != 1 {
+                    Button {
+                        withAnimation(.easeOut(duration: 0.18)) { zoom = 1 }
+                        pinch = 1
+                    } label: {
+                        ChassisLabel("\(Int((scale * 100).rounded()))% · FIT", size: 8)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .background(Theme.bezel)
+                            .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .chassisHover(2)
+                    .padding(10)
+                    .accessibilityLabel("Zoom \(Int((scale * 100).rounded())) percent; resets to fit")
+                }
+            }
+        }
+        .background(Theme.screen)
+        .accessibilityLabel("Image, pinch to zoom")
+    }
+
+    private var magnify: some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                pinch = value.magnification
+            }
+            .onEnded { value in
+                zoom = min(
+                    max(zoom * value.magnification, Self.range.lowerBound),
+                    Self.range.upperBound
+                )
+                pinch = 1
+            }
+    }
+
+    /// Aspect-fit inside the viewport, with breathing room; zoom multiplies
+    /// this baseline so 100% always means "fits the screen".
+    private func fittedSize(in container: CGSize) -> CGSize {
+        let available = CGSize(
+            width: max(40, container.width - 24),
+            height: max(40, container.height - 24)
+        )
+        let size = image.size
+        guard size.width > 0, size.height > 0 else { return available }
+        let ratio = min(
+            available.width / size.width,
+            available.height / size.height,
+            // Small images render at natural size instead of blowing up
+            // to fill a wall-sized window.
+            1
+        )
+        return CGSize(width: size.width * ratio, height: size.height * ratio)
     }
 }
 

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -14,6 +14,9 @@ import SwiftUI
 struct FileViewerPane: View {
     @Bindable var controller: FileViewerController
     var contentSafeArea = EdgeInsets()
+    /// The window's active tab is the only one that watches: an obscured
+    /// pane spends no network on a screen nobody sees (the wall's rule).
+    var isActive = true
     let close: () -> Void
 
     /// The standing column's presence at regular widths.
@@ -58,6 +61,12 @@ struct FileViewerPane: View {
         }
         .background(Theme.screen)
         .task { await controller.start() }
+        // Cancelled the moment the tab stops being active; re-created on
+        // return, so the first tick lands ~5 s after coming back.
+        .task(id: isActive) {
+            guard isActive else { return }
+            await controller.watchWhileActive()
+        }
         .sheet(item: $confirmingLink) { link in
             TerminalLinkSheet(
                 link: link,

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -21,11 +21,41 @@ struct FileViewerPane: View {
 
     /// The standing column's presence at regular widths.
     @State private var treeDocked = true
-    /// The drawer's presence at compact widths.
-    @State private var drawerOpen = false
+    /// The drawer's presence at compact widths. A browse summon starts
+    /// with it out — see `startsWithDrawerOpen`.
+    @State private var drawerOpen: Bool
     /// A markdown link awaiting the link sheet's confirmation — the same
     /// gate a pane press gets; a document never opens anything itself.
     @State private var confirmingLink: TerminalLink?
+
+    init(
+        controller: FileViewerController,
+        contentSafeArea: EdgeInsets = EdgeInsets(),
+        isActive: Bool = true,
+        close: @escaping () -> Void
+    ) {
+        self.controller = controller
+        self.contentSafeArea = contentSafeArea
+        self.isActive = isActive
+        self.close = close
+        _drawerOpen = State(initialValue: Self.startsWithDrawerOpen(controller))
+    }
+
+    /// A browse summon (+ TAB ▸ File Viewer) has no file to show, so at
+    /// compact widths the tree drawer starts out — picking the first file
+    /// is the whole point of that door. A pressed path keeps its file as
+    /// the subject, and a pane re-parented mid-session (merge/split)
+    /// keeps whatever is already on screen instead of re-opening the
+    /// drawer over it.
+    private static func startsWithDrawerOpen(
+        _ controller: FileViewerController
+    ) -> Bool {
+        guard controller.opensBrowsing else { return false }
+        switch controller.content {
+        case .document, .diff: return false
+        default: return true
+        }
+    }
 
     private static let treeWidth: CGFloat = 236
     private static let compactThreshold: CGFloat = 700

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -13,10 +13,10 @@ import SwiftUI
 /// tokens), while every frame, rail, and caption stays on `Theme`.
 struct FileViewerPane: View {
     @Bindable var controller: FileViewerController
-    var contentSafeArea = EdgeInsets()
+    let contentSafeArea: EdgeInsets
     /// The window's active tab is the only one that watches: an obscured
     /// pane spends no network on a screen nobody sees (the wall's rule).
-    var isActive = true
+    let isActive: Bool
     let close: () -> Void
 
     /// The standing column's presence at regular widths.
@@ -97,15 +97,7 @@ struct FileViewerPane: View {
             guard isActive else { return }
             await controller.watchWhileActive()
         }
-        .sheet(item: $confirmingLink) { link in
-            TerminalLinkSheet(
-                link: link,
-                onOpen: {
-                    if let url = link.openableURL { UIApplication.shared.open(url) }
-                },
-                onCopy: { UIPasteboard.general.string = link.raw }
-            )
-        }
+        .terminalLinkConfirmation(item: $confirmingLink)
     }
 
     // MARK: Content column
@@ -130,7 +122,7 @@ struct FileViewerPane: View {
         case .document(let document):
             documentBody(document)
         case .diff(let diff, let scope):
-            FileViewerDiffView(diff: diff, scope: scope, controller: controller)
+            FileViewerDiffView(diff: diff, scope: scope)
         case .failure(let title, let message):
             failurePanel(title: title, message: message)
         }
@@ -138,11 +130,18 @@ struct FileViewerPane: View {
 
     @ViewBuilder
     private func documentBody(_ document: FileViewerController.Document) -> some View {
-        if document.isBinary {
+        switch document.kind {
+        case .binary:
             binaryPanel(document)
-        } else if let imageData = document.imageData {
-            imageBody(document, data: imageData)
-        } else if !document.markdown.isEmpty {
+        case .image:
+            if let image = document.image {
+                FileViewerImageView(image: image)
+            } else {
+                // The controller reclassifies undecodable image bytes to
+                // .binary; this is the defensive twin.
+                binaryPanel(document)
+            }
+        case .markdown where !document.markdown.isEmpty:
             FileViewerMarkdownView(
                 blocks: document.markdown,
                 openLink: { destination in
@@ -165,7 +164,8 @@ struct FileViewerPane: View {
                     }
                 }
             )
-        } else {
+        case .markdown, .code:
+            // Markdown RAW renders as plain lines through the code screen.
             FileViewerCodeView(
                 lines: document.codeLines,
                 truncated: document.truncated,
@@ -243,24 +243,10 @@ struct FileViewerPane: View {
     }
 
     private var headerCounts: Text? {
-        switch controller.content {
-        case .diff(let diff, _) where !(diff.additions == 0 && diff.deletions == 0):
-            return plusMinus(diff.additions, diff.deletions)
-        case .document where controller.documentDiffBadge != nil:
-            guard case .document(let document) = controller.content,
-                  controller.badges[document.path] != nil,
-                  !controller.shortStat.isEmpty
-            else { return nil }
-            return nil
-        default:
-            return nil
-        }
-    }
-
-    private func plusMinus(_ additions: Int, _ deletions: Int) -> Text {
-        (Text("+\(additions) ").foregroundColor(CodePalette.diffAddText)
-            + Text("−\(deletions)").foregroundColor(CodePalette.diffDeleteText))
-            .font(.mono(9, weight: .semibold))
+        guard case .diff(let diff, _) = controller.content,
+              diff.additions > 0 || diff.deletions > 0
+        else { return nil }
+        return CodePalette.plusMinus(diff.additions, diff.deletions)
     }
 
     private func badgeCaption(_ badge: GitFileStatus.Badge) -> String {
@@ -302,8 +288,7 @@ struct FileViewerPane: View {
     }
 
     private func binaryPanel(_ document: FileViewerController.Document) -> some View {
-        VStack(spacing: 14) {
-            TallyLamp(caption: "BINARY", color: Theme.caution)
+        ChassisPanel(caption: "BINARY") {
             Text("\(document.name) · \(FileViewerController.formatBytes(document.size))")
                 .font(.mono(12))
                 .foregroundStyle(Theme.signal2)
@@ -311,31 +296,11 @@ struct FileViewerPane: View {
                 .font(.footnote)
                 .foregroundStyle(Theme.signal3)
         }
-        .padding(28)
-        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Theme.bezelHi, lineWidth: 1)
-        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func imageBody(_ document: FileViewerController.Document, data: Data) -> some View {
-        Group {
-            if let image = UIImage(data: data) {
-                FileViewerImageView(image: image)
-            } else {
-                failurePanel(
-                    title: "CAN'T DECODE",
-                    message: "\(document.name) didn't decode as an image."
-                )
-            }
-        }
-    }
-
     private func failurePanel(title: String, message: String) -> some View {
-        VStack(spacing: 14) {
-            TallyLamp(caption: title, color: Theme.caution)
+        ChassisPanel(caption: title) {
             Text(message)
                 .font(.subheadline)
                 .foregroundStyle(Theme.signal2)
@@ -343,12 +308,6 @@ struct FileViewerPane: View {
                 .frame(maxWidth: 380)
             ChassisChip("REFRESH", prominent: true) { controller.refresh() }
         }
-        .padding(30)
-        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Theme.bezelHi, lineWidth: 1)
-        )
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -373,15 +332,9 @@ struct FileViewerPane: View {
             ChassisBadge(controller.hostName.uppercased())
                 .fixedSize()
                 .accessibilityLabel("Files on \(controller.hostName)")
-            if compact {
-                ChassisChip(drawerOpen ? "HIDE" : "TREE") { drawerOpen.toggle() }
-                    .fixedSize()
-                    .accessibilityLabel(drawerOpen ? "Hide the file tree" : "Show the file tree")
-            } else {
-                ChassisChip(treeDocked ? "HIDE" : "TREE") { treeDocked.toggle() }
-                    .fixedSize()
-                    .accessibilityLabel(treeDocked ? "Hide the file tree" : "Show the file tree")
-            }
+            // Same chip, two homes: compact toggles the drawer, regular
+            // the standing column.
+            treeChip(compact ? $drawerOpen : $treeDocked)
             ChassisChip("REFRESH") { controller.refresh() }
                 .fixedSize()
                 .disabled(controller.isBusy)
@@ -407,6 +360,16 @@ struct FileViewerPane: View {
                 }
             }
         }
+    }
+
+    private func treeChip(_ visible: Binding<Bool>) -> some View {
+        ChassisChip(visible.wrappedValue ? "HIDE" : "TREE") {
+            visible.wrappedValue.toggle()
+        }
+        .fixedSize()
+        .accessibilityLabel(
+            visible.wrappedValue ? "Hide the file tree" : "Show the file tree"
+        )
     }
 
     private var isWorking: Bool {
@@ -481,6 +444,14 @@ enum CodePalette {
 
     static let diffAddText = Color(light: 0x3E7C58, dark: 0x7FBF9A)
     static let diffDeleteText = Color(light: 0xC13439, dark: 0xE5484D)
+
+    /// The `+N −M` counts voice — one spelling for the content header, the
+    /// repo diff's file sections, and the tree's branch block.
+    static func plusMinus(_ additions: Int, _ deletions: Int) -> Text {
+        (Text("+\(additions) ").foregroundColor(diffAddText)
+            + Text("−\(deletions)").foregroundColor(diffDeleteText))
+            .font(.mono(9, weight: .semibold))
+    }
     static let diffAddGround = Color(light: 0x3E7C58, dark: 0x7FBF9A).opacity(0.10)
     static let diffDeleteGround = Color(light: 0xC13439, dark: 0xE5484D).opacity(0.09)
     static let hunkHeader = Color(light: 0x2E6E8E, dark: 0x7FB4C9).opacity(0.8)
@@ -873,7 +844,6 @@ private enum MarkdownInlineText {
 struct FileViewerDiffView: View {
     let diff: GitDiff
     let scope: FileViewerController.DiffScope
-    var controller: FileViewerController
 
     var body: some View {
         ScrollView {
@@ -919,9 +889,7 @@ struct FileViewerDiffView: View {
                     ChassisLabel("RENAMED", size: 7, color: Theme.signal3).fixedSize()
                 }
                 Spacer(minLength: 6)
-                (Text("+\(file.additions) ").foregroundColor(CodePalette.diffAddText)
-                    + Text("−\(file.deletions)").foregroundColor(CodePalette.diffDeleteText))
-                    .font(.mono(9, weight: .semibold))
+                CodePalette.plusMinus(file.additions, file.deletions)
                     .fixedSize()
             }
             .padding(.horizontal, 12)

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -1,0 +1,933 @@
+import SwiftUI
+
+/// One file-viewer tab's surface — the bake-off verdict (see
+/// local-plan/file-viewer-bakeoff): the WORKBENCH split wearing the
+/// REGISTER rail. Content screen left; the tree stands on its own screen
+/// ground to the right while the window affords it (≥ 700 pt) and yields
+/// to a drawer summoned from the rail below that. The bottom rail keeps
+/// identical instrumentation across every render: SOURCE | DIFF where git
+/// has a verdict, the breadcrumb readout, the host tag, REFRESH, CLOSE.
+///
+/// Color discipline: everything inside the screens is *content* (syntax
+/// classes, diff tints — appearance-dynamic, deliberately not chrome
+/// tokens), while every frame, rail, and caption stays on `Theme`.
+struct FileViewerPane: View {
+    @Bindable var controller: FileViewerController
+    var contentSafeArea = EdgeInsets()
+    let close: () -> Void
+
+    /// The standing column's presence at regular widths.
+    @State private var treeDocked = true
+    /// The drawer's presence at compact widths.
+    @State private var drawerOpen = false
+    /// A markdown link awaiting the link sheet's confirmation — the same
+    /// gate a pane press gets; a document never opens anything itself.
+    @State private var confirmingLink: TerminalLink?
+
+    private static let treeWidth: CGFloat = 236
+    private static let compactThreshold: CGFloat = 700
+
+    var body: some View {
+        GeometryReader { geometry in
+            let compact = geometry.size.width < Self.compactThreshold
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    contentColumn
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    if !compact, treeDocked {
+                        Rectangle().fill(Theme.bezelHi).frame(width: 1)
+                        treeColumn
+                            .frame(width: Self.treeWidth)
+                    }
+                }
+                .overlay(alignment: .trailing) {
+                    if compact, drawerOpen {
+                        treeColumn
+                            .frame(width: min(Self.treeWidth + 24, geometry.size.width - 56))
+                            .background(Theme.bezel)
+                            .overlay(alignment: .leading) {
+                                Rectangle().fill(Theme.bezelHi).frame(width: 1)
+                            }
+                            .shadow(color: .black.opacity(0.35), radius: 18, x: -8, y: 0)
+                            .transition(.move(edge: .trailing))
+                    }
+                }
+                rail(compact: compact)
+            }
+            .animation(.easeOut(duration: 0.18), value: drawerOpen)
+        }
+        .background(Theme.screen)
+        .task { await controller.start() }
+        .sheet(item: $confirmingLink) { link in
+            TerminalLinkSheet(
+                link: link,
+                onOpen: {
+                    if let url = link.openableURL { UIApplication.shared.open(url) }
+                },
+                onCopy: { UIPasteboard.general.string = link.raw }
+            )
+        }
+    }
+
+    // MARK: Content column
+
+    private var contentColumn: some View {
+        VStack(spacing: 0) {
+            fileHeader
+            Rectangle().fill(Theme.bezelHi).frame(height: 1)
+            contentBody
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(Theme.screen)
+    }
+
+    @ViewBuilder
+    private var contentBody: some View {
+        switch controller.content {
+        case .idle:
+            emptyState
+        case .loading(let label):
+            loadingState(label)
+        case .document(let document):
+            documentBody(document)
+        case .diff(let diff, let scope):
+            FileViewerDiffView(diff: diff, scope: scope, controller: controller)
+        case .failure(let title, let message):
+            failurePanel(title: title, message: message)
+        }
+    }
+
+    @ViewBuilder
+    private func documentBody(_ document: FileViewerController.Document) -> some View {
+        if document.isBinary {
+            binaryPanel(document)
+        } else if let imageData = document.imageData {
+            imageBody(document, data: imageData)
+        } else if !document.markdown.isEmpty {
+            FileViewerMarkdownView(
+                blocks: document.markdown,
+                openLink: { destination in
+                    // External targets are untrusted document text — the
+                    // link sheet decides, exactly like a pane press. A
+                    // scheme-less relative target is in-document
+                    // navigation (docs/setup.md), which stays inside the
+                    // already-confirmed viewer.
+                    if let link = TerminalLink.resolve(destination) {
+                        confirmingLink = link
+                    } else if !destination.contains(":"),
+                              let current = controller.lastDocument {
+                        let base = FileTree.parent(of: current.path) ?? "/"
+                        Task {
+                            await controller.open(
+                                path: FileTree.join(base, destination),
+                                line: nil
+                            )
+                        }
+                    }
+                }
+            )
+        } else {
+            FileViewerCodeView(
+                lines: document.codeLines,
+                truncated: document.truncated,
+                targetLine: document.targetLine
+            )
+        }
+    }
+
+    // MARK: File header
+
+    private var fileHeader: some View {
+        HStack(spacing: 8) {
+            Text(headerName)
+                .font(.mono(11, weight: .semibold))
+                .foregroundStyle(Theme.signal)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            ChassisLabel(headerMeta, size: 8, color: Theme.signal3)
+                .lineLimit(1)
+            Spacer(minLength: 6)
+            if case .document(let document) = controller.content,
+               let badge = controller.badges[document.path] {
+                ChassisLabel(
+                    badgeCaption(badge),
+                    size: 8,
+                    color: FileViewerTreeColumn.badgeColor(badge)
+                )
+                .fixedSize()
+            }
+            if let counts = headerCounts {
+                counts.fixedSize()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(Theme.screen)
+    }
+
+    private var headerName: String {
+        switch controller.content {
+        case .document(let document): document.name
+        case .diff(_, .repo): "Working tree vs HEAD"
+        case .diff(_, .file(let path)): FileTree.name(of: path)
+        case .loading(let label): label
+        case .failure: "—"
+        case .idle: FileTree.name(of: controller.rootPath)
+        }
+    }
+
+    private var headerMeta: String {
+        switch controller.content {
+        case .document(let document):
+            var parts: [String] = []
+            if case .code(let language) = document.kind {
+                parts.append(language?.rawValue ?? "TEXT")
+            } else if document.kind == .markdown {
+                parts.append(controller.markdownRaw ? "MARKDOWN · RAW" : "MARKDOWN")
+            } else if document.kind == .image {
+                parts.append("IMAGE")
+            } else {
+                parts.append("BINARY")
+            }
+            parts.append(FileViewerController.formatBytes(document.size))
+            if document.truncated { parts.append("TRUNCATED") }
+            return parts.joined(separator: " · ")
+        case .diff(let diff, .repo):
+            return "\(diff.files.count) FILE\(diff.files.count == 1 ? "" : "S")"
+        case .diff(_, .file):
+            return "DIFF VS HEAD"
+        case .loading:
+            return "LOADING"
+        default:
+            return controller.hostName.uppercased()
+        }
+    }
+
+    private var headerCounts: Text? {
+        switch controller.content {
+        case .diff(let diff, _) where !(diff.additions == 0 && diff.deletions == 0):
+            return plusMinus(diff.additions, diff.deletions)
+        case .document where controller.documentDiffBadge != nil:
+            guard case .document(let document) = controller.content,
+                  controller.badges[document.path] != nil,
+                  !controller.shortStat.isEmpty
+            else { return nil }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    private func plusMinus(_ additions: Int, _ deletions: Int) -> Text {
+        (Text("+\(additions) ").foregroundColor(CodePalette.diffAddText)
+            + Text("−\(deletions)").foregroundColor(CodePalette.diffDeleteText))
+            .font(.mono(9, weight: .semibold))
+    }
+
+    private func badgeCaption(_ badge: GitFileStatus.Badge) -> String {
+        switch badge {
+        case .modified: "MODIFIED"
+        case .added: "STAGED ADD"
+        case .deleted: "DELETED"
+        case .renamed: "RENAMED"
+        case .untracked: "UNTRACKED"
+        case .conflicted: "CONFLICT"
+        }
+    }
+
+    // MARK: States
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            ChassisLabel("NO FILE ON SCREEN", size: 10, color: Theme.signal3)
+            Text("Pick a file from the tree\(controller.gitRoot != nil ? ", or open the branch's diff from its ± counts" : "").")
+                .font(.footnote)
+                .foregroundStyle(Theme.signal3)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 300)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func loadingState(_ label: String) -> some View {
+        VStack(spacing: 10) {
+            ChassisLabel("LOADING", size: 9, color: Theme.caution)
+            Text(label)
+                .font(.mono(11))
+                .foregroundStyle(Theme.signal2)
+                .lineLimit(2)
+                .truncationMode(.middle)
+                .frame(maxWidth: 360)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func binaryPanel(_ document: FileViewerController.Document) -> some View {
+        VStack(spacing: 14) {
+            TallyLamp(caption: "BINARY", color: Theme.caution)
+            Text("\(document.name) · \(FileViewerController.formatBytes(document.size))")
+                .font(.mono(12))
+                .foregroundStyle(Theme.signal2)
+            Text("Not text — Multiplex won't render it as code.")
+                .font(.footnote)
+                .foregroundStyle(Theme.signal3)
+        }
+        .padding(28)
+        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Theme.bezelHi, lineWidth: 1)
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func imageBody(_ document: FileViewerController.Document, data: Data) -> some View {
+        Group {
+            if let image = UIImage(data: data) {
+                ScrollView([.vertical, .horizontal]) {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(
+                            maxWidth: max(80, min(image.size.width, 1600)),
+                            maxHeight: max(80, min(image.size.height, 1600))
+                        )
+                        .padding(18)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                failurePanel(
+                    title: "CAN'T DECODE",
+                    message: "\(document.name) didn't decode as an image."
+                )
+            }
+        }
+    }
+
+    private func failurePanel(title: String, message: String) -> some View {
+        VStack(spacing: 14) {
+            TallyLamp(caption: title, color: Theme.caution)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(Theme.signal2)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 380)
+            ChassisChip("REFRESH", prominent: true) { controller.refresh() }
+        }
+        .padding(30)
+        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Theme.bezelHi, lineWidth: 1)
+        )
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: Tree column
+
+    private var treeColumn: some View {
+        FileViewerTreeColumn(
+            controller: controller,
+            closeDrawer: { drawerOpen = false }
+        )
+    }
+
+    // MARK: Rail
+
+    private func rail(compact: Bool) -> some View {
+        HStack(spacing: 8) {
+            if controller.documentDiffBadge != nil {
+                modeChips
+            }
+            pathReadout
+            ChassisBadge(controller.hostName.uppercased())
+                .fixedSize()
+                .accessibilityLabel("Files on \(controller.hostName)")
+            if compact {
+                ChassisChip(drawerOpen ? "HIDE" : "TREE") { drawerOpen.toggle() }
+                    .fixedSize()
+                    .accessibilityLabel(drawerOpen ? "Hide the file tree" : "Show the file tree")
+            } else {
+                ChassisChip(treeDocked ? "HIDE" : "TREE") { treeDocked.toggle() }
+                    .fixedSize()
+                    .accessibilityLabel(treeDocked ? "Hide the file tree" : "Show the file tree")
+            }
+            ChassisChip("REFRESH") { controller.refresh() }
+                .fixedSize()
+                .disabled(controller.isBusy)
+                .opacity(controller.isBusy ? 0.5 : 1)
+            ChassisChip("CLOSE", prominent: true, action: close)
+                .fixedSize()
+                .accessibilityLabel("Close file viewer")
+        }
+        .padding(.leading, 10 + contentSafeArea.leading)
+        .padding(.trailing, 10 + contentSafeArea.trailing)
+        .padding(.top, 8)
+        .padding(.bottom, 8 + contentSafeArea.bottom)
+        .background(Theme.bezel)
+        .overlay(alignment: .top) {
+            ZStack(alignment: .topLeading) {
+                Rectangle().fill(Theme.bezelHi).frame(height: 1)
+                if isWorking {
+                    Rectangle()
+                        .fill(Theme.caution)
+                        .frame(height: 2)
+                        .frame(maxWidth: 90)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+    }
+
+    private var isWorking: Bool {
+        if controller.isBusy { return true }
+        if case .loading = controller.content { return true }
+        return false
+    }
+
+    private var modeChips: some View {
+        HStack(spacing: 4) {
+            ChassisChip("SOURCE", prominent: isSourceMode) {
+                controller.showSource()
+            }
+            .fixedSize()
+            ChassisChip("DIFF", prominent: !isSourceMode) {
+                if case .document(let document) = controller.content {
+                    Task { await controller.showFileDiff(path: document.path) }
+                }
+            }
+            .fixedSize()
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Source or diff")
+    }
+
+    private var isSourceMode: Bool {
+        if case .document = controller.content { return true }
+        return false
+    }
+
+    /// Monospace readout, the file bright, its directory dim — the
+    /// viewport rail's voice aimed at a path.
+    private var pathReadout: some View {
+        Text(readoutText)
+            .font(.mono(10))
+            .lineLimit(1)
+            .truncationMode(.head)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel(controller.railPath)
+    }
+
+    private var readoutText: AttributedString {
+        let path = controller.railPath
+        let name = FileTree.name(of: path)
+        let directory = String(path.dropLast(name.count))
+        var head = AttributedString(directory)
+        head.foregroundColor = Theme.signal3
+        var tail = AttributedString(name)
+        tail.foregroundColor = Theme.signal
+        tail.font = .mono(10, weight: .semibold)
+        return head + tail
+    }
+}
+
+// MARK: - Syntax + diff palette (screen content, not chrome)
+
+/// The content screens' color vocabulary. Deliberately not `Theme` tokens:
+/// these color *what the file says*, the way a terminal theme colors a
+/// pane — appearance-dynamic so Frost gets legible ink, but never spent on
+/// chrome.
+enum CodePalette {
+    static let keyword = Color(light: 0x2E6E8E, dark: 0x7FB4C9)
+    static let type = Color(light: 0x966618, dark: 0xE0A33E)
+    static let string = Color(light: 0x3E7C58, dark: 0x7FBF9A)
+    static let comment = Color(light: 0x87919E, dark: 0x5C6166)
+    static let number = Color(light: 0x8A6D3B, dark: 0xC9A26D)
+    static let function = Color(light: 0x191E25, dark: 0xF2F3F4)
+    static let property = Color(light: 0x44618F, dark: 0x8FA8D0)
+    static let meta = Color(light: 0x7A4E75, dark: 0xC08CB8)
+    static let plain = Color(light: 0x3A434E, dark: 0xC8D2D6)
+    static let gutter = Color(light: 0x87919E, dark: 0x5C6166)
+
+    static let diffAddText = Color(light: 0x3E7C58, dark: 0x7FBF9A)
+    static let diffDeleteText = Color(light: 0xC13439, dark: 0xE5484D)
+    static let diffAddGround = Color(light: 0x3E7C58, dark: 0x7FBF9A).opacity(0.10)
+    static let diffDeleteGround = Color(light: 0xC13439, dark: 0xE5484D).opacity(0.09)
+    static let hunkHeader = Color(light: 0x2E6E8E, dark: 0x7FB4C9).opacity(0.8)
+    static let link = Color(light: 0x2E6E8E, dark: 0x7FB4C9)
+
+    static func color(for kind: CodeTokenKind) -> Color {
+        switch kind {
+        case .plain: plain
+        case .keyword: keyword
+        case .type: type
+        case .string: string
+        case .comment: comment
+        case .number: number
+        case .function: function
+        case .property: property
+        case .meta: meta
+        }
+    }
+
+    static func attributed(
+        _ line: HighlightedLine,
+        baseSize: CGFloat = 11
+    ) -> AttributedString {
+        var result = AttributedString()
+        for segment in line.segments {
+            var piece = AttributedString(segment.text)
+            piece.foregroundColor = color(for: segment.kind)
+            if segment.kind == .comment {
+                piece.font = .mono(baseSize).italic()
+            }
+            result += piece
+        }
+        if result.characters.isEmpty {
+            result = AttributedString(" ")
+        }
+        return result
+    }
+}
+
+// MARK: - Code view
+
+struct FileViewerCodeView: View {
+    let lines: [HighlightedLine]
+    var truncated = false
+    var targetLine: Int?
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if truncated {
+                        truncatedBanner
+                    }
+                    ForEach(lines.indices, id: \.self) { index in
+                        codeRow(number: index + 1, line: lines[index])
+                            .id(index + 1)
+                    }
+                }
+                .padding(.vertical, 10)
+            }
+            .onAppear {
+                if let targetLine, targetLine > 1, targetLine <= lines.count {
+                    proxy.scrollTo(targetLine, anchor: .center)
+                }
+            }
+        }
+        .background(Theme.screen)
+    }
+
+    private func codeRow(number: Int, line: HighlightedLine) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text("\(number)")
+                .font(.mono(9))
+                .foregroundStyle(
+                    number == targetLine ? Theme.caution : CodePalette.gutter
+                )
+                .frame(width: 44, alignment: .trailing)
+                .padding(.trailing, 12)
+            Text(CodePalette.attributed(line))
+                .font(.mono(11))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing, 14)
+        }
+        .padding(.vertical, 1)
+        .background(
+            number == targetLine ? Theme.caution.opacity(0.12) : Color.clear
+        )
+    }
+
+    private var truncatedBanner: some View {
+        HStack(spacing: 8) {
+            ChassisLabel("TRUNCATED", size: 8, color: Theme.caution)
+            Text("Showing the first \(FileViewerController.formatBytes(UInt64(FileViewerController.textByteLimit))).")
+                .font(.footnote)
+                .foregroundStyle(Theme.signal3)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.caution.opacity(0.08))
+    }
+}
+
+// MARK: - Markdown view
+
+struct FileViewerMarkdownView: View {
+    let blocks: [MarkdownBlock]
+    let openLink: (String) -> Void
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+                ForEach(blocks.indices, id: \.self) { index in
+                    MarkdownBlockView(block: blocks[index])
+                }
+            }
+            .padding(.horizontal, 22)
+            .padding(.vertical, 18)
+            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .background(Theme.screen)
+        .environment(\.openURL, OpenURLAction { url in
+            openLink(url.absoluteString)
+            return .handled
+        })
+    }
+}
+
+/// One block. A struct rather than a builder function because block quotes
+/// nest — a view type may recurse through its own body where an opaque
+/// `some View` function cannot.
+private struct MarkdownBlockView: View {
+    let block: MarkdownBlock
+
+    var body: some View {
+        switch block {
+        case .heading(let level, let inlines):
+            Text(MarkdownInlineText.render(inlines, baseFont: Self.headingFont(level)))
+                .padding(.top, level <= 2 ? 8 : 4)
+        case .paragraph(let inlines):
+            Text(MarkdownInlineText.render(inlines, baseFont: .ui(13)))
+                .lineSpacing(3)
+                .textSelection(.enabled)
+        case .code(let language, _, let lines):
+            fence(language: language, lines: lines)
+        case .quote(let inner):
+            HStack(alignment: .top, spacing: 12) {
+                Rectangle().fill(Theme.bezelHi).frame(width: 3)
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(inner.indices, id: \.self) { index in
+                        MarkdownBlockView(block: inner[index])
+                    }
+                }
+            }
+            .padding(.leading, 2)
+        case .listItem(let marker, let level, let inlines):
+            HStack(alignment: .firstTextBaseline, spacing: 9) {
+                Text(marker)
+                    .font(.mono(11))
+                    .foregroundStyle(Theme.signal3)
+                Text(MarkdownInlineText.render(inlines, baseFont: .ui(13)))
+                    .lineSpacing(3)
+                    .textSelection(.enabled)
+            }
+            .padding(.leading, CGFloat(level) * 18)
+        case .table(let header, let rows):
+            tableView(header: header, rows: rows)
+        case .rule:
+            Rectangle().fill(Theme.bezelHi).frame(height: 1).padding(.vertical, 4)
+        }
+    }
+
+    private static func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: .ui(22, weight: .bold)
+        case 2: .ui(17, weight: .bold)
+        case 3: .ui(14, weight: .semibold)
+        default: .ui(13, weight: .semibold)
+        }
+    }
+
+    private func fence(language: CodeLanguage?, lines: [String]) -> some View {
+        let highlighted = CodeHighlighter.highlight(
+            lines.joined(separator: "\n"),
+            language: language
+        )
+        return ScrollView(.horizontal, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(highlighted.indices, id: \.self) { index in
+                    Text(CodePalette.attributed(highlighted[index], baseSize: 10.5))
+                        .font(.mono(10.5))
+                }
+            }
+            .padding(10)
+        }
+        .background(Theme.chassis)
+        .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .strokeBorder(Theme.bezelHi, lineWidth: 1))
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .textSelection(.enabled)
+    }
+
+    private func tableView(header: [[MarkdownInline]], rows: [[[MarkdownInline]]]) -> some View {
+        let columns = max(header.count, rows.map(\.count).max() ?? 0)
+        return ScrollView(.horizontal, showsIndicators: false) {
+            Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+                GridRow {
+                    ForEach(0..<columns, id: \.self) { column in
+                        Text(column < header.count
+                            ? MarkdownInlineText.render(header[column], baseFont: .ui(12, weight: .semibold))
+                            : AttributedString(""))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .frame(minWidth: 60, alignment: .leading)
+                            .background(Theme.bezel)
+                    }
+                }
+                ForEach(rows.indices, id: \.self) { rowIndex in
+                    GridRow {
+                        ForEach(0..<columns, id: \.self) { column in
+                            Text(column < rows[rowIndex].count
+                                ? MarkdownInlineText.render(rows[rowIndex][column], baseFont: .ui(12))
+                                : AttributedString(""))
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .frame(minWidth: 60, alignment: .leading)
+                        }
+                    }
+                    .background(rowIndex.isMultiple(of: 2) ? Color.clear : Theme.bezel.opacity(0.4))
+                }
+            }
+            .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+        }
+    }
+}
+
+/// Inline runs → styled AttributedString, shared by paragraphs, headings,
+/// list items, and table cells.
+private enum MarkdownInlineText {
+    static func render(_ inlines: [MarkdownInline], baseFont: Font) -> AttributedString {
+        var result = AttributedString()
+        for inline in inlines {
+            switch inline {
+            case .text(let value, let emphasis):
+                var piece = AttributedString(value)
+                var font = baseFont
+                if emphasis.contains(.bold) { font = font.weight(.bold) }
+                if emphasis.contains(.italic) { font = font.italic() }
+                piece.font = font
+                if emphasis.contains(.strikethrough) {
+                    piece.strikethroughStyle = .single
+                }
+                piece.foregroundColor = CodePalette.plain
+                result += piece
+            case .code(let value):
+                var piece = AttributedString(value)
+                piece.font = .mono(11)
+                piece.foregroundColor = CodePalette.string
+                piece.backgroundColor = Theme.bezel
+                result += piece
+            case .link(let text, let destination):
+                var piece = AttributedString(text)
+                piece.font = baseFont
+                piece.foregroundColor = CodePalette.link
+                piece.underlineStyle = .single
+                if let encoded = destination.addingPercentEncoding(
+                    withAllowedCharacters: .urlQueryAllowed
+                ), let url = URL(string: destination) ?? URL(string: encoded) {
+                    piece.link = url
+                }
+                result += piece
+            case .image(let alt):
+                var piece = AttributedString("⟨image\(alt.isEmpty ? "" : ": \(alt)")⟩")
+                piece.font = .mono(10)
+                piece.foregroundColor = Theme.signal3
+                result += piece
+            }
+        }
+        if result.characters.isEmpty { result = AttributedString(" ") }
+        return result
+    }
+}
+
+// MARK: - Diff view
+
+struct FileViewerDiffView: View {
+    let diff: GitDiff
+    let scope: FileViewerController.DiffScope
+    var controller: FileViewerController
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if diff.files.isEmpty {
+                    cleanState
+                }
+                ForEach(diff.files.indices, id: \.self) { index in
+                    fileSection(diff.files[index], standalone: isRepoScope)
+                }
+            }
+            .padding(.bottom, 12)
+        }
+        .background(Theme.screen)
+    }
+
+    private var isRepoScope: Bool {
+        if case .repo = scope { return true }
+        return false
+    }
+
+    private var cleanState: some View {
+        VStack(spacing: 10) {
+            ChassisLabel("NOTHING TO DIFF", size: 10, color: Theme.signal3)
+            Text("The working tree matches HEAD here.")
+                .font(.footnote)
+                .foregroundStyle(Theme.signal3)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 60)
+    }
+
+    @ViewBuilder
+    private func fileSection(_ file: GitDiffFile, standalone: Bool) -> some View {
+        if standalone {
+            HStack(spacing: 8) {
+                Text(file.displayPath)
+                    .font(.mono(10, weight: .semibold))
+                    .foregroundStyle(Theme.signal)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if file.kind == .renamed {
+                    ChassisLabel("RENAMED", size: 7, color: Theme.signal3).fixedSize()
+                }
+                Spacer(minLength: 6)
+                (Text("+\(file.additions) ").foregroundColor(CodePalette.diffAddText)
+                    + Text("−\(file.deletions)").foregroundColor(CodePalette.diffDeleteText))
+                    .font(.mono(9, weight: .semibold))
+                    .fixedSize()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Theme.bezel)
+            .overlay(alignment: .bottom) {
+                Rectangle().fill(Theme.bezelHi).frame(height: 1)
+            }
+        }
+        if file.isBinary {
+            HStack {
+                ChassisLabel("BINARY", size: 8, color: Theme.signal3)
+                Text("Binary files differ.")
+                    .font(.footnote)
+                    .foregroundStyle(Theme.signal3)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+        } else if file.hunks.isEmpty {
+            HStack {
+                Text(file.kind == .renamed ? "Rename only — contents unchanged." : "No textual hunks.")
+                    .font(.footnote)
+                    .foregroundStyle(Theme.signal3)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+        }
+        ForEach(file.hunks.indices, id: \.self) { hunkIndex in
+            hunkView(file.hunks[hunkIndex], language: language(for: file))
+        }
+    }
+
+    private func language(for file: GitDiffFile) -> CodeLanguage? {
+        if case .code(let language) = FileKind.classify(
+            fileName: FileTree.name(of: file.displayPath)
+        ) { return language }
+        return nil
+    }
+
+    @ViewBuilder
+    private func hunkView(_ hunk: GitDiffHunk, language: CodeLanguage?) -> some View {
+        Text(hunk.header)
+            .font(.mono(9))
+            .foregroundStyle(CodePalette.hunkHeader)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Theme.bezel.opacity(0.5))
+        ForEach(hunk.lines.indices, id: \.self) { lineIndex in
+            diffRow(hunk.lines[lineIndex], language: language)
+        }
+    }
+
+    private func diffRow(_ line: GitDiffLine, language: CodeLanguage?) -> some View {
+        // Stateless per-row highlight: a diff row mid-block-comment loses
+        // comment color — the accepted trade for lazy rows (recorded in
+        // local-plan/file-viewer.md).
+        var state = CodeHighlighter.LineState.normal
+        let highlighted: HighlightedLine =
+            if let rules = language.flatMap({ CodeHighlighter.rules(for: $0) }) {
+                CodeHighlighter.highlightLine(line.text, state: &state, rules: rules)
+            } else {
+                HighlightedLine(segments: [.init(text: line.text, kind: .plain)])
+            }
+        return HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text(line.oldNumber.map(String.init) ?? "")
+                .font(.mono(8.5))
+                .foregroundStyle(CodePalette.gutter)
+                .frame(width: 34, alignment: .trailing)
+            Text(line.newNumber.map(String.init) ?? "")
+                .font(.mono(8.5))
+                .foregroundStyle(CodePalette.gutter)
+                .frame(width: 34, alignment: .trailing)
+                .padding(.trailing, 8)
+            Text(sign(for: line.kind))
+                .font(.mono(10, weight: .semibold))
+                .foregroundStyle(signColor(for: line.kind))
+                .frame(width: 14, alignment: .center)
+            Text(CodePalette.attributed(highlighted))
+                .font(.mono(10.5))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing, 14)
+        }
+        .padding(.vertical, 0.5)
+        .background(ground(for: line.kind))
+    }
+
+    private func sign(for kind: GitDiffLine.Kind) -> String {
+        switch kind {
+        case .addition: "+"
+        case .deletion: "−"
+        case .context: " "
+        }
+    }
+
+    private func signColor(for kind: GitDiffLine.Kind) -> Color {
+        switch kind {
+        case .addition: CodePalette.diffAddText
+        case .deletion: CodePalette.diffDeleteText
+        case .context: CodePalette.gutter
+        }
+    }
+
+    private func ground(for kind: GitDiffLine.Kind) -> Color {
+        switch kind {
+        case .addition: CodePalette.diffAddGround
+        case .deletion: CodePalette.diffDeleteGround
+        case .context: .clear
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Code + diff palette") {
+    FileViewerCodeView(
+        lines: CodeHighlighter.highlight(
+            """
+            import Foundation
+
+            /// The probe's one exec round-trip.
+            @MainActor
+            struct Probe {
+                let host: String
+                func run(attempts: Int = 3) async -> [String] {
+                    let banner = \"tmux -u list-panes\"
+                    return banner.split(separator: \" \").map(String.init)
+                }
+            }
+            """,
+            language: .swift
+        ),
+        targetLine: 7
+    )
+    .frame(width: 620, height: 380)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Multiplex/Views/Terminal/FileViewerTreeColumn.swift
+++ b/Multiplex/Views/Terminal/FileViewerTreeColumn.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+/// The tree monitor — the WORKBENCH's right screen. Location header
+/// (HOST ▸ ROOT + UP), the git block (branch, ± counts opening the repo
+/// diff, CHANGED filter), then lazy-expanding rows with letter badges.
+/// The same view docks as a standing column at regular widths and rides
+/// the compact drawer.
+struct FileViewerTreeColumn: View {
+    @Bindable var controller: FileViewerController
+    /// Compact drawer only: picking a file dismisses the drawer so the
+    /// content it chose is visible. No-op when docked.
+    var closeDrawer: () -> Void = {}
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Rectangle().fill(Theme.bezelHi).frame(height: 1)
+            if controller.gitRoot != nil {
+                gitBlock
+                Rectangle().fill(Theme.bezelHi).frame(height: 1)
+            }
+            rows
+        }
+        .background(Theme.screen)
+    }
+
+    private var header: some View {
+        HStack(spacing: 7) {
+            ChassisLabel(
+                locationLabel,
+                size: 8,
+                color: Theme.signal2
+            )
+            .lineLimit(1)
+            .truncationMode(.head)
+            Spacer(minLength: 4)
+            if FileTree.parent(of: controller.rootPath) != nil {
+                ChassisChip("UP") { controller.hoistRoot() }
+                    .fixedSize()
+                    .accessibilityLabel("Show the parent directory")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+    }
+
+    private var locationLabel: String {
+        let root = FileTree.name(of: controller.rootPath)
+        return "\(controller.hostName) ▸ \(root.isEmpty ? "/" : root)"
+    }
+
+    private var gitBlock: some View {
+        HStack(spacing: 8) {
+            Text("⎇ \(controller.branch ?? "—")")
+                .font(.mono(10, weight: .semibold))
+                .foregroundStyle(Theme.signal)
+                .lineLimit(1)
+            Button {
+                Task { await controller.showRepoDiff() }
+            } label: {
+                countsText
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .chassisHover(2)
+            .accessibilityLabel("Open the working tree's diff")
+            Spacer(minLength: 4)
+            ChassisChip("CHANGED", prominent: controller.changedFilter) {
+                controller.changedFilter.toggle()
+            }
+            .fixedSize()
+            .accessibilityLabel(
+                controller.changedFilter
+                    ? "Show the whole tree" : "Show only changed files"
+            )
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+    }
+
+    private var countsText: Text {
+        if controller.shortStat.isEmpty {
+            return Text("±0")
+                .font(.mono(9))
+                .foregroundColor(Theme.signal3)
+        }
+        return (Text("+\(controller.shortStat.insertions) ")
+            .foregroundColor(CodePalette.diffAddText)
+            + Text("−\(controller.shortStat.deletions)")
+            .foregroundColor(CodePalette.diffDeleteText))
+            .font(.mono(9, weight: .semibold))
+    }
+
+    private var rows: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if let failure = controller.treeFailure {
+                    Text(failure)
+                        .font(.footnote)
+                        .foregroundStyle(Theme.caution)
+                        .padding(10)
+                }
+                let treeRows = controller.treeRows
+                if treeRows.isEmpty, controller.treeFailure == nil {
+                    ChassisLabel(
+                        controller.changedFilter ? "NOTHING CHANGED" : "EMPTY",
+                        size: 8,
+                        color: Theme.signal3
+                    )
+                    .padding(12)
+                }
+                ForEach(treeRows) { row in
+                    rowView(row)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func rowView(_ row: FileTree.Row) -> some View {
+        Button {
+            controller.select(row)
+            if !row.entry.isDirectory { closeDrawer() }
+        } label: {
+            HStack(spacing: 6) {
+                Text(disclosure(row))
+                    .font(.mono(8))
+                    .foregroundStyle(Theme.signal3)
+                    .frame(width: 10)
+                Text(row.entry.name)
+                    .font(.mono(10.5))
+                    .foregroundStyle(isCurrent(row) ? Theme.signal : Theme.signal2)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 4)
+                if let badge = row.badge {
+                    Text(badge.rawValue)
+                        .font(.mono(9, weight: .semibold))
+                        .foregroundStyle(Self.badgeColor(badge))
+                } else if row.containsChanges {
+                    Circle()
+                        .fill(Theme.caution.opacity(0.7))
+                        .frame(width: 4, height: 4)
+                        .accessibilityLabel("Contains changes")
+                }
+            }
+            .padding(.leading, 10 + CGFloat(row.depth) * 14)
+            .padding(.trailing, 10)
+            .padding(.vertical, 4.5)
+            .background(isCurrent(row) ? Theme.bezelHi : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .chassisHover(2)
+        .accessibilityLabel(rowAccessibilityLabel(row))
+    }
+
+    private func disclosure(_ row: FileTree.Row) -> String {
+        guard row.entry.isDirectory else { return "" }
+        return row.isExpanded ? "▾" : "▸"
+    }
+
+    private func isCurrent(_ row: FileTree.Row) -> Bool {
+        controller.railPath == row.entry.path
+    }
+
+    private func rowAccessibilityLabel(_ row: FileTree.Row) -> String {
+        var label = row.entry.name
+        if row.entry.isDirectory {
+            label += row.isExpanded ? ", expanded folder" : ", folder"
+        }
+        if let badge = row.badge {
+            label += ", " + badgeWord(badge)
+        }
+        return label
+    }
+
+    private func badgeWord(_ badge: GitFileStatus.Badge) -> String {
+        switch badge {
+        case .modified: "modified"
+        case .added: "staged addition"
+        case .deleted: "deleted"
+        case .renamed: "renamed"
+        case .untracked: "untracked"
+        case .conflicted: "conflicted"
+        }
+    }
+
+    /// The badge letters' ink — state colors, captioned by the letter
+    /// itself (the deck's telemetry voice at tree scale).
+    static func badgeColor(_ badge: GitFileStatus.Badge) -> Color {
+        switch badge {
+        case .modified: Theme.caution
+        case .added: Theme.ok
+        case .deleted: CodePalette.diffDeleteText
+        case .renamed: Theme.signal2
+        case .untracked: CodePalette.keyword
+        case .conflicted: Theme.tally
+        }
+    }
+}

--- a/Multiplex/Views/Terminal/FileViewerTreeColumn.swift
+++ b/Multiplex/Views/Terminal/FileViewerTreeColumn.swift
@@ -84,11 +84,10 @@ struct FileViewerTreeColumn: View {
                 .font(.mono(9))
                 .foregroundColor(Theme.signal3)
         }
-        return (Text("+\(controller.shortStat.insertions) ")
-            .foregroundColor(CodePalette.diffAddText)
-            + Text("−\(controller.shortStat.deletions)")
-            .foregroundColor(CodePalette.diffDeleteText))
-            .font(.mono(9, weight: .semibold))
+        return CodePalette.plusMinus(
+            controller.shortStat.insertions,
+            controller.shortStat.deletions
+        )
     }
 
     private var rows: some View {

--- a/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
+++ b/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
@@ -26,18 +26,7 @@ struct TerminalFilePathSheet: View {
                                         .font(.mono(13, weight: .semibold))
                                         .foregroundStyle(Theme.signal)
                                 }
-                                VStack(alignment: .leading, spacing: 4) {
-                                    ChassisLabel("PATH", size: 9, color: Theme.signal3)
-                                    Text(target.path)
-                                        .font(.mono(11))
-                                        .foregroundStyle(Theme.signal2)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                        .textSelection(.enabled)
-                                }
-                                .padding(10)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(Theme.screen)
-                                .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+                                TerminalSheetValueBox(label: "PATH", value: target.path)
 
                                 if let line = target.line {
                                     HStack(spacing: 8) {

--- a/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
+++ b/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// Confirmation for a filesystem path activated in a terminal pane — the
+/// file viewer's twin of `TerminalLinkSheet`, holding the same line: pane
+/// bytes are untrusted, so the resolved target is shown before anything
+/// opens. The ▤ VIEW chip docks a read-only viewer tab; COPY stays the
+/// answer for a path wanted elsewhere.
+struct TerminalFilePathSheet: View {
+    let target: TerminalPathTarget
+    let hostName: String
+    let onView: (TerminalPathTarget) -> Void
+    let onCopy: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 18) {
+                    TallyFormSection(sectionTitle, detail: detail) {
+                        TallyFormRow {
+                            VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    ChassisLabel("HOST", size: 9, color: Theme.signal3)
+                                    Text(hostName)
+                                        .font(.mono(13, weight: .semibold))
+                                        .foregroundStyle(Theme.signal)
+                                }
+                                VStack(alignment: .leading, spacing: 4) {
+                                    ChassisLabel("PATH", size: 9, color: Theme.signal3)
+                                    Text(target.path)
+                                        .font(.mono(11))
+                                        .foregroundStyle(Theme.signal2)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .textSelection(.enabled)
+                                }
+                                .padding(10)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Theme.screen)
+                                .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+
+                                if let line = target.line {
+                                    HStack(spacing: 8) {
+                                        ChassisLabel("LINE", size: 9, color: Theme.signal3)
+                                        Text("\(line)")
+                                            .font(.mono(11))
+                                            .foregroundStyle(Theme.signal2)
+                                    }
+                                }
+
+                                HStack(spacing: 10) {
+                                    ChassisChip("▤ VIEW", prominent: true) {
+                                        onView(target)
+                                        dismiss()
+                                    }
+                                    ChassisChip("COPY", systemImage: "doc.on.doc") {
+                                        onCopy()
+                                        dismiss()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: 560)
+                .padding(18)
+                .frame(maxWidth: .infinity)
+            }
+            .chassisSheetGround()
+            .navigationTitle("View file")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ChassisSheetTitle("View file")
+                ToolbarItem(placement: .cancellationAction) {
+                    ChassisBarButton("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var sectionTitle: String {
+        switch target.base {
+        case .absolute: "A path on \(hostName)"
+        case .home: "In \(hostName)'s home"
+        case .workingDirectory: "Relative to the pane's directory"
+        }
+    }
+
+    private var detail: String {
+        var text = "VIEW opens it read-only in the file viewer, beside this "
+            + "session — nothing runs, nothing is written."
+        if target.base == .workingDirectory {
+            text += " The path resolves against the pane's current directory."
+        }
+        return text
+    }
+}
+
+extension View {
+    /// Presents `controller`'s pending path confirmation — the sibling of
+    /// `terminalLinkConfirmation`, packaged the same way for the same
+    /// type-checker reason.
+    func terminalPathConfirmation(
+        for controller: TerminalSessionController?,
+        hostName: String?,
+        openViewer: ((TerminalPathTarget) -> Void)?
+    ) -> some View {
+        let binding = Binding<TerminalPathTarget?>(
+            get: { controller?.pendingPath },
+            set: { if $0 == nil { controller?.dismissPendingPath() } }
+        )
+        return sheet(item: binding) { target in
+            TerminalFilePathSheet(
+                target: target,
+                hostName: hostName ?? "the host",
+                onView: { openViewer?($0) },
+                onCopy: { controller?.copyPendingPath() }
+            )
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Path press") {
+    TerminalFilePathSheet(
+        target: TerminalPathTarget.resolve("Multiplex/Services/TmuxProbe.swift:42")!,
+        hostName: "devbox",
+        onView: { _ in },
+        onCopy: {}
+    )
+    .frame(width: 720, height: 620)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Multiplex/Views/Terminal/TerminalLinkSheet.swift
+++ b/Multiplex/Views/Terminal/TerminalLinkSheet.swift
@@ -45,18 +45,7 @@ struct TerminalLinkSheet: View {
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
                                 }
-                                VStack(alignment: .leading, spacing: 4) {
-                                    ChassisLabel("TARGET", size: 9, color: Theme.signal3)
-                                    Text(link.raw)
-                                        .font(.mono(11))
-                                        .foregroundStyle(Theme.signal2)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                        .textSelection(.enabled)
-                                }
-                                .padding(10)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(Theme.screen)
-                                .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+                                TerminalSheetValueBox(label: "TARGET", value: link.raw)
 
                                 if let viewport {
                                     VStack(alignment: .leading, spacing: 4) {
@@ -186,6 +175,29 @@ struct TerminalLinkSheet: View {
     }
 }
 
+/// The confirm sheets' boxed value — the resolved target in the mono data
+/// voice on a screen inset. One spelling for the link sheet's TARGET and
+/// the path sheet's PATH, so the two deliberate twins can't drift.
+struct TerminalSheetValueBox: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ChassisLabel(label, size: 9, color: Theme.signal3)
+            Text(value)
+                .font(.mono(11))
+                .foregroundStyle(Theme.signal2)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.screen)
+        .overlay(Rectangle().strokeBorder(Theme.bezelHi, lineWidth: 1))
+    }
+}
+
 extension View {
     /// Presents `controller`'s pending link confirmation. Packaged as one
     /// modifier because `TerminalWindowRoot`'s body is already at the Swift
@@ -212,6 +224,21 @@ extension View {
                 onOpen: { controller?.openPendingLink() },
                 onCopy: { controller?.copyPendingLink() },
                 onOpenViewport: openViewport
+            )
+        }
+    }
+
+    /// The binding-backed spelling, for panes that confirm a link without a
+    /// session controller (a viewport's refused navigation, a markdown
+    /// link) — same sheet, same open/copy actions, no viewport row.
+    func terminalLinkConfirmation(item: Binding<TerminalLink?>) -> some View {
+        sheet(item: item) { link in
+            TerminalLinkSheet(
+                link: link,
+                onOpen: {
+                    if let url = link.openableURL { UIApplication.shared.open(url) }
+                },
+                onCopy: { UIPasteboard.general.string = link.raw }
             )
         }
     }

--- a/Multiplex/Views/Terminal/TerminalTabStrip.swift
+++ b/Multiplex/Views/Terminal/TerminalTabStrip.swift
@@ -13,10 +13,10 @@ struct TerminalTabStrip: View {
         var hostName: String?
         var controller: TerminalSessionController?
         var isActive: Bool
-        /// A viewport tab's cell carries the ⌗ mark in its title and NO
-        /// tally dot — a page is not a shell, and the red dot stays a
-        /// shell's live state.
-        var isViewport = false
+        /// An auxiliary tab (viewport ⌗, file viewer ▤) carries its mark in
+        /// its title and NO tally dot — a page or a file is not a shell,
+        /// and the red dot stays a shell's live state.
+        var isAuxiliary = false
     }
 
     let items: [Item]
@@ -40,7 +40,7 @@ struct TerminalTabStrip: View {
             activate(item.id)
         } label: {
             HStack(spacing: 8) {
-                if !item.isViewport {
+                if !item.isAuxiliary {
                     Circle()
                         .fill(dotColor(item))
                         .frame(width: 6, height: 6)

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -1046,6 +1046,7 @@ struct TerminalWindowRoot: View {
                             FileViewerPane(
                                 controller: fileViewer,
                                 contentSafeArea: contentSafeArea,
+                                isActive: isActive,
                                 close: { close(tab.id) }
                             )
                         }

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -206,6 +206,11 @@ struct TerminalWindowRoot: View {
                 viewportHost: activeTabHost,
                 openViewport: openViewport
             )
+            .terminalPathConfirmation(
+                for: activeController,
+                hostName: activeTabHost?.name,
+                openViewer: { openFileViewer(target: $0) }
+            )
             .alert(
                 "Couldn't Create Session",
                 isPresented: newTabFailedAlertBinding
@@ -266,6 +271,20 @@ struct TerminalWindowRoot: View {
             .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugViewportOpen)) { _ in
                 debugOpenViewportForPendingLink()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugFileViewer)) { _ in
+                debugOpenFileViewer()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugPathView)) { _ in
+                debugViewPendingPath()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugFileViewerRepoDiff)) { _ in
+                // The tree's ± chip, headlessly: the active file-viewer tab
+                // flips to the repo-wide diff.
+                guard let activeTab, activeTab.isFileViewer,
+                      let fileViewer = workspace.fileViewerController(for: activeTab.id)
+                else { return }
+                Task { await fileViewer.showRepoDiff() }
+            }
             .onReceive(NotificationCenter.default.publisher(for: .multiplexDebugLinkRegions)) { _ in
                 debugLogLinkRegions()
             }
@@ -304,9 +323,9 @@ struct TerminalWindowRoot: View {
             }
             // Keyboard focus follows the visible tab…
             .onChange(of: route.activeTabID) { previousTabID, _ in
-                if let activeTab, activeTab.isViewport {
-                    // A page makes no responder claim; the terminal now
-                    // hidden behind it must not keep receiving hardware keys.
+                if let activeTab, activeTab.isAuxiliaryPane {
+                    // A page (or file) makes no responder claim; the terminal
+                    // now hidden behind it must not keep receiving hardware keys.
                     if let previousTabID {
                         workspace.controller(for: previousTabID)?.releaseFocus()
                     }
@@ -372,6 +391,7 @@ struct TerminalWindowRoot: View {
         NewTabDebugHook.install()
         MessageJumpDebugHook.install()
         TerminalLinkDebugHook.install()
+        FileViewerDebugHook.install()
         #endif
         guard let hostID = activeTab?.hostID, let host = store.host(id: hostID) else { return }
         let model = hub.model(for: host)
@@ -393,10 +413,11 @@ struct TerminalWindowRoot: View {
     /// reaches the network-heavy branch app-wide.
     private func watchActivePane() async {
         guard let activeTab,
-              !activeTab.isViewport,
+              !activeTab.isAuxiliaryPane,
               let host = store.host(id: activeTab.hostID)
         else {
-            // A viewport tab has no pane, no agent, and no PTY to watch.
+            // A viewport/file-viewer tab has no pane, no agent, and no PTY
+            // to watch.
             activePaneFingerprint = nil
             shownAgent = nil
             return
@@ -570,6 +591,29 @@ struct TerminalWindowRoot: View {
         openViewport(offer)
     }
 
+    /// The + TAB dropdown's File Viewer action, headlessly — focused
+    /// window only, same gating as the chip hook.
+    private func debugOpenFileViewer() {
+        guard let controller = activeController,
+              let view = controller.terminalView,
+              view === TerminalFocusArbiter.current
+        else { return }
+        openFileViewer(target: nil)
+    }
+
+    /// The path sheet's ▤ VIEW chip, headlessly: requires a pending path
+    /// (raised by `….debug.link` over path-shaped text) and runs the exact
+    /// resolve → dock path the chip takes.
+    private func debugViewPendingPath() {
+        guard let controller = activeController,
+              let view = controller.terminalView,
+              view === TerminalFocusArbiter.current,
+              let target = controller.pendingPath
+        else { return }
+        controller.dismissPendingPath()
+        openFileViewer(target: target)
+    }
+
     /// Headless proof of the visionOS gaze link regions: logs what the
     /// hover overlay would light for the focused terminal (category
     /// `links`, debug level — `log stream`, not `log show`). Gaze itself
@@ -662,6 +706,43 @@ struct TerminalWindowRoot: View {
         }
     }
 
+    /// The active tab's monitor-face close wording — the one string the
+    /// shared chrome varies between the viewport and the file viewer.
+    private var auxiliaryCloseLabel: String {
+        activeTab?.isFileViewer == true ? "Close file viewer" : "Close viewport"
+    }
+
+    /// Dock a file viewer beside the active tab — the viewport's summon
+    /// shape exactly: resolve the pane's cwd first (the same `list-panes`
+    /// truth drops use; nil → the controller roots at $HOME), register the
+    /// controller BEFORE the tab enters the route, insert after the active
+    /// tab, activate. `target` carries a pressed path (and its line) when
+    /// the summon came from the path sheet.
+    private func openFileViewer(target: TerminalPathTarget?) {
+        guard let activeTab, let host = store.host(id: activeTab.hostID) else { return }
+        let anchorID = activeTab.id
+        let hostID = activeTab.hostID
+        Task {
+            let cwd = await workspace.controller(for: anchorID)?.paneWorkingDirectory()
+            let tab = TerminalRoute(
+                hostID: hostID,
+                mode: .fileViewer(path: target?.path ?? cwd ?? "~")
+            )
+            workspace.openFileViewer(
+                tab: tab,
+                host: host,
+                startDirectory: cwd,
+                target: target
+            )
+            if let index = route.tabs.firstIndex(where: { $0.id == anchorID }) {
+                route.tabs.insert(tab, at: index + 1)
+            } else {
+                route.tabs.append(tab)
+            }
+            route.activate(tab.id)
+        }
+    }
+
     /// Dock a confirmed page as a viewport tab immediately after the tab
     /// whose pane printed the URL — the + TAB precedent: arrive where you
     /// are, move later (split it out to stand beside the terminal, merge it
@@ -727,17 +808,18 @@ struct TerminalWindowRoot: View {
                 // below-edge anchor (.top) parked the keys and window bar in
                 // the floating keyboard's summon zone (both user-reported).
                 .ornament(attachmentAnchor: .scene(.bottom), contentAlignment: .center) {
-                    if activeTab?.isViewport == true {
-                        // A page needs no keys, helper strip, or session
-                        // controls — the viewport face carries DECK, the
-                        // source label, MERGE, and CLOSE; the in-window rail
-                        // owns everything page-scoped.
+                    if activeTab?.isAuxiliaryPane == true {
+                        // A page (or file screen) needs no keys, helper
+                        // strip, or session controls — the monitor face
+                        // carries DECK, the source label, MERGE, and CLOSE;
+                        // the in-window rail owns everything pane-scoped.
                         ViewportUMD(
                             title: umdTitle,
                             mergeSources: mergeSources,
                             showDeck: showDeck,
                             merge: { merge($0) },
-                            close: { if let activeTab { close(activeTab.id) } }
+                            close: { if let activeTab { close(activeTab.id) } },
+                            closeAccessibilityLabel: auxiliaryCloseLabel
                         )
                         .alignmentGuide(VerticalAlignment.center) { _ in 24 }
                     } else {
@@ -779,6 +861,7 @@ struct TerminalWindowRoot: View {
                                     fontDown: { fontSize = max(9, fontSize - 1) },
                                     fontUp: { fontSize = min(32, fontSize + 1) },
                                     newSession: { openNewTab(launching: $0) },
+                                    openFileViewer: { openFileViewer(target: nil) },
                                     merge: { merge($0) },
                                     detach: { detachActiveTab() },
                                     closeSession: activeTabHasSession
@@ -836,7 +919,7 @@ struct TerminalWindowRoot: View {
 
     private func shellBody(_ configuration: ShellConfiguration) -> some View {
         VStack(spacing: 0) {
-            if activeTab?.isViewport == true {
+            if activeTab?.isAuxiliaryPane == true {
                 ViewportUMD(
                     title: umdTitle,
                     mergeSources: [],
@@ -845,7 +928,8 @@ struct TerminalWindowRoot: View {
                     close: { if let activeTab { close(activeTab.id) } },
                     style: .shell,
                     deckControlLabel: configuration.deckControlLabel,
-                    contentSafeArea: configuration.contentSafeArea
+                    contentSafeArea: configuration.contentSafeArea,
+                    closeAccessibilityLabel: auxiliaryCloseLabel
                 )
             } else {
             UMDBar(
@@ -856,6 +940,7 @@ struct TerminalWindowRoot: View {
                 fontDown: { fontSize = max(9, fontSize - 1) },
                 fontUp: { fontSize = min(32, fontSize + 1) },
                 newSession: { openNewTab(launching: $0) },
+                openFileViewer: { openFileViewer(target: nil) },
                 merge: { _ in },
                 detach: { detachActiveTab() },
                 closeSession: activeTabHasSession
@@ -882,7 +967,7 @@ struct TerminalWindowRoot: View {
             #if os(visionOS)
             paneStack
                 .overlay(alignment: .bottom) {
-                    if activeTab?.isViewport != true {
+                    if activeTab?.isAuxiliaryPane != true {
                         VStack(spacing: 8) {
                             helperStrip(
                                 floating: true,
@@ -951,6 +1036,15 @@ struct TerminalWindowRoot: View {
                         if let viewport = workspace.viewportController(for: tab.id) {
                             ViewportPane(
                                 controller: viewport,
+                                contentSafeArea: contentSafeArea,
+                                close: { close(tab.id) }
+                            )
+                        }
+                    } else if tab.isFileViewer {
+                        // Same guarantee, same strip rule (isAuxiliaryPane).
+                        if let fileViewer = workspace.fileViewerController(for: tab.id) {
+                            FileViewerPane(
+                                controller: fileViewer,
                                 contentSafeArea: contentSafeArea,
                                 close: { close(tab.id) }
                             )
@@ -1034,12 +1128,18 @@ struct TerminalWindowRoot: View {
 
     /// A viewport tab's label follows the page it is on — the route's
     /// urlString is only the address it was summoned with, and the rail's
-    /// editor can move the page after that.
+    /// editor can move the page after that. A file viewer's label follows
+    /// the file on screen the same way.
     private func tabTitle(for tab: TerminalRoute) -> String {
-        guard tab.isViewport,
-              let viewport = workspace.viewportController(for: tab.id)
-        else { return tab.displayName }
-        return TerminalRoute.viewportLabel(viewport.displayURL.absoluteString)
+        if tab.isViewport,
+           let viewport = workspace.viewportController(for: tab.id) {
+            return TerminalRoute.viewportLabel(viewport.displayURL.absoluteString)
+        }
+        if tab.isFileViewer,
+           let fileViewer = workspace.fileViewerController(for: tab.id) {
+            return "▤ \(fileViewer.displayName)"
+        }
+        return tab.displayName
     }
 
     private var tabItems: [TerminalTabStrip.Item] {
@@ -1051,7 +1151,7 @@ struct TerminalWindowRoot: View {
                 hostName: multiHost ? store.host(id: tab.hostID)?.name : nil,
                 controller: workspace.controller(for: tab.id),
                 isActive: tab.id == activeTab?.id,
-                isViewport: tab.isViewport
+                isAuxiliary: tab.isAuxiliaryPane
             )
         }
     }
@@ -1137,10 +1237,11 @@ struct TerminalWindowRoot: View {
             )
             .accessibilityHint("Shows how to unlock the keychain")
         }
-        if activeTab?.isViewport == true {
-            // A page needs none of the terminal's controls: MERGE (the road
-            // home for a split-out viewport) and CLOSE are the window's
-            // whole vocabulary — the rail under the page owns the rest.
+        if activeTab?.isAuxiliaryPane == true {
+            // A page (or file screen) needs none of the terminal's
+            // controls: MERGE (the road home for a split-out tab) and
+            // CLOSE are the window's whole vocabulary — the rail under
+            // the pane owns the rest.
             if !mergeSources.isEmpty {
                 mergeMenu
             }
@@ -1148,7 +1249,7 @@ struct TerminalWindowRoot: View {
                 if let activeTab { close(activeTab.id) }
             }
             .fixedSize()
-            .accessibilityLabel("Close viewport")
+            .accessibilityLabel(auxiliaryCloseLabel)
             .padding(.trailing, trailingPadding)
         } else if horizontalSizeClass == .compact {
             // UIKit's automatic toolbar overflow keeps only the trailing
@@ -1177,6 +1278,7 @@ struct TerminalWindowRoot: View {
             fontDown: { fontSize = max(9, fontSize - 1) },
             fontUp: { fontSize = min(32, fontSize + 1) },
             newSession: { openNewTab(launching: $0) },
+            openFileViewer: { openFileViewer(target: nil) },
             merge: { merge($0) },
             detach: { detachActiveTab() },
             closeSession: activeTabHasSession
@@ -1212,13 +1314,16 @@ struct TerminalWindowRoot: View {
     }
 
     /// Dropdown: a fresh session in the active tab's directory, plain or
-    /// launching an agent — mirrors the deck's New Session options.
+    /// launching an agent — mirrors the deck's New Session options — plus
+    /// the file viewer, which docks beside this tab at the pane's cwd.
     private var newTabMenu: some View {
         Menu {
             Button("New Session") { openNewTab(launching: nil) }
             ForEach(AgentKind.allCases, id: \.self) { agent in
                 Button(agent.displayName) { openNewTab(launching: agent) }
             }
+            Divider()
+            Button("File Viewer") { openFileViewer(target: nil) }
         } label: {
             ChassisBadge("TAB", systemImage: "plus")
         }
@@ -1226,7 +1331,7 @@ struct TerminalWindowRoot: View {
         .buttonStyle(.plain)
         .chassisHover(2)
         .fixedSize()
-        .accessibilityLabel("New tab: another session in this window")
+        .accessibilityLabel("New tab: another session or the file viewer")
     }
 
     private var deckButton: some View {
@@ -1299,15 +1404,22 @@ struct TerminalWindowRoot: View {
     /// closes), otherwise controllers exist for every tab and the window's
     /// directory entry is fresh.
     private func syncTabs() {
-        // The viewport's no-persistence rule: its controllers exist only in
-        // the process that summoned them (`openViewport` registers before
-        // the tab enters any route), so a viewport tab without one can only
-        // be scene restoration handing back a previous launch's page —
-        // summoned, not restored, it is stripped rather than resurrected.
-        // The mutation re-enters here through onChange; the second pass
-        // finds nothing to strip.
-        let restoredViewports = route.tabs.filter {
-            $0.isViewport && workspace.viewportController(for: $0.id) == nil
+        // The auxiliary panes' no-persistence rule: viewport and file-viewer
+        // controllers exist only in the process that summoned them
+        // (`openViewport`/`openFileViewer` register before the tab enters
+        // any route), so an auxiliary tab without one can only be scene
+        // restoration handing back a previous launch's page — summoned, not
+        // restored, it is stripped rather than resurrected. The mutation
+        // re-enters here through onChange; the second pass finds nothing to
+        // strip.
+        let restoredViewports = route.tabs.filter { tab in
+            if tab.isViewport {
+                return workspace.viewportController(for: tab.id) == nil
+            }
+            if tab.isFileViewer {
+                return workspace.fileViewerController(for: tab.id) == nil
+            }
+            return false
         }
         if !restoredViewports.isEmpty {
             let ids = Set(restoredViewports.map(\.id))
@@ -1329,7 +1441,9 @@ struct TerminalWindowRoot: View {
             }
             return
         }
-        for tab in route.tabs where !tab.isViewport {
+        for tab in route.tabs where !tab.isAuxiliaryPane {
+            // Auxiliary tabs must never mint a TerminalSessionController —
+            // a file-viewer route has no PTY to dial.
             _ = workspace.controller(for: tab, store: store)
         }
         workspace.registerWindow(.init(
@@ -1850,6 +1964,46 @@ extension Notification.Name {
     static let multiplexDebugLinkOpen = Notification.Name("MultiplexDebugLinkOpen")
     static let multiplexDebugViewportOpen = Notification.Name("MultiplexDebugViewportOpen")
     static let multiplexDebugLinkRegions = Notification.Name("MultiplexDebugLinkRegions")
+    static let multiplexDebugFileViewer = Notification.Name("MultiplexDebugFileViewer")
+    static let multiplexDebugPathView = Notification.Name("MultiplexDebugPathView")
+    static let multiplexDebugFileViewerRepoDiff = Notification.Name(
+        "MultiplexDebugFileViewerRepoDiff"
+    )
+}
+
+/// `….debug.fileviewer` runs the focused window's + TAB ▸ File Viewer
+/// action (pane-cwd resolve → controller registration → tab dock);
+/// `….debug.pathview` runs the path sheet's ▤ VIEW for the pending path a
+/// prior `….debug.link` raised over path-shaped text — together the
+/// headless walk of both summon doors.
+@MainActor
+enum FileViewerDebugHook {
+    private static var installed = false
+
+    static func install() {
+        guard !installed else { return }
+        installed = true
+        var openToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.fileviewer", &openToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugFileViewer, object: nil)
+        }
+        var viewToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.pathview", &viewToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugPathView, object: nil)
+        }
+        var repoDiffToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.fvrepodiff", &repoDiffToken, .main
+        ) { _ in
+            NotificationCenter.default.post(
+                name: .multiplexDebugFileViewerRepoDiff, object: nil
+            )
+        }
+    }
 }
 
 /// `….debug.link` activates the first link on the focused terminal's visible

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -734,12 +734,7 @@ struct TerminalWindowRoot: View {
                 startDirectory: cwd,
                 target: target
             )
-            if let index = route.tabs.firstIndex(where: { $0.id == anchorID }) {
-                route.tabs.insert(tab, at: index + 1)
-            } else {
-                route.tabs.append(tab)
-            }
-            route.activate(tab.id)
+            dock(tab, after: anchorID)
         }
     }
 
@@ -756,7 +751,14 @@ struct TerminalWindowRoot: View {
             mode: .viewport(urlString: offer.url.absoluteString)
         )
         workspace.openViewport(tab: tab, offer: offer, host: host)
-        if let index = route.tabs.firstIndex(where: { $0.id == activeTab.id }) {
+        dock(tab, after: activeTab.id)
+    }
+
+    /// Insert a freshly summoned tab immediately after its anchor (the
+    /// + TAB precedent: arrive where you are, move later) and make it
+    /// active — the shared tail of every auxiliary summon.
+    private func dock(_ tab: TerminalRoute, after anchorID: UUID) {
+        if let index = route.tabs.firstIndex(where: { $0.id == anchorID }) {
             route.tabs.insert(tab, at: index + 1)
         } else {
             route.tabs.append(tab)
@@ -1127,18 +1129,13 @@ struct TerminalWindowRoot: View {
         }
     }
 
-    /// A viewport tab's label follows the page it is on — the route's
-    /// urlString is only the address it was summoned with, and the rail's
-    /// editor can move the page after that. A file viewer's label follows
-    /// the file on screen the same way.
+    /// An auxiliary tab's label follows what its pane is showing NOW — the
+    /// route only knows the summons (a viewport's page moves, a viewer
+    /// navigates), so the live controller answers whenever it exists.
     private func tabTitle(for tab: TerminalRoute) -> String {
-        if tab.isViewport,
-           let viewport = workspace.viewportController(for: tab.id) {
-            return TerminalRoute.viewportLabel(viewport.displayURL.absoluteString)
-        }
-        if tab.isFileViewer,
-           let fileViewer = workspace.fileViewerController(for: tab.id) {
-            return "▤ \(fileViewer.displayName)"
+        if tab.isAuxiliaryPane,
+           let auxiliary = workspace.auxiliaryController(for: tab.id) {
+            return auxiliary.tabLabel
         }
         return tab.displayName
     }
@@ -1319,12 +1316,10 @@ struct TerminalWindowRoot: View {
     /// the file viewer, which docks beside this tab at the pane's cwd.
     private var newTabMenu: some View {
         Menu {
-            Button("New Session") { openNewTab(launching: nil) }
-            ForEach(AgentKind.allCases, id: \.self) { agent in
-                Button(agent.displayName) { openNewTab(launching: agent) }
-            }
-            Divider()
-            Button("File Viewer") { openFileViewer(target: nil) }
+            NewTabMenuItems(
+                newSession: { openNewTab(launching: $0) },
+                openFileViewer: { openFileViewer(target: nil) }
+            )
         } label: {
             ChassisBadge("TAB", systemImage: "plus")
         }
@@ -1405,25 +1400,18 @@ struct TerminalWindowRoot: View {
     /// closes), otherwise controllers exist for every tab and the window's
     /// directory entry is fresh.
     private func syncTabs() {
-        // The auxiliary panes' no-persistence rule: viewport and file-viewer
-        // controllers exist only in the process that summoned them
-        // (`openViewport`/`openFileViewer` register before the tab enters
-        // any route), so an auxiliary tab without one can only be scene
-        // restoration handing back a previous launch's page — summoned, not
-        // restored, it is stripped rather than resurrected. The mutation
-        // re-enters here through onChange; the second pass finds nothing to
-        // strip.
-        let restoredViewports = route.tabs.filter { tab in
-            if tab.isViewport {
-                return workspace.viewportController(for: tab.id) == nil
-            }
-            if tab.isFileViewer {
-                return workspace.fileViewerController(for: tab.id) == nil
-            }
-            return false
+        // The auxiliary panes' no-persistence rule: their controllers exist
+        // only in the process that summoned them (`openViewport`/
+        // `openFileViewer` register before the tab enters any route), so an
+        // auxiliary tab without one can only be scene restoration handing
+        // back a previous launch's pane — summoned, not restored, it is
+        // stripped rather than resurrected. The mutation re-enters here
+        // through onChange; the second pass finds nothing to strip.
+        let orphanedAuxiliaries = route.tabs.filter { tab in
+            tab.isAuxiliaryPane && workspace.auxiliaryController(for: tab.id) == nil
         }
-        if !restoredViewports.isEmpty {
-            let ids = Set(restoredViewports.map(\.id))
+        if !orphanedAuxiliaries.isEmpty {
+            let ids = Set(orphanedAuxiliaries.map(\.id))
             route.tabs.removeAll { ids.contains($0.id) }
             if let active = route.activeTabID, ids.contains(active) {
                 route.activeTabID = route.tabs.first?.id
@@ -1671,7 +1659,7 @@ private struct TerminalPane: View {
     private func statusOverlay(for controller: TerminalSessionController) -> some View {
         switch controller.status {
         case .connecting:
-            chassisPanel {
+            ChassisPanel {
                 ProgressView()
                 Text(connectingCaption(for: controller))
                     .font(.mono(14))
@@ -1680,7 +1668,7 @@ private struct TerminalPane: View {
         case .live:
             EmptyView()
         case .ended(let reason):
-            chassisPanel {
+            ChassisPanel {
                 TallyLamp(caption: reason == nil ? "DETACHED" : "ENDED", color: Theme.signal3)
                 if let reason {
                     Text(reason)
@@ -1710,7 +1698,7 @@ private struct TerminalPane: View {
 
     /// A restored tab whose host was removed — say so, never a blank pane.
     private var missingHost: some View {
-        chassisPanel {
+        ChassisPanel {
             Text("This host was removed")
                 .font(.mono(17, weight: .semibold))
                 .foregroundStyle(Theme.signal)
@@ -1722,17 +1710,6 @@ private struct TerminalPane: View {
             ChassisChip("CLOSE TAB", prominent: true) { close() }
                 .padding(.top, 4)
         }
-    }
-
-    private func chassisPanel<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        VStack(spacing: 14) {
-            content()
-        }
-        .padding(30)
-        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Theme.bezelHi, lineWidth: 1))
     }
 }
 

--- a/Multiplex/Views/Terminal/UMDBar.swift
+++ b/Multiplex/Views/Terminal/UMDBar.swift
@@ -25,6 +25,8 @@ struct UMDBar: View {
     /// New tab: a fresh session on the active tab's host, in its pane's
     /// directory — nil for a plain shell session, or an agent to launch.
     var newSession: (AgentKind?) -> Void
+    /// New tab: the file viewer, rooted at the active pane's directory.
+    var openFileViewer: () -> Void
     var merge: (UUID) -> Void
     var detach: () -> Void
     /// Kill the active tab's tmux session, then close the tab — the detach
@@ -190,13 +192,15 @@ struct UMDBar: View {
             ForEach(AgentKind.allCases, id: \.self) { agent in
                 Button(agent.displayName) { newSession(agent) }
             }
+            Divider()
+            Button("File Viewer") { openFileViewer() }
         } label: {
             ChassisBadge("TAB", systemImage: "plus")
         }
         .menuStyle(.button)
         .buttonStyle(.plain)
         .chassisHover(2)
-        .accessibilityLabel("New tab: another session in this window")
+        .accessibilityLabel("New tab: another session or the file viewer")
     }
 
     private var tmuxShortcutButton: some View {
@@ -237,6 +241,7 @@ struct UMDBar: View {
             fontDown: fontDown,
             fontUp: fontUp,
             newSession: newSession,
+            openFileViewer: openFileViewer,
             merge: merge,
             detach: detach,
             closeSession: closeSession
@@ -358,6 +363,7 @@ struct TerminalOverflowMenu: View {
     var fontDown: () -> Void
     var fontUp: () -> Void
     var newSession: (AgentKind?) -> Void
+    var openFileViewer: () -> Void
     var merge: (UUID) -> Void
     var detach: () -> Void
     var closeSession: (() -> Void)?
@@ -378,6 +384,8 @@ struct TerminalOverflowMenu: View {
                 ForEach(AgentKind.allCases, id: \.self) { agent in
                     Button(agent.displayName) { newSession(agent) }
                 }
+                Divider()
+                Button("File Viewer") { openFileViewer() }
             }
             FileAttachSubmenu(controller: controller) {
                 requestedFileAttachPicker = $0
@@ -430,6 +438,7 @@ struct TerminalOverflowMenu: View {
         fontDown: {},
         fontUp: {},
         newSession: { _ in },
+        openFileViewer: {},
         merge: { _ in },
         detach: {},
         closeSession: {}
@@ -447,6 +456,7 @@ struct TerminalOverflowMenu: View {
         fontDown: {},
         fontUp: {},
         newSession: { _ in },
+        openFileViewer: {},
         merge: { _ in },
         detach: {},
         closeSession: {},

--- a/Multiplex/Views/Terminal/UMDBar.swift
+++ b/Multiplex/Views/Terminal/UMDBar.swift
@@ -188,12 +188,7 @@ struct UMDBar: View {
 
     private var newTabMenu: some View {
         Menu {
-            Button("New Session") { newSession(nil) }
-            ForEach(AgentKind.allCases, id: \.self) { agent in
-                Button(agent.displayName) { newSession(agent) }
-            }
-            Divider()
-            Button("File Viewer") { openFileViewer() }
+            NewTabMenuItems(newSession: newSession, openFileViewer: openFileViewer)
         } label: {
             ChassisBadge("TAB", systemImage: "plus")
         }
@@ -354,6 +349,25 @@ struct UMDBar: View {
     }
 }
 
+/// The + TAB dropdown's content — a fresh session in the active tab's
+/// directory, plain or launching an agent (the deck's New Session grammar),
+/// plus the file viewer. ONE spelling for its three homes — the classic
+/// toolbar, the UMD bar, and the compact overflow's New Tab submenu — so a
+/// new entry lands on every surface or none.
+struct NewTabMenuItems: View {
+    var newSession: (AgentKind?) -> Void
+    var openFileViewer: () -> Void
+
+    var body: some View {
+        Button("New Session") { newSession(nil) }
+        ForEach(AgentKind.allCases, id: \.self) { agent in
+            Button(agent.displayName) { newSession(agent) }
+        }
+        Divider()
+        Button("File Viewer") { openFileViewer() }
+    }
+}
+
 /// Shared compact action menu for the iPhone shell and narrow classic iPad
 /// windows. Keeping one menu definition prevents either compact surface from
 /// silently losing actions as the regular terminal chrome evolves.
@@ -380,12 +394,7 @@ struct TerminalOverflowMenu: View {
                 Button("Larger Text", action: fontUp)
             }
             Menu("New Tab") {
-                Button("New Session") { newSession(nil) }
-                ForEach(AgentKind.allCases, id: \.self) { agent in
-                    Button(agent.displayName) { newSession(agent) }
-                }
-                Divider()
-                Button("File Viewer") { openFileViewer() }
+                NewTabMenuItems(newSession: newSession, openFileViewer: openFileViewer)
             }
             FileAttachSubmenu(controller: controller) {
                 requestedFileAttachPicker = $0

--- a/Multiplex/Views/Terminal/ViewportPane.swift
+++ b/Multiplex/Views/Terminal/ViewportPane.swift
@@ -64,15 +64,7 @@ struct ViewportPane: View {
         // A page may navigate to something the gate refuses to render
         // (mailto, a custom scheme). Same discipline as a pane press: the
         // target is shown and confirmed, never followed.
-        .sheet(item: $controller.externalLink) { link in
-            TerminalLinkSheet(
-                link: link,
-                onOpen: {
-                    if let url = link.openableURL { UIApplication.shared.open(url) }
-                },
-                onCopy: { UIPasteboard.general.string = link.raw }
-            )
-        }
+        .terminalLinkConfirmation(item: $controller.externalLink)
     }
 
     // MARK: Rail
@@ -239,8 +231,7 @@ struct ViewportPane: View {
     /// happened and, when the address lives on the host's network, whose
     /// network that is.
     private func failurePanel(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            TallyLamp(caption: "NO ROUTE", color: Theme.caution)
+        ChassisPanel(caption: "NO ROUTE") {
             Text(message)
                 .font(.subheadline)
                 .foregroundStyle(Theme.signal2)
@@ -259,11 +250,6 @@ struct ViewportPane: View {
             }
             .padding(.top, 4)
         }
-        .padding(30)
-        .background(Theme.bezel, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Theme.bezelHi, lineWidth: 1))
         .padding(20)
     }
 

--- a/Multiplex/Views/Terminal/ViewportPane.swift
+++ b/Multiplex/Views/Terminal/ViewportPane.swift
@@ -338,6 +338,9 @@ struct ViewportUMD: View {
     var style: Style = .regular
     var deckControlLabel = "DECK"
     var contentSafeArea = EdgeInsets()
+    /// The file viewer shares this monitor face; only the close wording
+    /// differs.
+    var closeAccessibilityLabel = "Close viewport"
 
     @ViewBuilder
     var body: some View {
@@ -357,7 +360,7 @@ struct ViewportUMD: View {
             }
             divider
             ChassisChip("CLOSE", prominent: true, action: close)
-                .accessibilityLabel("Close viewport")
+                .accessibilityLabel(closeAccessibilityLabel)
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 11)
@@ -376,7 +379,7 @@ struct ViewportUMD: View {
             Spacer(minLength: 4)
             ChassisChip("CLOSE", prominent: true, action: close)
                 .fixedSize()
-                .accessibilityLabel("Close viewport")
+                .accessibilityLabel(closeAccessibilityLabel)
         }
         .padding(.leading, 10 + contentSafeArea.leading)
         .padding(.trailing, 10 + contentSafeArea.trailing)

--- a/MultiplexTests/CodeHighlighterTests.swift
+++ b/MultiplexTests/CodeHighlighterTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import Multiplex
+
+final class CodeHighlighterTests: XCTestCase {
+    private func kinds(
+        _ line: String,
+        _ language: CodeLanguage
+    ) -> [(String, CodeTokenKind)] {
+        let lines = CodeHighlighter.highlight(line, language: language)
+        return lines.first?.segments.map { ($0.text, $0.kind) } ?? []
+    }
+
+    private func kind(
+        of word: String,
+        in line: String,
+        _ language: CodeLanguage
+    ) -> CodeTokenKind? {
+        kinds(line, language).first { $0.0 == word }?.1
+    }
+
+    // MARK: The invariant: segments always rebuild the exact line
+
+    func testSegmentsRejoinToOriginalText() {
+        let samples: [(CodeLanguage, String)] = [
+            (.swift, "func probe(_ x: Int) -> String { return \"\\(x)\" } // trailing"),
+            (.typescript, "const url = `https://${host}:${port}/api`; // template"),
+            (.python, "def f(x): return {'a': 1, \"b\": x}  # dict"),
+            (.rust, "let mut v: Vec<u32> = vec![1, 0xFF, 2_000];"),
+            (.go, "func main() { fmt.Println(`raw`) }"),
+            (.shell, "if [ -n \"$HOME\" ]; then echo ${PATH}; fi # done"),
+            (.json, "{\"key\": [1, 2.5, true, null], \"s\": \"v\"}"),
+            (.yaml, "key: value # comment"),
+            (.html, "<div class=\"row\" data-x='1'>text &amp; more</div>"),
+            (.sql, "SELECT id, name FROM users WHERE age > 21 -- adults"),
+            (.css, "body { color: #fff; margin: 0 auto; } /* base */"),
+        ]
+        for (language, line) in samples {
+            let highlighted = CodeHighlighter.highlight(line, language: language)
+            XCTAssertEqual(highlighted.count, 1, line)
+            XCTAssertEqual(highlighted[0].text, line, "segments must cover the line exactly")
+        }
+    }
+
+    // MARK: Basic classification
+
+    func testSwiftBasics() {
+        let line = "func probe(name: String) -> Int { return 42 } // answer"
+        XCTAssertEqual(kind(of: "func", in: line, .swift), .keyword)
+        XCTAssertEqual(kind(of: "probe", in: line, .swift), .function)
+        XCTAssertEqual(kind(of: "String", in: line, .swift), .type)
+        XCTAssertEqual(kind(of: "return", in: line, .swift), .keyword)
+        XCTAssertEqual(kind(of: "42", in: line, .swift), .number)
+        XCTAssertEqual(kind(of: "// answer", in: line, .swift), .comment)
+    }
+
+    func testSwiftAttributeAndDirective() {
+        XCTAssertEqual(kind(of: "@Observable", in: "@Observable final class X {}", .swift), .meta)
+        XCTAssertEqual(kind(of: "#if", in: "#if os(visionOS)", .swift), .meta)
+    }
+
+    func testStringWithEscapes() {
+        // Adjacent same-kind segments merge, so plain text around the
+        // string coalesces — assert containment, not exact splits.
+        let segments = kinds("let s = \"a \\\" quote\" + tail", .swift)
+        XCTAssertTrue(segments.contains { $0.0 == "\"a \\\" quote\"" && $0.1 == .string })
+        XCTAssertTrue(segments.contains { $0.0.hasSuffix("tail") && $0.1 == .plain })
+    }
+
+    func testBlockCommentCarriesAcrossLines() {
+        let lines = CodeHighlighter.highlight("let a = 1 /* start\nstill inside\nend */ let b = 2", language: .swift)
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertTrue(lines[1].segments.allSatisfy { $0.kind == .comment })
+        XCTAssertTrue(lines[2].segments.contains { $0.text.contains("end */") && $0.kind == .comment })
+        XCTAssertTrue(lines[2].segments.contains { $0.text == "let" && $0.kind == .keyword })
+    }
+
+    func testSwiftNestedBlockComments() {
+        let lines = CodeHighlighter.highlight("/* outer /* inner */ still */ let x = 1", language: .swift)
+        let segments = lines[0].segments
+        XCTAssertEqual(segments.first?.kind, .comment)
+        XCTAssertTrue(segments.first!.text.hasSuffix("still */"))
+        XCTAssertTrue(segments.contains { $0.text == "let" && $0.kind == .keyword })
+    }
+
+    func testPythonTripleQuoteCarries() {
+        let lines = CodeHighlighter.highlight("x = \"\"\"doc\nline two\n\"\"\" + y", language: .python)
+        XCTAssertTrue(lines[1].segments.allSatisfy { $0.kind == .string })
+        XCTAssertTrue(lines[2].segments.contains { $0.text.hasSuffix("y") && $0.kind == .plain })
+    }
+
+    func testTemplateLiteralCarries() {
+        let lines = CodeHighlighter.highlight("const s = `one\ntwo` + x", language: .typescript)
+        XCTAssertTrue(lines[0].segments.contains { $0.text == "`one" && $0.kind == .string })
+        XCTAssertTrue(lines[1].segments.contains { $0.text == "two`" && $0.kind == .string })
+        XCTAssertTrue(lines[1].segments.contains { $0.text.hasSuffix("x") && $0.kind == .plain })
+    }
+
+    func testUnterminatedPlainStringDoesNotCarry() {
+        let lines = CodeHighlighter.highlight("let s = \"open\nlet t = 2", language: .swift)
+        // Next line must highlight normally, not drown in string color.
+        XCTAssertTrue(lines[1].segments.contains { $0.text == "let" && $0.kind == .keyword })
+    }
+
+    func testJSONKeysAreProperties() {
+        let segments = kinds("{stable: true, other: 2}", .json)
+        XCTAssertTrue(segments.contains { $0.0 == "stable" && $0.1 == .property })
+        XCTAssertTrue(segments.contains { $0.0 == "true" && $0.1 == .keyword })
+    }
+
+    func testYAMLCommentNeedsBoundary() {
+        // In-word # must not start a comment...
+        let inWord = kinds("url: http://x/a#anchor", .yaml)
+        XCTAssertFalse(inWord.contains { $0.1 == .comment })
+        // ...but a spaced one does.
+        let spaced = kinds("key: value # note", .yaml)
+        XCTAssertTrue(spaced.contains { $0.0 == "# note" && $0.1 == .comment })
+    }
+
+    func testShellVariables() {
+        let segments = kinds("echo $HOME ${PATH} $(pwd)", .shell)
+        XCTAssertTrue(segments.contains { $0.0 == "$HOME" && $0.1 == .property })
+        XCTAssertTrue(segments.contains { $0.0 == "${PATH}" && $0.1 == .property })
+        XCTAssertTrue(segments.contains { $0.0 == "$(pwd)" && $0.1 == .property })
+    }
+
+    func testSQLKeywordsCaseInsensitive() {
+        XCTAssertEqual(kind(of: "select", in: "select id from t", .sql), .keyword)
+        XCTAssertEqual(kind(of: "SELECT", in: "SELECT id FROM t", .sql), .keyword)
+    }
+
+    func testTOMLSectionHeader() {
+        let lines = CodeHighlighter.highlight("[dependencies]\nname = \"serde\"", language: .toml)
+        XCTAssertEqual(lines[0].segments.first?.kind, .meta)
+        XCTAssertTrue(lines[1].segments.contains { $0.text == "\"serde\"" && $0.kind == .string })
+    }
+
+    func testMarkupTagsAttributesAndCommentCarry() {
+        let lines = CodeHighlighter.highlight("<div class=\"row\">\n<!-- note\nstill -->\n</div>", language: .html)
+        XCTAssertTrue(lines[0].segments.contains { $0.text == "<div" && $0.kind == .keyword })
+        XCTAssertTrue(lines[0].segments.contains { $0.text == "class" && $0.kind == .property })
+        XCTAssertTrue(lines[0].segments.contains { $0.text == "\"row\"" && $0.kind == .string })
+        XCTAssertTrue(lines[1].segments.allSatisfy { $0.kind == .comment })
+        XCTAssertTrue(lines[2].segments.allSatisfy { $0.kind == .comment })
+        // "</div" and ">" are both keyword ink, so they merge into one run.
+        XCTAssertTrue(lines[3].segments.contains { $0.text == "</div>" && $0.kind == .keyword })
+    }
+
+    func testPlainLanguageFastPath() {
+        let lines = CodeHighlighter.highlight("anything at all // not a comment", language: nil)
+        XCTAssertEqual(lines[0].segments.count, 1)
+        XCTAssertEqual(lines[0].segments[0].kind, .plain)
+    }
+
+    func testHexAndUnderscoreNumbers() {
+        XCTAssertEqual(kind(of: "0xFF", in: "let x = 0xFF", .swift), .number)
+        XCTAssertEqual(kind(of: "1_000_000", in: "let y = 1_000_000", .swift), .number)
+    }
+
+    func testEmptyLinesKeepOneSegment() {
+        let lines = CodeHighlighter.highlight("a\n\nb", language: .swift)
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertEqual(lines[1].text, "")
+    }
+}

--- a/MultiplexTests/FileKindTests.swift
+++ b/MultiplexTests/FileKindTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Multiplex
+
+final class FileKindTests: XCTestCase {
+    func testExtensionClassification() {
+        XCTAssertEqual(FileKind.classify(fileName: "App.swift"), .code(.swift))
+        XCTAssertEqual(FileKind.classify(fileName: "probe.ts"), .code(.typescript))
+        XCTAssertEqual(FileKind.classify(fileName: "Widget.tsx"), .code(.typescript))
+        XCTAssertEqual(FileKind.classify(fileName: "main.rs"), .code(.rust))
+        XCTAssertEqual(FileKind.classify(fileName: "README.md"), .markdown)
+        XCTAssertEqual(FileKind.classify(fileName: "shot.PNG"), .image)
+        XCTAssertEqual(FileKind.classify(fileName: "bundle.zip"), .binary)
+        XCTAssertEqual(FileKind.classify(fileName: "no-extension"), .code(nil))
+        XCTAssertEqual(FileKind.classify(fileName: "weird.xyzzy"), .code(nil))
+    }
+
+    func testFullNameClassification() {
+        XCTAssertEqual(FileKind.classify(fileName: "Dockerfile"), .code(.dockerfile))
+        XCTAssertEqual(FileKind.classify(fileName: "Makefile"), .code(.makefile))
+        XCTAssertEqual(FileKind.classify(fileName: ".gitignore"), .code(.ini))
+        XCTAssertEqual(FileKind.classify(fileName: "Gemfile"), .code(.ruby))
+        XCTAssertEqual(FileKind.classify(fileName: "README"), .markdown)
+    }
+
+    func testCompoundArchiveExtensions() {
+        XCTAssertEqual(FileKind.classify(fileName: "release.tar.gz"), .binary)
+    }
+
+    func testDotfileIsNotAnExtension() {
+        // ".zshrc" — the leading dot is a hidden-file marker, not an
+        // extension separator.
+        XCTAssertEqual(FileKind.classify(fileName: ".zshrc"), .code(.shell))
+    }
+
+    func testFenceLanguage() {
+        XCTAssertEqual(FileKind.fenceLanguage("swift"), .swift)
+        XCTAssertEqual(FileKind.fenceLanguage("ts"), .typescript)
+        XCTAssertEqual(FileKind.fenceLanguage("typescript title=\"x\""), .typescript)
+        XCTAssertEqual(FileKind.fenceLanguage("objective-c"), .objectiveC)
+        XCTAssertNil(FileKind.fenceLanguage(""))
+        XCTAssertNil(FileKind.fenceLanguage("madeup"))
+    }
+
+    func testBinarySniff() {
+        XCTAssertTrue(FileKind.looksBinary(Data([0x89, 0x50, 0x4E, 0x47, 0x00, 0x01])))
+        XCTAssertFalse(FileKind.looksBinary(Data("plain utf8 ✳ text".utf8)))
+        XCTAssertFalse(FileKind.looksBinary(Data()))
+    }
+}
+
+final class TerminalPathTargetTests: XCTestCase {
+    func testAbsoluteHomeAndRelative() {
+        XCTAssertEqual(TerminalPathTarget.resolve("/etc/hosts")?.base, .absolute)
+        XCTAssertEqual(TerminalPathTarget.resolve("~/notes/todo.md")?.base, .home)
+        XCTAssertEqual(TerminalPathTarget.resolve("$HOME/notes.md")?.base, .home)
+        XCTAssertEqual(TerminalPathTarget.resolve("./src/main.rs")?.base, .workingDirectory)
+        XCTAssertEqual(TerminalPathTarget.resolve("../lib/util.ts")?.base, .workingDirectory)
+        XCTAssertEqual(TerminalPathTarget.resolve("src/foo.ts")?.base, .workingDirectory)
+    }
+
+    func testRelativePart() {
+        XCTAssertEqual(TerminalPathTarget.resolve("~/notes/todo.md")?.relativePart, "notes/todo.md")
+        XCTAssertEqual(TerminalPathTarget.resolve("$HOME/notes.md")?.relativePart, "notes.md")
+        XCTAssertEqual(TerminalPathTarget.resolve("./src/main.rs")?.relativePart, "src/main.rs")
+        XCTAssertEqual(TerminalPathTarget.resolve("/etc/hosts")?.relativePart, "/etc/hosts")
+        XCTAssertEqual(TerminalPathTarget.resolve("../x/y.c")?.relativePart, "../x/y.c")
+    }
+
+    func testLineSuffixes() {
+        let single = TerminalPathTarget.resolve("src/app.ts:42")
+        XCTAssertEqual(single?.path, "src/app.ts")
+        XCTAssertEqual(single?.line, 42)
+        let pair = TerminalPathTarget.resolve("Multiplex/App.swift:120:15")
+        XCTAssertEqual(pair?.path, "Multiplex/App.swift")
+        XCTAssertEqual(pair?.line, 120)
+    }
+
+    func testDeclines() {
+        // URLs belong to TerminalLink.
+        XCTAssertNil(TerminalPathTarget.resolve("https://example.com/a/b"))
+        // Unknown environment variables can't be resolved from here.
+        XCTAssertNil(TerminalPathTarget.resolve("$WORKDIR/src/main.rs"))
+        // Colon prose ("warning:") and non-suffix colons.
+        XCTAssertNil(TerminalPathTarget.resolve("warning:"))
+        XCTAssertNil(TerminalPathTarget.resolve("a/b:c/d"))
+        // A bare word is not a path.
+        XCTAssertNil(TerminalPathTarget.resolve("README"))
+        // Root alone and protocol-relative shapes.
+        XCTAssertNil(TerminalPathTarget.resolve("/"))
+        XCTAssertNil(TerminalPathTarget.resolve("//cdn.example.com/x"))
+        XCTAssertNil(TerminalPathTarget.resolve(""))
+    }
+
+    func testTrailingPunctuationTrimmed() {
+        XCTAssertEqual(TerminalPathTarget.resolve("src/foo.ts.")?.path, "src/foo.ts")
+        XCTAssertEqual(TerminalPathTarget.resolve("src/foo.ts,")?.path, "src/foo.ts")
+    }
+
+    func testInteriorWhitespaceIsProse() {
+        XCTAssertNil(TerminalPathTarget.resolve("(see src/foo.ts)"))
+        XCTAssertNil(TerminalPathTarget.resolve("path with space/file.txt"))
+    }
+
+    func testTimeIsNotAPath() {
+        XCTAssertNil(TerminalPathTarget.resolve("12:30"))
+    }
+}

--- a/MultiplexTests/FileTreeTests.swift
+++ b/MultiplexTests/FileTreeTests.swift
@@ -86,6 +86,39 @@ final class FileTreeTests: XCTestCase {
         XCTAssertEqual(rows[0].badge, .added)
     }
 
+    func testEditorHiddenSetIsInvisibleEverywhere() {
+        let root = "/repo"
+        let children: [String: [FileTreeEntry]] = [
+            root: [
+                entry(".git", in: root, dir: true),
+                entry(".DS_Store", in: root),
+                entry(".gitignore", in: root),
+                entry("src", in: root, dir: true),
+            ]
+        ]
+        let rows = FileTree.rows(
+            root: root, children: children,
+            expanded: [], badges: [:], changedDirectories: []
+        )
+        // .git and .DS_Store vanish; .gitignore is a file people open.
+        XCTAssertEqual(rows.map(\.entry.name), ["src", ".gitignore"])
+
+        // A stray untracked .DS_Store must not light its directory's dot
+        // or appear in the CHANGED review index.
+        let statuses = [
+            GitFileStatus(path: "src/.DS_Store", originPath: nil, badge: .untracked),
+            GitFileStatus(path: "src/app.ts", originPath: nil, badge: .modified),
+        ]
+        XCTAssertEqual(
+            FileTree.changedDirectories(statuses: [statuses[0]], repoRoot: root),
+            []
+        )
+        XCTAssertEqual(
+            FileTree.changedRows(statuses: statuses, repoRoot: root).map(\.entry.name),
+            ["src/app.ts"]
+        )
+    }
+
     func testPathHelpers() {
         XCTAssertEqual(FileTree.join("/a/b", "c.txt"), "/a/b/c.txt")
         XCTAssertEqual(FileTree.join("/a/b/", "c.txt"), "/a/b/c.txt")

--- a/MultiplexTests/FileTreeTests.swift
+++ b/MultiplexTests/FileTreeTests.swift
@@ -88,13 +88,15 @@ final class FileTreeTests: XCTestCase {
 
     func testEditorHiddenSetIsInvisibleEverywhere() {
         let root = "/repo"
+        // rows() consumes children pre-sorted, the way the controller
+        // stores them.
         let children: [String: [FileTreeEntry]] = [
-            root: [
+            root: FileTree.sorted([
                 entry(".git", in: root, dir: true),
                 entry(".DS_Store", in: root),
                 entry(".gitignore", in: root),
                 entry("src", in: root, dir: true),
-            ]
+            ])
         ]
         let rows = FileTree.rows(
             root: root, children: children,

--- a/MultiplexTests/FileTreeTests.swift
+++ b/MultiplexTests/FileTreeTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import Multiplex
+
+final class FileTreeTests: XCTestCase {
+    private func entry(
+        _ name: String,
+        in directory: String,
+        dir: Bool = false
+    ) -> FileTreeEntry {
+        FileTreeEntry(
+            name: name,
+            path: FileTree.join(directory, name),
+            isDirectory: dir
+        )
+    }
+
+    func testSortDirectoriesFirstCaseInsensitive() {
+        let sorted = FileTree.sorted([
+            entry("zeta.txt", in: "/r"),
+            entry("Alpha", in: "/r", dir: true),
+            entry("beta", in: "/r", dir: true),
+            entry("Apple.txt", in: "/r"),
+        ])
+        XCTAssertEqual(sorted.map(\.name), ["Alpha", "beta", "Apple.txt", "zeta.txt"])
+    }
+
+    func testRowsFlattenExpandedDirectories() {
+        let root = "/repo"
+        let children: [String: [FileTreeEntry]] = [
+            root: [
+                entry("Sources", in: root, dir: true),
+                entry("README.md", in: root),
+            ],
+            "/repo/Sources": [
+                entry("App.swift", in: "/repo/Sources"),
+            ],
+        ]
+        let collapsed = FileTree.rows(
+            root: root, children: children,
+            expanded: [], badges: [:], changedDirectories: []
+        )
+        XCTAssertEqual(collapsed.map(\.entry.name), ["Sources", "README.md"])
+
+        let expanded = FileTree.rows(
+            root: root, children: children,
+            expanded: ["/repo/Sources"], badges: [:], changedDirectories: []
+        )
+        XCTAssertEqual(expanded.map(\.entry.name), ["Sources", "App.swift", "README.md"])
+        XCTAssertEqual(expanded.map(\.depth), [0, 1, 0])
+        XCTAssertTrue(expanded[0].isExpanded)
+    }
+
+    func testExpandedButUnlistedDirectoryContributesOnlyItself() {
+        let root = "/r"
+        let children: [String: [FileTreeEntry]] = [
+            root: [entry("lazy", in: root, dir: true)]
+        ]
+        let rows = FileTree.rows(
+            root: root, children: children,
+            expanded: ["/r/lazy"], badges: [:], changedDirectories: []
+        )
+        XCTAssertEqual(rows.count, 1)
+    }
+
+    func testBadgesAndChangedDirectories() {
+        let statuses = [
+            GitFileStatus(path: "Sources/App.swift", originPath: nil, badge: .modified),
+            GitFileStatus(path: "probe.ts", originPath: nil, badge: .untracked),
+        ]
+        let badges = FileTree.badges(statuses: statuses, repoRoot: "/repo")
+        XCTAssertEqual(badges["/repo/Sources/App.swift"], .modified)
+        XCTAssertEqual(badges["/repo/probe.ts"], .untracked)
+
+        let changed = FileTree.changedDirectories(statuses: statuses, repoRoot: "/repo")
+        XCTAssertEqual(changed, ["/repo/Sources"])
+    }
+
+    func testChangedRowsAreFlatAndSorted() {
+        let statuses = [
+            GitFileStatus(path: "b/two.swift", originPath: nil, badge: .modified),
+            GitFileStatus(path: "a/one.swift", originPath: nil, badge: .added),
+        ]
+        let rows = FileTree.changedRows(statuses: statuses, repoRoot: "/repo")
+        XCTAssertEqual(rows.map(\.entry.name), ["a/one.swift", "b/two.swift"])
+        XCTAssertEqual(rows.map(\.entry.path), ["/repo/a/one.swift", "/repo/b/two.swift"])
+        XCTAssertEqual(rows[0].badge, .added)
+    }
+
+    func testPathHelpers() {
+        XCTAssertEqual(FileTree.join("/a/b", "c.txt"), "/a/b/c.txt")
+        XCTAssertEqual(FileTree.join("/a/b/", "c.txt"), "/a/b/c.txt")
+        XCTAssertEqual(FileTree.parent(of: "/a/b/c.txt"), "/a/b")
+        XCTAssertEqual(FileTree.parent(of: "/a"), "/")
+        XCTAssertNil(FileTree.parent(of: "/"))
+        XCTAssertEqual(FileTree.name(of: "/a/b/c.txt"), "c.txt")
+        XCTAssertEqual(FileTree.name(of: "plain"), "plain")
+    }
+}

--- a/MultiplexTests/GitDiffTests.swift
+++ b/MultiplexTests/GitDiffTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+@testable import Multiplex
+
+final class GitDiffTests: XCTestCase {
+    func testModifiedFileWithOneHunk() {
+        let diff = GitDiff.parse("""
+        diff --git a/Sources/App.swift b/Sources/App.swift
+        index 3f9c1a2..8b0d221 100644
+        --- a/Sources/App.swift
+        +++ b/Sources/App.swift
+        @@ -10,4 +10,5 @@ struct App {
+             let name: String
+        -    let old: Int
+        +    let new: Int
+        +    let extra: Bool
+             let tail: String
+        """)
+        XCTAssertEqual(diff.files.count, 1)
+        let file = diff.files[0]
+        XCTAssertEqual(file.displayPath, "Sources/App.swift")
+        XCTAssertEqual(file.kind, .modified)
+        XCTAssertEqual(file.hunks.count, 1)
+        XCTAssertEqual(file.additions, 2)
+        XCTAssertEqual(file.deletions, 1)
+        let hunk = file.hunks[0]
+        XCTAssertEqual(hunk.heading, "struct App {")
+        XCTAssertEqual(hunk.oldStart, 10)
+        XCTAssertEqual(hunk.newStart, 10)
+        XCTAssertEqual(hunk.lines.count, 5)
+        // Line numbering: context advances both sides, +/- one side each.
+        XCTAssertEqual(hunk.lines[0].oldNumber, 10)
+        XCTAssertEqual(hunk.lines[0].newNumber, 10)
+        XCTAssertEqual(hunk.lines[1].kind, .deletion)
+        XCTAssertEqual(hunk.lines[1].oldNumber, 11)
+        XCTAssertNil(hunk.lines[1].newNumber)
+        XCTAssertEqual(hunk.lines[2].kind, .addition)
+        XCTAssertEqual(hunk.lines[2].newNumber, 11)
+        XCTAssertNil(hunk.lines[2].oldNumber)
+        XCTAssertEqual(hunk.lines[4].kind, .context)
+        XCTAssertEqual(hunk.lines[4].oldNumber, 12)
+        XCTAssertEqual(hunk.lines[4].newNumber, 13)
+    }
+
+    func testAddedAndDeletedFiles() {
+        let diff = GitDiff.parse("""
+        diff --git a/new.ts b/new.ts
+        new file mode 100644
+        index 0000000..2b5e1a0
+        --- /dev/null
+        +++ b/new.ts
+        @@ -0,0 +1,2 @@
+        +const a = 1;
+        +export default a;
+        diff --git a/gone.rb b/gone.rb
+        deleted file mode 100644
+        index 9daeafb..0000000
+        --- a/gone.rb
+        +++ /dev/null
+        @@ -1,1 +0,0 @@
+        -puts "bye"
+        """)
+        XCTAssertEqual(diff.files.count, 2)
+        XCTAssertEqual(diff.files[0].kind, .added)
+        XCTAssertEqual(diff.files[0].displayPath, "new.ts")
+        XCTAssertEqual(diff.files[0].additions, 2)
+        XCTAssertEqual(diff.files[1].kind, .deleted)
+        XCTAssertEqual(diff.files[1].displayPath, "gone.rb")
+        XCTAssertEqual(diff.files[1].deletions, 1)
+        XCTAssertEqual(diff.additions, 2)
+        XCTAssertEqual(diff.deletions, 1)
+    }
+
+    func testRenameWithoutHunks() {
+        let diff = GitDiff.parse("""
+        diff --git a/old name.txt b/new name.txt
+        similarity index 100%
+        rename from old name.txt
+        rename to new name.txt
+        """)
+        XCTAssertEqual(diff.files.count, 1)
+        XCTAssertEqual(diff.files[0].kind, .renamed)
+        XCTAssertEqual(diff.files[0].oldPath, "old name.txt")
+        XCTAssertEqual(diff.files[0].newPath, "new name.txt")
+        XCTAssertEqual(diff.files[0].displayPath, "new name.txt")
+        XCTAssertTrue(diff.files[0].hunks.isEmpty)
+    }
+
+    func testBinaryFile() {
+        let diff = GitDiff.parse("""
+        diff --git a/icon.png b/icon.png
+        index 1111111..2222222 100644
+        Binary files a/icon.png and b/icon.png differ
+        """)
+        XCTAssertEqual(diff.files.count, 1)
+        XCTAssertTrue(diff.files[0].isBinary)
+        XCTAssertTrue(diff.files[0].hunks.isEmpty)
+    }
+
+    func testQuotedPathsUnquote() {
+        // git C-quotes controls; with core.quotepath=false non-ASCII stays
+        // raw, but tabs still escape.
+        let diff = GitDiff.parse("""
+        diff --git "a/we\\tird.txt" "b/we\\tird.txt"
+        index 1111111..2222222 100644
+        --- "a/we\\tird.txt"
+        +++ "b/we\\tird.txt"
+        @@ -1 +1 @@
+        -a
+        +b
+        """)
+        XCTAssertEqual(diff.files[0].displayPath, "we\tird.txt")
+    }
+
+    func testOctalEscapeUnquote() {
+        XCTAssertEqual(GitDiffFile.unquote(#""caf\303\251.md""#), "café.md")
+        XCTAssertEqual(GitDiffFile.unquote("plain.md"), "plain.md")
+    }
+
+    func testNoNewlineMarkerAnnotatesPreviousLine() {
+        let diff = GitDiff.parse("""
+        diff --git a/x b/x
+        --- a/x
+        +++ b/x
+        @@ -1 +1 @@
+        -old
+        \\ No newline at end of file
+        +new
+        \\ No newline at end of file
+        """)
+        let lines = diff.files[0].hunks[0].lines
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[0].noTrailingNewline)
+        XCTAssertTrue(lines[1].noTrailingNewline)
+    }
+
+    func testEmptyContextLineSurvives() {
+        // Transports can strip the single space a blank context line is
+        // made of; the row must still count on both sides.
+        let text = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n a\n\n b\n"
+        let diff = GitDiff.parse(text)
+        let lines = diff.files[0].hunks[0].lines
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertEqual(lines[1].kind, .context)
+        XCTAssertEqual(lines[2].oldNumber, 3)
+        XCTAssertEqual(lines[2].newNumber, 3)
+    }
+
+    func testTrailingNewlineAddsNoPhantomRow() {
+        let text = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"
+        let diff = GitDiff.parse(text)
+        XCTAssertEqual(diff.files[0].hunks[0].lines.count, 2)
+    }
+
+    func testUntrackedNoIndexShape() {
+        // `git diff --no-index -- /dev/null path` — the all-additions render
+        // for untracked files.
+        let diff = GitDiff.parse("""
+        diff --git a/dev/null b/probe.ts
+        new file mode 100644
+        index 0000000..f2a9b1c
+        --- /dev/null
+        +++ b/probe.ts
+        @@ -0,0 +1,2 @@
+        +export const x = 1;
+        +export const y = 2;
+        """)
+        XCTAssertEqual(diff.files[0].kind, .added)
+        XCTAssertEqual(diff.files[0].displayPath, "probe.ts")
+        XCTAssertEqual(diff.files[0].additions, 2)
+    }
+
+    func testCountOmittedDefaultsToOne() {
+        guard let hunk = GitDiffHunk.parseHeader("@@ -5 +7 @@") else {
+            return XCTFail("header should parse")
+        }
+        XCTAssertEqual(hunk.oldStart, 5)
+        XCTAssertEqual(hunk.oldCount, 1)
+        XCTAssertEqual(hunk.newStart, 7)
+        XCTAssertEqual(hunk.newCount, 1)
+    }
+
+    func testGarbageDoesNotCrashAndYieldsNothing() {
+        XCTAssertTrue(GitDiff.parse("").files.isEmpty)
+        XCTAssertTrue(GitDiff.parse("not a diff at all\n@@ stray @@\n+x").files.isEmpty)
+    }
+}

--- a/MultiplexTests/GitStatusTests.swift
+++ b/MultiplexTests/GitStatusTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import Multiplex
+
+final class GitStatusTests: XCTestCase {
+    func testPorcelainZBasics() {
+        let output = " M Multiplex/App.swift\0?? probe.ts\0A  added.md\0 D gone.txt\0"
+        let entries = GitFileStatus.parse(porcelainZ: output)
+        XCTAssertEqual(entries.count, 4)
+        XCTAssertEqual(entries[0].path, "Multiplex/App.swift")
+        XCTAssertEqual(entries[0].badge, .modified)
+        XCTAssertEqual(entries[1].badge, .untracked)
+        XCTAssertEqual(entries[2].badge, .added)
+        XCTAssertEqual(entries[3].badge, .deleted)
+    }
+
+    func testRenameCarriesOriginFromNextToken() {
+        let output = "R  new/name.swift\0old/name.swift\0 M other.txt\0"
+        let entries = GitFileStatus.parse(porcelainZ: output)
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].badge, .renamed)
+        XCTAssertEqual(entries[0].path, "new/name.swift")
+        XCTAssertEqual(entries[0].originPath, "old/name.swift")
+        // The origin token must not be misread as its own entry.
+        XCTAssertEqual(entries[1].path, "other.txt")
+    }
+
+    func testConflictBadges() {
+        let output = "UU both.swift\0AA added-both.txt\0DD deleted-both.txt\0"
+        let entries = GitFileStatus.parse(porcelainZ: output)
+        XCTAssertEqual(entries.map(\.badge), [.conflicted, .conflicted, .conflicted])
+    }
+
+    func testPathsWithSpacesAndNewlinesSurviveZ() {
+        // -z's whole point: no quoting, NUL separation — a newline is just
+        // a filename byte.
+        let output = " M has space.txt\0?? has\nnewline.txt\0"
+        let entries = GitFileStatus.parse(porcelainZ: output)
+        XCTAssertEqual(entries[0].path, "has space.txt")
+        XCTAssertEqual(entries[1].path, "has\nnewline.txt")
+    }
+
+    func testShortStatVariants() {
+        XCTAssertEqual(
+            GitShortStat.parse(" 3 files changed, 42 insertions(+), 17 deletions(-)\n"),
+            GitShortStat(filesChanged: 3, insertions: 42, deletions: 17)
+        )
+        XCTAssertEqual(
+            GitShortStat.parse(" 1 file changed, 1 deletion(-)"),
+            GitShortStat(filesChanged: 1, insertions: 0, deletions: 1)
+        )
+        XCTAssertTrue(GitShortStat.parse("").isEmpty)
+        XCTAssertTrue(GitShortStat.parse("\n").isEmpty)
+    }
+
+    // MARK: GitCommands
+
+    func testSplitExitFindsTrailingSentinel() {
+        let (body, exit) = GitCommands.splitExit("line one\nline two\nMPXFV_EXIT:0")
+        XCTAssertEqual(body, "line one\nline two")
+        XCTAssertEqual(exit, 0)
+    }
+
+    func testSplitExitEmptyBody() {
+        let (body, exit) = GitCommands.splitExit("MPXFV_EXIT:128")
+        XCTAssertEqual(body, "")
+        XCTAssertEqual(exit, 128)
+    }
+
+    func testSplitExitTakesLastOccurrence() {
+        // Body content can echo the sentinel; ours is always the final one.
+        let (body, exit) = GitCommands.splitExit("x\nMPXFV_EXIT:7\ny\nMPXFV_EXIT:1")
+        XCTAssertEqual(body, "x\nMPXFV_EXIT:7\ny")
+        XCTAssertEqual(exit, 1)
+    }
+
+    func testSplitExitMissingSentinel() {
+        let (body, exit) = GitCommands.splitExit("truncated")
+        XCTAssertEqual(body, "truncated")
+        XCTAssertNil(exit)
+    }
+
+    func testCommandsQuotePaths() {
+        let command = GitCommands.diffFile(root: "/srv/my repo", path: "a'b.swift")
+        XCTAssertTrue(command.contains("'/srv/my repo'"))
+        XCTAssertTrue(command.contains("'a'\\''b.swift'"))
+        XCTAssertTrue(command.contains("--no-ext-diff"))
+        XCTAssertTrue(command.contains("2>/dev/null"))
+        XCTAssertTrue(command.hasSuffix("printf '\\nMPXFV_EXIT:%s' \"$?\""))
+    }
+
+    func testRepoProbeParse() {
+        let body = "/home/dev/app\nMPXFV_BR:main"
+        let parsed = GitCommands.parseRepoProbe(body: body)
+        XCTAssertEqual(parsed.toplevel, "/home/dev/app")
+        XCTAssertEqual(parsed.branch, "main")
+
+        let unborn = GitCommands.parseRepoProbe(body: "/home/dev/app\nMPXFV_BR:")
+        XCTAssertEqual(unborn.toplevel, "/home/dev/app")
+        XCTAssertNil(unborn.branch)
+
+        let outside = GitCommands.parseRepoProbe(body: "\nMPXFV_BR:")
+        XCTAssertNil(outside.toplevel)
+        XCTAssertNil(outside.branch)
+    }
+}

--- a/MultiplexTests/GitStatusTests.swift
+++ b/MultiplexTests/GitStatusTests.swift
@@ -88,6 +88,35 @@ final class GitStatusTests: XCTestCase {
         XCTAssertTrue(command.hasSuffix("printf '\\nMPXFV_EXIT:%s' \"$?\""))
     }
 
+    func testWatchProbeParse() {
+        // One round trip: branch line, porcelain -z bytes (NULs and all),
+        // shortstat behind its sentinel, exit behind the usual tail.
+        let output = "MPXFV_BR:main\n M src/app.ts\0?? probe.ts\0"
+            + "\nMPXFV_STAT: 1 file changed, 4 insertions(+), 2 deletions(-)"
+            + "\nMPXFV_EXIT:0"
+        guard let probe = GitCommands.parseWatchProbe(output) else {
+            return XCTFail("watch probe should parse")
+        }
+        XCTAssertEqual(probe.branch, "main")
+        XCTAssertEqual(probe.statuses.map(\.path), ["src/app.ts", "probe.ts"])
+        XCTAssertEqual(probe.statuses.map(\.badge), [.modified, .untracked])
+        XCTAssertEqual(
+            probe.shortStat,
+            GitShortStat(filesChanged: 1, insertions: 4, deletions: 2)
+        )
+
+        // Clean tree: empty status, empty shortstat, unborn branch.
+        let clean = GitCommands.parseWatchProbe("MPXFV_BR:\n\nMPXFV_STAT:\nMPXFV_EXIT:0")
+        XCTAssertNotNil(clean)
+        XCTAssertNil(clean?.branch)
+        XCTAssertEqual(clean?.statuses, [])
+        XCTAssertEqual(clean?.shortStat.isEmpty, true)
+
+        // Status failed (repo vanished, git gone) → nil, never garbage.
+        XCTAssertNil(GitCommands.parseWatchProbe("MPXFV_BR:x\n\nMPXFV_STAT:\nMPXFV_EXIT:128"))
+        XCTAssertNil(GitCommands.parseWatchProbe("truncated mid-flight"))
+    }
+
     func testRepoProbeParse() {
         let body = "/home/dev/app\nMPXFV_BR:main"
         let parsed = GitCommands.parseRepoProbe(body: body)

--- a/MultiplexTests/MarkdownDocumentTests.swift
+++ b/MultiplexTests/MarkdownDocumentTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import Multiplex
+
+final class MarkdownDocumentTests: XCTestCase {
+    func testHeadingsAndParagraphJoin() {
+        let blocks = MarkdownDocument.parse("""
+        # Title
+
+        First line
+        continues here.
+
+        ## Section ##
+        """)
+        XCTAssertEqual(blocks.count, 3)
+        guard case .heading(1, let title) = blocks[0] else { return XCTFail("h1") }
+        XCTAssertEqual(title, [.text("Title", [])])
+        guard case .paragraph(let inlines) = blocks[1] else { return XCTFail("para") }
+        XCTAssertEqual(inlines, [.text("First line continues here.", [])])
+        guard case .heading(2, let section) = blocks[2] else { return XCTFail("h2") }
+        XCTAssertEqual(section, [.text("Section", [])])
+    }
+
+    func testFenceKeepsBodyVerbatimAndLanguage() {
+        let blocks = MarkdownDocument.parse("""
+        ```swift
+        let x = 1  // keep  spacing
+        # not a heading
+        ```
+        after
+        """)
+        guard case .code(let language, let info, let lines) = blocks[0] else {
+            return XCTFail("fence")
+        }
+        XCTAssertEqual(language, .swift)
+        XCTAssertEqual(info, "swift")
+        XCTAssertEqual(lines, ["let x = 1  // keep  spacing", "# not a heading"])
+        guard case .paragraph = blocks[1] else { return XCTFail("after") }
+    }
+
+    func testUnclosedFenceRunsToEnd() {
+        let blocks = MarkdownDocument.parse("```\ncode\nmore")
+        guard case .code(_, _, let lines) = blocks[0] else { return XCTFail("fence") }
+        XCTAssertEqual(lines, ["code", "more"])
+        XCTAssertEqual(blocks.count, 1)
+    }
+
+    func testQuoteRecursion() {
+        let blocks = MarkdownDocument.parse("> # Inside\n> body text")
+        guard case .quote(let inner) = blocks[0] else { return XCTFail("quote") }
+        guard case .heading(1, _) = inner[0] else { return XCTFail("inner heading") }
+        guard case .paragraph = inner[1] else { return XCTFail("inner para") }
+    }
+
+    func testListsWithTasksAndOrder() {
+        let blocks = MarkdownDocument.parse("""
+        - plain
+        - [ ] open task
+        - [x] done task
+          wrapped continuation
+        3. third
+        """)
+        guard case .listItem("•", 0, _) = blocks[0] else { return XCTFail("bullet") }
+        guard case .listItem("□", 0, _) = blocks[1] else { return XCTFail("open task") }
+        guard case .listItem("▣", 0, let done) = blocks[2] else { return XCTFail("done task") }
+        // The continuation folded into the done task's inlines.
+        XCTAssertTrue(done.contains { inline in
+            if case .text(let value, _) = inline { return value.contains("wrapped continuation") }
+            return false
+        })
+        guard case .listItem("3.", 0, _) = blocks[3] else { return XCTFail("ordered") }
+    }
+
+    func testNestedListLevel() {
+        let blocks = MarkdownDocument.parse("- top\n  - nested")
+        guard case .listItem(_, 0, _) = blocks[0] else { return XCTFail("top") }
+        guard case .listItem(_, 1, _) = blocks[1] else { return XCTFail("nested") }
+    }
+
+    func testTable() {
+        let blocks = MarkdownDocument.parse("""
+        | Name | Count |
+        | ---- | ----: |
+        | a    | 1     |
+        | b    | 2     |
+        """)
+        guard case .table(let header, let rows) = blocks[0] else { return XCTFail("table") }
+        XCTAssertEqual(header.count, 2)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[1][0], [.text("b", [])])
+    }
+
+    func testRule() {
+        let blocks = MarkdownDocument.parse("---")
+        XCTAssertEqual(blocks, [.rule])
+    }
+
+    // MARK: Inlines
+
+    func testInlineEmphasisAndCode() {
+        let inlines = MarkdownDocument.parseInlines("mix **bold** and *italic* and `code` and ~~gone~~")
+        XCTAssertTrue(inlines.contains(.text("bold", .bold)))
+        XCTAssertTrue(inlines.contains(.text("italic", .italic)))
+        XCTAssertTrue(inlines.contains(.code("code")))
+        XCTAssertTrue(inlines.contains(.text("gone", .strikethrough)))
+    }
+
+    func testNestedEmphasis() {
+        let inlines = MarkdownDocument.parseInlines("**bold *both* bold**")
+        XCTAssertTrue(inlines.contains(.text("both", [.bold, .italic])))
+    }
+
+    func testLinkImageAutolink() {
+        let inlines = MarkdownDocument.parseInlines(
+            "see [docs](https://example.com/x) and ![shot](img.png) and <https://a.dev>"
+        )
+        XCTAssertTrue(inlines.contains(.link(text: "docs", destination: "https://example.com/x")))
+        XCTAssertTrue(inlines.contains(.image(alt: "shot")))
+        XCTAssertTrue(inlines.contains(.link(text: "https://a.dev", destination: "https://a.dev")))
+    }
+
+    func testUnmatchedDelimitersStayPlain() {
+        let inlines = MarkdownDocument.parseInlines("2 * 3 = 6 and a_b_c stays")
+        // "* 3 = 6…" has a space after the opener — not emphasis.
+        XCTAssertEqual(inlines.count, 1)
+        if case .text(let value, let style) = inlines[0] {
+            XCTAssertEqual(style, [])
+            XCTAssertTrue(value.contains("2 * 3 = 6"))
+        } else {
+            XCTFail("expected plain text")
+        }
+    }
+
+    func testCodeSpanSwallowsMarkers() {
+        let inlines = MarkdownDocument.parseInlines("`let *x* = 1`")
+        XCTAssertEqual(inlines, [.code("let *x* = 1")])
+    }
+}

--- a/MultiplexTests/TmuxProbeTests.swift
+++ b/MultiplexTests/TmuxProbeTests.swift
@@ -406,6 +406,21 @@ final class TmuxProbeTests: XCTestCase {
         XCTAssertTrue(command.contains("echo MULTIPLEX_GIT"))
     }
 
+    func testParseDropDestinationReadsPathAndWorktreeMarker() {
+        let inWorktree = TmuxProbe.parseDropDestination("/home/dev/repo\nMULTIPLEX_GIT\n")
+        XCTAssertEqual(inWorktree.cwd, "/home/dev/repo")
+        XCTAssertTrue(inWorktree.insideGitWorktree)
+
+        let plain = TmuxProbe.parseDropDestination("  /srv/data \n")
+        XCTAssertEqual(plain.cwd, "/srv/data")
+        XCTAssertFalse(plain.insideGitWorktree)
+
+        // No pane answered: empty output, or noise without a /-prefixed line.
+        let empty = TmuxProbe.parseDropDestination("\n")
+        XCTAssertNil(empty.cwd)
+        XCTAssertFalse(empty.insideGitWorktree)
+    }
+
     // MARK: New sessions (the + TAB button, the deck tile's quick options)
 
     func testNewSessionCommandInheritsSourceDirectoryAndTypesLaunch() {

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -168,3 +168,5 @@ Worth checking:
   the open document, diff, tree badges, and ± counts catch up without
   touching REFRESH (which stays for forcing the issue). Deleting the
   open file shows FILE GONE rather than stale bytes.
+- iPhone: + TAB > File Viewer now opens with the tree already out, so the
+  first file is one tap; opening a pressed path still lands on the file.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -163,3 +163,8 @@ Worth checking:
   path into a hidden folder still works.
 - Open an image: it fits the screen; pinch to zoom (double-tap flips
   fit ↔ 2×), pan when zoomed, and the % chip bottom-right resets to fit.
+- The viewer now follows the host on its own: with its tab frontmost it
+  re-checks every ~5 seconds — edit a file in the session beside it and
+  the open document, diff, tree badges, and ± counts catch up without
+  touching REFRESH (which stays for forcing the issue). Deleting the
+  open file shows FILE GONE rather than stale bytes.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -158,3 +158,8 @@ Worth checking:
   its own connection). Relaunch the app: ▤ tabs must be gone.
 - mosh hosts: the viewer works there too (it reads over SSH).
 - iPhone: the tree is a drawer behind the TREE chip in the bottom rail.
+- The tree hides what your editor hides (.git, .DS_Store and friends) —
+  but .gitignore and other dotfiles stay visible, and opening a pressed
+  path into a hidden folder still works.
+- Open an image: it fits the screen; pinch to zoom (double-tap flips
+  fit ↔ 2×), pan when zoomed, and the % chip bottom-right resets to fit.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -120,3 +120,41 @@ Worth checking:
   never glow, links under your gaze in a build log should light within a
   second of printing, and scrolling/pane-switching over a link must keep
   working exactly as before.
+
+FILE VIEWER — the host's files and git diffs, beside the terminal
+
+Two ways in. Long-press a file path printed in any pane — ./src/app.ts,
+~/notes/todo.md, Multiplex/App.swift:120 — and a sheet names the host and
+the resolved path; ▤ VIEW docks a read-only file viewer as a tab beside
+that session. Or press + TAB ▸ File Viewer to open one rooted at the
+pane's current directory. It moves like any tab (split it out beside the
+terminal, MERGE it back) and never survives a relaunch — summoned, not
+restored, like the viewport.
+
+Inside: code with syntax highlighting (Swift, TS/JS, Rust, Python, Go,
+C/C++, JSON, YAML, shell, and more), Markdown rendered as a document
+(RAW one chip away), images, and — the point — git. The tree on the
+right stands on its own screen: branch, +/− counts, letter badges
+(M modified, A staged, U untracked, D deleted), and a CHANGED filter.
+A modified file grows a SOURCE | DIFF pair; the ± counts in the tree
+header open the whole working tree's diff, grouped per file.
+
+Worth checking:
+- Long-press a path an agent printed (with a :12 line suffix if you can) —
+  the viewer must open scrolled to that line, highlighted.
+- Paths that aren't paths must keep falling through to text selection:
+  "warning:", $VAR/things, prose with spaces.
+- In a repo, edit a file, open the viewer: the file wears M in the tree,
+  DIFF shows the hunks (green adds, red deletes), CHANGED collapses the
+  tree to what moved, and the ± chip opens the repo-wide diff.
+- README.md renders as a document — headings, lists, tables, fenced code
+  with highlighting. Links in it confirm through the same sheet as pane
+  links; relative links (docs/x.md) navigate inside the viewer.
+- A binary file must say BINARY and its size, never garbage; a huge file
+  renders its head under a TRUNCATED banner.
+- Split the ▤ tab into its own window beside the terminal, keep working,
+  press REFRESH — tree badges and diffs follow your edits.
+- Close the terminal that summoned it: the viewer keeps working (it holds
+  its own connection). Relaunch the app: ▤ tabs must be gone.
+- mosh hosts: the viewer works there too (it reads over SSH).
+- iPhone: the tree is a drawer behind the TREE chip in the bottom rail.


### PR DESCRIPTION
## What this is

A `▤` file-viewer tab — the `⌗` viewport's sibling: the host's files rendered beside the terminal, read-only, with git as the first-class citizen. Content left, file tree right.

**Two summon doors.** A long-pressed filesystem path in any pane (`./src/app.ts`, `~/notes.md`, `Multiplex/App.swift:120:15`) now confirms through a sheet — host + resolved path + line — whose `▤ VIEW` chip docks the viewer beside that session, scrolled to the cited line. And **+ TAB ▸ File Viewer** roots one at the pane's cwd (the same `list-panes` truth drops use). Path presses used to fall through to text selection; now only what both resolvers decline (`$VAR/…`, colon prose, interior whitespace) still does.

**Four renders.** Code with syntax color (~30 languages), Markdown as a document (RAW one chip away; relative links navigate in place, external ones ride the link sheet's confirm), images, and diffs: a modified file grows a SOURCE | DIFF pair, a deleted row opens its diff, and the tree's ± counts open the repo-wide working-tree-vs-HEAD review grouped per file.

**The tree is telemetry.** Standing right-hand screen with location header, `⎇ branch`, ± counts, M/A/U/D/R letter badges, change dots on directories, and a CHANGED filter; it yields to a drawer under 700 pt (the iPhone-shell story).

## Load-bearing decisions

- **Own SSH connection per tab** — never the probe's (a disabled host must not be revived), never the summoning tab's transport (merge/split moves the viewer away). Redialed once per op after suspension; mosh hosts work (SSH stays the control plane).
- **SFTP for listings/bytes, exec for git** — and because Citadel throws on nonzero exit, every git command tails its real exit code behind a sentinel (`GitCommands.splitExit`): "not a repo" ≠ "empty diff", and `--no-index` (untracked → all-adds) exits 1 routinely. `core.quotepath=false`, `--no-ext-diff`.
- **Zero-dependency rendering, on purpose.** The 2026 survey (local-plan/file-viewer.md) found no maintained pure-Swift multi-language highlighter; every alternative vendors megabytes of C or JS. `CodeHighlighter` is an in-repo line-oriented scanner with carry states (lazy rows; per-side diff highlighting), `MarkdownDocument` a GFM subset, `GitDiff`/`GitFileStatus` pure parsers. The tree-sitter stack is the recorded graduation path behind the `CodeHighlighter.highlight(_:language:)` seam.
- **Auxiliary-pane citizenship shared with the viewport**: no tally dot, no focus claim, `syncTabs` strips controller-less tabs (summoned, never restored), and syncTabs never mints a `TerminalSessionController` for an auxiliary route.
- Honesty rules: NUL sniff says BINARY, >1.5 MB renders its head under TRUNCATED, failures name their cause on a chassis panel.

Design bake-off (3 candidates → C WORKBENCH posture + A REGISTER rail, B drawer at compact) is recorded in `local-plan/file-viewer-bakeoff/`; research + deferrals (MARK VIEWED, side-by-side diff, markdown image fetch, gaze glow on paths) in `local-plan/file-viewer.md` (both local-plan, deliberately untracked).

## Verification

- 638 unit tests green — 7 new suites (diff parser, porcelain -z + shortstat, highlighter incl. the segments-rebuild-the-line invariant, markdown, file kinds, path targets, tree).
- visionOS + iPad builds.
- Harness E2E, screenshots inspected: path press → sheet → viewer at line 3 with tree badges and `⎇ main +6 −2` → repo-wide diff with tinted hunks; relaunch brings no `▤` tab back. New headless hooks: `….debug.fileviewer`, `….debug.pathview`, `….debug.fvrepodiff`.
- Not visually driven: the iPhone-shell drawer layout (compiles; covered in the TestFlight tester script).