### PR TITLE
Open spaced paths and schemeless URLs from a pane press

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1002,12 +1002,29 @@ views.
   **A wrapped row can hand over a sentence glued to the path below it** —
   the fork reassembles wrapped rows and a hard wrap leaves no space at the
   seam, so `…the file.` above `/Users/me/x.swift` arrives as one
-  bare-relative match. `strippingWrappedProseHead` cuts at the first `X./`
-  whose `X` is neither `.` nor `..`, and only when the text doesn't already
-  start with its own base marker (`/`, `~`, `.`, `$`) — so real paths,
-  including `a.b/c.d` and `dir/./file`, are untouched. A join whose lower
-  row carried a *relative* path is unrecoverable by construction; that is
-  what the sheet's editable field is for.
+  bare-relative match, and `…and` above `local-plan/x` arrives as
+  `andlocal-plan/x`. The joined *text* cannot always tell glue from a real
+  wrapped target, so the fork keeps the seams: `LinkMatch.rowTexts`
+  carries the match's per-row fragments into `linkActivationHandler`'s
+  params (`rowTexts`, newline-joined — buffer cells cannot hold one), and
+  `WrappedRowGlue.cutTarget` (pure + tested) cuts at the first seam whose
+  butting chunk — the run since the last space — carries neither `/` nor
+  `.`: structure there means a target continuing
+  (`/Users/jhen/wor`⏎`kspace2/x`, `example.c`⏎`om/x`), a plain word means
+  the rows below start their own target. The cut suffix resolves through
+  the normal link-then-path order with the join as fallback, so a wrong
+  cut can never turn a working press into a dead one. Accepted trade, on
+  record: a bare path whose entire first segment sat on the upper row
+  (`local-p`⏎`lan/x`) reads as glue and cuts wrong — visible in the
+  editable field, and far rarer than hard-wrapped prose above a path.
+  `strippingWrappedProseHead` stays as the textual fallback for callers
+  without seam info (the edited field, gaze regions; the debug.link hook
+  carries seams via `Terminal.linkWithRowTexts`): it
+  cuts at the first `X./` whose `X` is neither `.` nor `..`, and only when
+  the text doesn't already start with its own base marker (`/`, `~`, `.`,
+  `$`) — so real paths, including `a.b/c.d` and `dir/./file`, are
+  untouched; a *relative* join stays unrecoverable there, which is what
+  the sheet's editable field is for.
   Load-bearing details: **the viewer dials its own SSHConnection** — never
   the probe's (a disabled host must not be revived by a tab) and never the
   summoning tab's transport (merge/split moves the viewer away) — redialed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,8 +252,9 @@ terminal's agent HISTORY panel (session-file prompt list) for layout
 capture, and
 `… -p app.multiplexterm.multiplex.debug.link` activates the first link on
 the focused pane's visible screen through the same resolve → policy →
-confirmation path a long press takes (a screen of only filesystem paths
-must present nothing — that's the decline working), with
+confirmation path a long press takes (a URL raises the link sheet, a
+path-shaped press the file-viewer sheet; a screen of only what both
+resolvers decline — $VAR/…, colon prose — must present nothing), with
 `….debug.linkopen` running the sheet's OPEN action so the system log shows
 the URL reaching SurfBoard, and `….debug.viewportopen` running the sheet's
 ⌗ VIEWPORT chip for the pending link — the headless way to dock the inline
@@ -884,9 +885,21 @@ views.
   `open?host=…&action=agent&prompt=…`**, so pane output can't launch an
   agent on another host; implicit detection matches **filesystem paths**
   (`./x`, `/etc/hosts`, `~/x`) as readily as URLs, so those resolve to nil
-  and the press falls through to selection; and interior whitespace
-  disqualifies a target, because prose carrying a colon (`warning: unused
-  variable`) otherwise classifies as a `warning:` link. The sheet renders
+  here (and confirm through the file-viewer sheet instead); and interior
+  whitespace disqualifies a link target, because prose carrying a colon
+  (`warning: unused variable`) otherwise classifies as a `warning:` link.
+  **Schemeless URLs resolve as links too** (`TerminalLink.schemelessLink`):
+  the matcher hands `example.com/docs` over through its bare-relative
+  *path* branch, so without this they confirmed as files. The gate is
+  narrow because everything here is also a legal filename — the authority
+  must be domain-shaped (≥2 ASCII labels, alphabetic ≥2-char TLD) or
+  dotted-quad IPv4, with URL evidence beyond the dot (a `/`/`?`/`#` rest
+  or a `www.` prefix, so a markdown link's `setup.md` stays a sibling
+  document and file-viewer relative navigation keeps working), userinfo
+  rejected outright; the scheme defaults by reach exactly like the
+  viewport's typed input (http for LAN/loopback, https elsewhere). A
+  *dotted* non-allowlisted scheme candidate (`example.com:99999/x`)
+  declines to nil rather than reporting a nonsense blocked scheme. The sheet renders
   the **resolved target** with the host on its own line — an OSC 8 label is
   chosen independently of its destination, and that line is also what
   exposes `https://github.com@evil.example/x`. Blocked and malformed
@@ -973,7 +986,18 @@ views.
   `TerminalFilePathSheet`, whose ▤ VIEW docks the tab. **This changed a
   load-bearing behavior**: path-shaped presses used to fall through to text
   selection; now only what BOTH resolvers decline ($VAR/…, colon prose,
-  interior whitespace) still does. visionOS gaze regions stay URL-only on
+  whitespace in a *bare-relative* shape) still does. **Paths with spaces
+  resolve when they root themselves with a base marker** (`/`, `~/`, `./`,
+  `$HOME/`) — the marker says "path" when whitespace no longer can; bare
+  relatives keep the prose guard ("see src/foo.ts and lib/bar.rs" must not
+  classify as one spaced path). The matcher's space-segment branches
+  swallow trailing prose whenever the first chunk is dot-free
+  (`/etc/hosts is missing` arrives whole), so `trimmingProseTail` sheds
+  end chunks carrying neither `/` nor `.`; a spaced directory whose last
+  segment is markerless (`~/My Folder`) loses that segment to the same
+  rule, which is why the sheet shows an OPENS row (verbatim mono — a path
+  is screen content) whenever the resolved spelling differs from the
+  field. visionOS gaze regions stay URL-only on
   purpose (hover regions are hit regions; build logs are walls of paths).
   **A wrapped row can hand over a sentence glued to the path below it** —
   the fork reassembles wrapped rows and a hard wrap leaves no space at the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -893,13 +893,19 @@ views.
   *path* branch, so without this they confirmed as files. The gate is
   narrow because everything here is also a legal filename — the authority
   must be domain-shaped (≥2 ASCII labels, alphabetic ≥2-char TLD) or
-  dotted-quad IPv4, with URL evidence beyond the dot (a `/`/`?`/`#` rest
-  or a `www.` prefix, so a markdown link's `setup.md` stays a sibling
-  document and file-viewer relative navigation keeps working), userinfo
-  rejected outright; the scheme defaults by reach exactly like the
-  viewport's typed input (http for LAN/loopback, https elsewhere). A
-  *dotted* non-allowlisted scheme candidate (`example.com:99999/x`)
-  declines to nil rather than reporting a nonsense blocked scheme. The sheet renders
+  dotted-quad IPv4 (`ViewportReach.isIPv4Literal`, the one parser), with
+  URL evidence beyond the dot (a `/`/`?`/`#` rest or a `www.` prefix, so
+  a markdown link's `setup.md` stays a sibling document), userinfo
+  rejected outright; the scheme defaults by reach through the shared
+  `ViewportReach.classify(host:)` — the viewport's typed-input rule, http
+  for LAN/loopback, https elsewhere — and `raw` is the *composed* URL, so
+  the sheet says the scheme this resolution chose (cleartext http on a
+  LAN address in particular) instead of implying it. Markdown
+  destinations opt out entirely (`resolve(_:schemelessHosts: false)` in
+  `FileViewerPane`): a schemeless markdown href is a relative reference
+  by spec, so `api.v2/index.md` keeps navigating in-document. A *dotted*
+  non-allowlisted scheme candidate (`example.com:99999/x`) declines to
+  nil rather than reporting a nonsense blocked scheme. The sheet renders
   the **resolved target** with the host on its own line — an OSC 8 label is
   chosen independently of its destination, and that line is also what
   exposes `https://github.com@evil.example/x`. Blocked and malformed
@@ -1005,8 +1011,11 @@ views.
   bare-relative match, and `…and` above `local-plan/x` arrives as
   `andlocal-plan/x`. The joined *text* cannot always tell glue from a real
   wrapped target, so the fork keeps the seams: `LinkMatch.rowTexts`
-  carries the match's per-row fragments into `linkActivationHandler`'s
-  params (`rowTexts`, newline-joined — buffer cells cannot hold one), and
+  carries the match's per-row fragments (built only when a match actually
+  spans rows — the gaze-region rebuild never pays for it) into
+  `linkActivationHandler`'s own third parameter — deliberately NOT the
+  `params` dictionary, whose explicit-branch keys are parsed out of the
+  remote-authored OSC 8 payload — and
   `WrappedRowGlue.cutTarget` (pure + tested) cuts at the first seam whose
   butting chunk — the run since the last space — carries neither `/` nor
   `.`: structure there means a target continuing

--- a/Multiplex/Models/FileViewer/TerminalPathTarget.swift
+++ b/Multiplex/Models/FileViewer/TerminalPathTarget.swift
@@ -38,6 +38,13 @@ struct TerminalPathTarget: Equatable, Identifiable {
 
     var id: String { raw }
 
+    /// The canonical field spelling — the path plus its `:line` suffix —
+    /// i.e. the text that re-resolves to this same target. The sheet's
+    /// editable field starts here, and its OPENS row compares against it.
+    var spelling: String {
+        line.map { "\(path):\($0)" } ?? path
+    }
+
     /// The path relative to its base, ready for remote resolution:
     /// absolute stays absolute, home drops the `~/`/`$HOME/` marker,
     /// working-directory keeps its relative spelling (minus `./`).
@@ -60,33 +67,29 @@ struct TerminalPathTarget: Equatable, Identifiable {
         guard !text.isEmpty, text.count <= 1024 else { return nil }
         // URLs belong to TerminalLink; anything scheme-shaped is not a path.
         if text.contains("://") { return nil }
-        // Tabs and line breaks are never part of a target; plain spaces are
-        // judged below.
-        guard !text.contains(where: { $0.isWhitespace && $0 != " " }) else { return nil }
-        guard !text.contains(where: { $0.asciiValue.map { $0 < 0x20 } == true })
-        else { return nil }
-
-        if text.contains(" ") {
-            // A spaced target is admitted only when it roots itself with a
-            // base marker (`/x y`, `~/x y`, `./x y`, `$HOME/x y`): the
-            // marker is what says "path" when whitespace no longer can.
-            // Bare-relative keeps the prose guard — "see src/foo.ts and
-            // lib/bar.rs" must not classify as one spaced path.
-            guard let first = text.first, "/~.$".contains(first) else { return nil }
-            // The matcher's space-segment branches swallow trailing prose
-            // whenever the first chunk is dot-free ("/etc/hosts is missing"
-            // arrives whole), so prose-shaped tail chunks — no `/`, no `.` —
-            // are shed until the text ends path-like again. A spaced
-            // directory whose last segment is markerless ("~/My Folder")
-            // loses that segment to this rule; the sheet's editable field
-            // is the recovery.
-            text = trimmingProseTail(text)
-        } else {
-            // Trailing prose punctuation the matcher can leave on a path.
-            while let last = text.last, ".,;)".contains(last) {
-                text.removeLast()
-            }
+        // One pass: controls and non-space whitespace (tabs, line breaks,
+        // Unicode spaces) are never part of a target; plain spaces are
+        // judged by the marker gate below.
+        var hasSpace = false
+        for character in text {
+            if character == " " { hasSpace = true; continue }
+            if character.isWhitespace { return nil }
+            if character.asciiValue.map({ $0 < 0x20 }) == true { return nil }
         }
+
+        // A spaced target is admitted only when it roots itself with a
+        // base marker (`/x y`, `~/x y`, `./x y`, `$HOME/x y`): the marker
+        // is what says "path" when whitespace no longer can. Bare-relative
+        // keeps the prose guard — "see src/foo.ts and lib/bar.rs" must not
+        // classify as one spaced path.
+        if hasSpace, !hasBaseMarker(text) { return nil }
+        // Shed trailing sentence punctuation, and — because the matcher's
+        // space-segment branches swallow trailing prose whenever the first
+        // chunk is dot-free ("/etc/hosts is missing" arrives whole) —
+        // prose-shaped tail chunks too. A spaced directory whose last
+        // segment is markerless ("~/My Folder") loses that segment to the
+        // same rule; the sheet's editable field is the recovery.
+        text = trimmingProseTail(text)
         guard !text.isEmpty else { return nil }
         text = strippingWrappedProseHead(text)
 
@@ -114,21 +117,30 @@ struct TerminalPathTarget: Equatable, Identifiable {
         return classified(raw: raw, path: text, line: line)
     }
 
-    /// Sheds trailing space-chunks that read as prose, one at a time from
-    /// the end: a chunk carrying neither `/` nor `.` is a sentence word,
-    /// not a path segment ("is", "missing", "now"). Sentence punctuation is
-    /// re-trimmed after every cut so "…/app.log failed." sheds cleanly.
+    /// The self-rooting first characters — absolute, home, dot-relative,
+    /// `$HOME` — one definition for the spaced-target gate and the
+    /// prose-head stripper's early return.
+    private static func hasBaseMarker(_ text: String) -> Bool {
+        text.first.map { "/~.$".contains($0) } ?? false
+    }
+
+    /// Sheds trailing sentence punctuation and space-chunks that read as
+    /// prose, one at a time from the end (`WrappedRowGlue.isProseChunk` is
+    /// the shared tell: no `/`, no `.` — "is", "missing", "now").
+    /// Punctuation is re-examined after every cut so "…/app.log failed."
+    /// sheds cleanly. One index walks backward; the string is copied once.
     private static func trimmingProseTail(_ input: String) -> String {
-        var text = input
+        var end = input.endIndex
         while true {
-            while let last = text.last, ".,;) ".contains(last) {
-                text.removeLast()
+            while end > input.startIndex, ".,;) ".contains(input[input.index(before: end)]) {
+                end = input.index(before: end)
             }
-            guard let cut = text.lastIndex(of: " ") else { return text }
-            let tail = text[text.index(after: cut)...]
-            if tail.contains("/") || tail.contains(".") { return text }
-            text = String(text[text.startIndex..<cut])
+            guard let cut = input[input.startIndex..<end].lastIndex(of: " "),
+                  WrappedRowGlue.isProseChunk(input[input.index(after: cut)..<end])
+            else { break }
+            end = cut
         }
+        return end == input.endIndex ? input : String(input[input.startIndex..<end])
     }
 
     /// Drops a sentence's tail that a *row join* glued to the front of a
@@ -150,9 +162,7 @@ struct TerminalPathTarget: Equatable, Identifiable {
     /// (`word.src/foo.ts` cannot be told from a real `word.src/foo.ts`) —
     /// that is what the confirmation sheet's editable field is for.
     private static func strippingWrappedProseHead(_ text: String) -> String {
-        guard let first = text.first,
-              first != "/", first != "~", first != ".", first != "$"
-        else { return text }
+        guard !hasBaseMarker(text) else { return text }
         let characters = Array(text)
         for index in 1..<max(1, characters.count - 1)
         where characters[index] == "." && characters[index + 1] == "/" {

--- a/Multiplex/Models/FileViewer/TerminalPathTarget.swift
+++ b/Multiplex/Models/FileViewer/TerminalPathTarget.swift
@@ -60,16 +60,32 @@ struct TerminalPathTarget: Equatable, Identifiable {
         guard !text.isEmpty, text.count <= 1024 else { return nil }
         // URLs belong to TerminalLink; anything scheme-shaped is not a path.
         if text.contains("://") { return nil }
-        // Interior whitespace is the prose guard, same rule as
-        // TerminalLink: "see src/foo.ts and lib/bar.rs" must not classify.
-        // Paths with spaces lose this trade — a wrong open costs more.
-        guard !text.contains(where: \.isWhitespace) else { return nil }
+        // Tabs and line breaks are never part of a target; plain spaces are
+        // judged below.
+        guard !text.contains(where: { $0.isWhitespace && $0 != " " }) else { return nil }
         guard !text.contains(where: { $0.asciiValue.map { $0 < 0x20 } == true })
         else { return nil }
 
-        // Trailing prose punctuation the matcher can leave on a path.
-        while let last = text.last, ".,;)".contains(last) {
-            text.removeLast()
+        if text.contains(" ") {
+            // A spaced target is admitted only when it roots itself with a
+            // base marker (`/x y`, `~/x y`, `./x y`, `$HOME/x y`): the
+            // marker is what says "path" when whitespace no longer can.
+            // Bare-relative keeps the prose guard — "see src/foo.ts and
+            // lib/bar.rs" must not classify as one spaced path.
+            guard let first = text.first, "/~.$".contains(first) else { return nil }
+            // The matcher's space-segment branches swallow trailing prose
+            // whenever the first chunk is dot-free ("/etc/hosts is missing"
+            // arrives whole), so prose-shaped tail chunks — no `/`, no `.` —
+            // are shed until the text ends path-like again. A spaced
+            // directory whose last segment is markerless ("~/My Folder")
+            // loses that segment to this rule; the sheet's editable field
+            // is the recovery.
+            text = trimmingProseTail(text)
+        } else {
+            // Trailing prose punctuation the matcher can leave on a path.
+            while let last = text.last, ".,;)".contains(last) {
+                text.removeLast()
+            }
         }
         guard !text.isEmpty else { return nil }
         text = strippingWrappedProseHead(text)
@@ -96,6 +112,23 @@ struct TerminalPathTarget: Equatable, Identifiable {
         // more than declining into text selection.
         guard !text.contains(":") else { return nil }
         return classified(raw: raw, path: text, line: line)
+    }
+
+    /// Sheds trailing space-chunks that read as prose, one at a time from
+    /// the end: a chunk carrying neither `/` nor `.` is a sentence word,
+    /// not a path segment ("is", "missing", "now"). Sentence punctuation is
+    /// re-trimmed after every cut so "…/app.log failed." sheds cleanly.
+    private static func trimmingProseTail(_ input: String) -> String {
+        var text = input
+        while true {
+            while let last = text.last, ".,;) ".contains(last) {
+                text.removeLast()
+            }
+            guard let cut = text.lastIndex(of: " ") else { return text }
+            let tail = text[text.index(after: cut)...]
+            if tail.contains("/") || tail.contains(".") { return text }
+            text = String(text[text.startIndex..<cut])
+        }
     }
 
     /// Drops a sentence's tail that a *row join* glued to the front of a

--- a/Multiplex/Models/TerminalLink.swift
+++ b/Multiplex/Models/TerminalLink.swift
@@ -68,8 +68,13 @@ extension TerminalLink {
     /// word, or bytes that cannot be a URL. `SwiftTermView` declines those, so
     /// the gesture falls through to normal selection handling.
     ///
+    /// `schemelessHosts` opts the schemeless reading out for callers whose
+    /// spec already answers the question: a markdown destination without a
+    /// scheme is a *relative reference* by definition, so the file viewer
+    /// passes false and `api.v2/index.md` keeps navigating in-document.
+    ///
     /// Pure: no URL is opened here and nothing is logged.
-    static func resolve(_ target: String) -> TerminalLink? {
+    static func resolve(_ target: String, schemelessHosts: Bool = true) -> TerminalLink? {
         let trimmed = target.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, trimmed.count <= maxLength else { return nil }
         // Controls and line breaks are never part of a legitimate target, and
@@ -98,7 +103,7 @@ extension TerminalLink {
         // in a pane is a URL to a person, but implicit detection hands it
         // over through a *path* branch, and `example.com:8080/x` parses as
         // scheme "example.com" under RFC 3986 (dots are scheme characters).
-        if let link = schemelessLink(from: trimmed) { return link }
+        if schemelessHosts, let link = schemelessLink(from: trimmed) { return link }
         // A real scheme that is neither allowlisted nor a host:port shape
         // keeps today's answer: reported, never opened. A *dotted* scheme
         // candidate is a hostname that failed the reading above, not a
@@ -155,11 +160,12 @@ extension TerminalLink {
     private static func schemelessLink(from text: String) -> TerminalLink? {
         var candidate = text
         // Path-branch matches carry sentence punctuation the URL branch's
-        // own guard would have stripped ("visit example.com/foo.").
+        // own guard would have stripped ("visit example.com/foo."). `)` is
+        // deliberately NOT trimmed here, unlike paths: parens are real in
+        // URLs (Wikipedia articles) and never reach us from the matcher.
         while let last = candidate.last, ".,;".contains(last) {
             candidate.removeLast()
         }
-        guard !candidate.isEmpty else { return nil }
         let restStart = candidate.firstIndex(where: { "/?#".contains($0) })
             ?? candidate.endIndex
         let authority = candidate[candidate.startIndex..<restStart]
@@ -178,16 +184,21 @@ extension TerminalLink {
         guard restStart < candidate.endIndex || lowered.hasPrefix("www.") else {
             return nil
         }
-        guard isDomainShaped(lowered) || isIPv4(lowered) else { return nil }
+        guard isDomainShaped(lowered) || ViewportReach.isIPv4Literal(lowered) else {
+            return nil
+        }
 
-        guard let probe = URL(string: "http://" + candidate, encodingInvalidCharacters: true),
-              let reach = ViewportReach.classify(probe)
+        // The viewport's typed-input rule, from the shared classifier:
+        // LAN/loopback addresses are dev servers and default cleartext
+        // http, everything else https.
+        let prefix = ViewportReach.classify(host: lowered) == .internet
+            ? "https://" : "http://"
+        guard let url = URL(string: prefix + candidate, encodingInvalidCharacters: true)
         else { return nil }
-        let prefix = reach == .internet ? "https://" : "http://"
-        guard let url = URL(string: prefix + candidate, encodingInvalidCharacters: true),
-              let urlHost = url.host(), !urlHost.isEmpty
-        else { return nil }
-        return TerminalLink(raw: candidate, kind: .openable(url))
+        // raw is what the sheet shows and what a press opens — the composed
+        // URL, so the scheme this resolution chose (cleartext http on a LAN
+        // address in particular) is said in the open, never implied.
+        return TerminalLink(raw: url.absoluteString, kind: .openable(url))
     }
 
     /// ≥2 DNS-shaped ASCII labels with an alphabetic, ≥2-char final label.
@@ -195,26 +206,13 @@ extension TerminalLink {
     /// is far more likely a filename than an IDN worth guessing at.
     private static func isDomainShaped(_ host: String) -> Bool {
         let labels = host.split(separator: ".", omittingEmptySubsequences: false)
-        guard labels.count >= 2 else { return false }
-        for label in labels {
-            guard (1...63).contains(label.count),
-                  label.first != "-", label.last != "-",
-                  label.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") })
-            else { return false }
-        }
-        guard let tld = labels.last else { return false }
-        return tld.count >= 2 && tld.allSatisfy { $0.isASCII && $0.isLetter }
-    }
-
-    private static func isIPv4(_ host: String) -> Bool {
-        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count == 4 else { return false }
-        return parts.allSatisfy { part in
-            guard !part.isEmpty, part.count <= 3,
-                  part.allSatisfy({ $0.isASCII && $0.isNumber }),
-                  let value = Int(part)
-            else { return false }
-            return (0...255).contains(value)
+        guard labels.count >= 2, let tld = labels.last,
+              tld.count >= 2, tld.allSatisfy({ $0.isASCII && $0.isLetter })
+        else { return false }
+        return labels.allSatisfy { label in
+            (1...63).contains(label.count)
+                && label.first != "-" && label.last != "-"
+                && label.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
         }
     }
 

--- a/Multiplex/Models/TerminalLink.swift
+++ b/Multiplex/Models/TerminalLink.swift
@@ -82,21 +82,34 @@ extension TerminalLink {
         // A URI has no raw spaces, and interior whitespace is what separates
         // an actual target from ordinary prose that happens to carry a colon:
         // `warning: unused variable` otherwise classifies as a `warning:`
-        // link. Implicit detection's path branches do match spaces, but those
-        // have no scheme and are declined below anyway.
+        // link. Implicit detection's path branches do match spaces; those
+        // belong to `TerminalPathTarget`, never here.
         guard !trimmed.contains(where: \.isWhitespace) else { return nil }
 
-        // No scheme means implicit detection matched a path branch
-        // (`./src/main.swift`, `/etc/hosts`, `~/notes`) or a bare token.
-        // Those are ordinary terminal output, not links.
-        guard let scheme = scheme(of: trimmed) else { return nil }
-        guard allowedSchemes.contains(scheme) else {
+        let scheme = scheme(of: trimmed)
+        if let scheme, allowedSchemes.contains(scheme) {
+            guard let url = url(from: trimmed, scheme: scheme) else {
+                return TerminalLink(raw: trimmed, kind: .malformed)
+            }
+            return TerminalLink(raw: trimmed, kind: .openable(url))
+        }
+        // No allowlisted scheme: before declining (or reporting a blocked
+        // scheme), try the schemeless reading — `example.com/docs` printed
+        // in a pane is a URL to a person, but implicit detection hands it
+        // over through a *path* branch, and `example.com:8080/x` parses as
+        // scheme "example.com" under RFC 3986 (dots are scheme characters).
+        if let link = schemelessLink(from: trimmed) { return link }
+        // A real scheme that is neither allowlisted nor a host:port shape
+        // keeps today's answer: reported, never opened. A *dotted* scheme
+        // candidate is a hostname that failed the reading above, not a
+        // scheme anyone registered — reporting it as one ("A example.com:
+        // link…") is nonsense, so it declines instead.
+        if let scheme, !scheme.contains(".") {
             return TerminalLink(raw: trimmed, kind: .blockedScheme(scheme))
         }
-        guard let url = url(from: trimmed, scheme: scheme) else {
-            return TerminalLink(raw: trimmed, kind: .malformed)
-        }
-        return TerminalLink(raw: trimmed, kind: .openable(url))
+        // A path branch match (`./src/main.swift`, `/etc/hosts`, `~/notes`)
+        // or a bare token — ordinary terminal output, not a link.
+        return nil
     }
 
     /// RFC 3986 scheme: an ASCII letter followed by letters, digits, `+`,
@@ -115,6 +128,94 @@ extension TerminalLink {
             return nil
         }
         return candidate.lowercased()
+    }
+
+    /// The schemeless reading of a target: `example.com/docs`,
+    /// `www.example.com`, `docs.rs/serde`, `192.168.1.5:3000/app`. Implicit
+    /// detection's bare-relative *path* branch is what hands these over (its
+    /// dotted lookahead guarantees a dot), so without this they confirmed as
+    /// files instead of links.
+    ///
+    /// The gate is deliberately narrow, because everything here is also a
+    /// legal filename:
+    /// - The authority must be domain-shaped — ≥2 ASCII labels, the last one
+    ///   alphabetic and ≥2 chars (TLD-shaped) — or a dotted-quad IPv4.
+    /// - There must be URL evidence beyond the dot: a path/query/fragment
+    ///   (`/`, `?`, `#`) or a `www.` prefix. A bare dotted word stays what it
+    ///   is — `setup.md` in a markdown link is a sibling document, not a
+    ///   Moldovan site, and the file viewer's relative navigation depends on
+    ///   that staying declined.
+    /// - Userinfo is rejected outright: `github.com@evil.example/x` is the
+    ///   exact lie the host line exists to expose, and a schemeless target
+    ///   has no business carrying credentials.
+    ///
+    /// The scheme is defaulted the way the viewport's typed input does it:
+    /// `http` where the address lives on a LAN or loopback (dev servers are
+    /// cleartext) and `https` everywhere else.
+    private static func schemelessLink(from text: String) -> TerminalLink? {
+        var candidate = text
+        // Path-branch matches carry sentence punctuation the URL branch's
+        // own guard would have stripped ("visit example.com/foo.").
+        while let last = candidate.last, ".,;".contains(last) {
+            candidate.removeLast()
+        }
+        guard !candidate.isEmpty else { return nil }
+        let restStart = candidate.firstIndex(where: { "/?#".contains($0) })
+            ?? candidate.endIndex
+        let authority = candidate[candidate.startIndex..<restStart]
+        guard !authority.isEmpty, !authority.contains("@") else { return nil }
+
+        var host = authority
+        if let colon = authority.firstIndex(of: ":") {
+            let port = authority[authority.index(after: colon)...]
+            guard (1...5).contains(port.count),
+                  port.allSatisfy({ $0.isASCII && $0.isNumber }),
+                  let value = Int(port), (1...65535).contains(value)
+            else { return nil }
+            host = authority[authority.startIndex..<colon]
+        }
+        let lowered = host.lowercased()
+        guard restStart < candidate.endIndex || lowered.hasPrefix("www.") else {
+            return nil
+        }
+        guard isDomainShaped(lowered) || isIPv4(lowered) else { return nil }
+
+        guard let probe = URL(string: "http://" + candidate, encodingInvalidCharacters: true),
+              let reach = ViewportReach.classify(probe)
+        else { return nil }
+        let prefix = reach == .internet ? "https://" : "http://"
+        guard let url = URL(string: prefix + candidate, encodingInvalidCharacters: true),
+              let urlHost = url.host(), !urlHost.isEmpty
+        else { return nil }
+        return TerminalLink(raw: candidate, kind: .openable(url))
+    }
+
+    /// ≥2 DNS-shaped ASCII labels with an alphabetic, ≥2-char final label.
+    /// ASCII only on purpose: a non-ASCII first segment in terminal output
+    /// is far more likely a filename than an IDN worth guessing at.
+    private static func isDomainShaped(_ host: String) -> Bool {
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.count >= 2 else { return false }
+        for label in labels {
+            guard (1...63).contains(label.count),
+                  label.first != "-", label.last != "-",
+                  label.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") })
+            else { return false }
+        }
+        guard let tld = labels.last else { return false }
+        return tld.count >= 2 && tld.allSatisfy { $0.isASCII && $0.isLetter }
+    }
+
+    private static func isIPv4(_ host: String) -> Bool {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        return parts.allSatisfy { part in
+            guard !part.isEmpty, part.count <= 3,
+                  part.allSatisfy({ $0.isASCII && $0.isNumber }),
+                  let value = Int(part)
+            else { return false }
+            return (0...255).contains(value)
+        }
     }
 
     private static func url(from text: String, scheme: String) -> URL? {

--- a/Multiplex/Models/ViewportReach.swift
+++ b/Multiplex/Models/ViewportReach.swift
@@ -31,10 +31,22 @@ enum ViewportReach: Equatable {
               scheme == "http" || scheme == "https",
               let rawHost = url.host(), !rawHost.isEmpty
         else { return nil }
-        let host = rawHost.lowercased()
+        return classify(host: rawHost)
+    }
+
+    /// The same verdict for a bare host — callers that already hold the
+    /// authority (schemeless link resolution) skip building a probe URL.
+    static func classify(host: String) -> ViewportReach {
+        let host = host.lowercased()
         if isLoopback(host) { return .remoteLoopback }
         if isLAN(host) { return .lan }
         return .internet
+    }
+
+    /// Whether `host` is a dotted-quad IPv4 literal — the one parser for
+    /// that shape, shared with schemeless link resolution.
+    static func isIPv4Literal(_ host: String) -> Bool {
+        ipv4Octets(host) != nil
     }
 
     /// The host's own loopback spellings, including `0.0.0.0`/`::` — a

--- a/Multiplex/Models/WrappedRowGlue.swift
+++ b/Multiplex/Models/WrappedRowGlue.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// The wrapped-row glue detector: decides whether a pressed match that
+/// crossed a hard-wrap seam is one wrapped target or a sentence's tail glued
+/// to the path or address below it.
+///
+/// The fork reassembles wrapped rows before matching — necessary, because a
+/// long URL or path legitimately wraps — but a hard wrap leaves no space at
+/// the seam, so a source line ending `…and` above `local-plan/x` reaches the
+/// resolvers as `andlocal-plan/x`, one plausible-looking relative path. The
+/// joined *text* cannot tell those apart (`andlocal-plan` is a legal
+/// directory name); the seam position can, and the fork now hands it over
+/// as per-row fragments.
+///
+/// The tell is the run of characters between the last space and the seam:
+/// a genuine wrapped target contributes path/address structure there — a
+/// `/` (`/Users/jhen/wor`⏎`kspace2/x`) or a `.` (`example.c`⏎`om/x`) —
+/// while a glued sentence butts a plain word against the seam (`and`,
+/// `table`). A word carrying neither means the rows below start their own
+/// target, so resolution should begin at the seam.
+///
+/// Accepted trade, on record: a bare-relative path whose entire first
+/// segment sat on the upper row (`local-p`⏎`lan/x`) is indistinguishable
+/// from glue and gets cut to `lan/x` — wrong, but visible in the sheet's
+/// editable field, and far rarer than hard-wrapped prose above a path
+/// (any doc or agent transcript wrapped at pane width produces those).
+enum WrappedRowGlue {
+    /// The target to resolve *instead of* the joined text, cut at the first
+    /// prose-glue seam. nil when no seam qualifies — resolve the join as
+    /// always. Callers fall back to the join when the cut resolves to
+    /// nothing; a wrong cut must not turn a working press into a dead one.
+    static func cutTarget(fragments: [String]) -> String? {
+        guard fragments.count >= 2 else { return nil }
+        var prefix = ""
+        for index in 0..<(fragments.count - 1) {
+            prefix += fragments[index]
+            // The chunk butting this seam: everything after the last space
+            // (the whole prefix when it carries none).
+            let chunk = prefix.lastIndex(of: " ").map {
+                String(prefix[prefix.index(after: $0)...])
+            } ?? prefix
+            // Empty means the row ended on a space — no glue evidence, and
+            // a spaced path can genuinely wrap right after its space.
+            guard !chunk.isEmpty else { continue }
+            if !chunk.contains("/"), !chunk.contains(".") {
+                let suffix = fragments[(index + 1)...].joined()
+                return suffix.isEmpty ? nil : suffix
+            }
+        }
+        return nil
+    }
+}

--- a/Multiplex/Models/WrappedRowGlue.swift
+++ b/Multiplex/Models/WrappedRowGlue.swift
@@ -37,16 +37,24 @@ enum WrappedRowGlue {
             // The chunk butting this seam: everything after the last space
             // (the whole prefix when it carries none).
             let chunk = prefix.lastIndex(of: " ").map {
-                String(prefix[prefix.index(after: $0)...])
-            } ?? prefix
+                prefix[prefix.index(after: $0)...]
+            } ?? prefix[...]
             // Empty means the row ended on a space — no glue evidence, and
             // a spaced path can genuinely wrap right after its space.
             guard !chunk.isEmpty else { continue }
-            if !chunk.contains("/"), !chunk.contains(".") {
+            if isProseChunk(chunk) {
                 let suffix = fragments[(index + 1)...].joined()
                 return suffix.isEmpty ? nil : suffix
             }
         }
         return nil
+    }
+
+    /// The one spelling of "this space-delimited chunk reads as a sentence
+    /// word, not a path segment": it carries neither `/` nor `.`. Shared
+    /// with `TerminalPathTarget.trimmingProseTail`, so the glue cut and the
+    /// shed tail can never disagree about what prose looks like.
+    static func isProseChunk(_ chunk: Substring) -> Bool {
+        !chunk.contains("/") && !chunk.contains(".")
     }
 }

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -219,12 +219,8 @@ final class TerminalSessionController {
         // never fire here; this pane decides instead. The view owns the
         // closure and this controller owns the view — capture weakly.
         view.linkActivationIgnoresHighlight = true
-        view.linkActivationHandler = { [weak self] target, params in
-            self?.activateLink(
-                target,
-                rowFragments: params["rowTexts"]
-                    .map { $0.components(separatedBy: "\n") } ?? []
-            ) ?? false
+        view.linkActivationHandler = { [weak self] target, _, rowTexts in
+            self?.activateLink(target, rowFragments: rowTexts) ?? false
         }
         if !pendingOutput.isEmpty {
             view.feed(byteArray: pendingOutput[...])

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -219,8 +219,12 @@ final class TerminalSessionController {
         // never fire here; this pane decides instead. The view owns the
         // closure and this controller owns the view — capture weakly.
         view.linkActivationIgnoresHighlight = true
-        view.linkActivationHandler = { [weak self] target, _ in
-            self?.activateLink(target) ?? false
+        view.linkActivationHandler = { [weak self] target, params in
+            self?.activateLink(
+                target,
+                rowFragments: params["rowTexts"]
+                    .map { $0.components(separatedBy: "\n") } ?? []
+            ) ?? false
         }
         if !pendingOutput.isEmpty {
             view.feed(byteArray: pendingOutput[...])
@@ -1492,10 +1496,24 @@ final class TerminalSessionController {
     /// confirms through the file-viewer sheet instead of falling to
     /// selection; only what neither resolver accepts ($VAR/…, colon prose)
     /// still declines into text selection.
-    func activateLink(_ target: String) -> Bool {
+    ///
+    /// `rowFragments` is the match split at its hard-wrap seams (empty when
+    /// it fit one row, or from callers without seam info — the debug hook,
+    /// gaze regions): a prose word butting a seam means the rows below start
+    /// their own target (`and`⏎`local-plan/x` is not one path), so the cut
+    /// suffix resolves first and the join stays the fallback.
+    func activateLink(_ target: String, rowFragments: [String] = []) -> Bool {
         // The jump search owns the pane's input while it pages and its veil
         // covers the text being pressed — same rule as a drop.
         if case .finding = historyJump { return false }
+        if let cut = WrappedRowGlue.cutTarget(fragments: rowFragments),
+           claimResolved(cut) {
+            return true
+        }
+        return claimResolved(target)
+    }
+
+    private func claimResolved(_ target: String) -> Bool {
         if let link = TerminalLink.resolve(target) {
             pendingActivation = .link(link)
             return true

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -186,10 +186,11 @@ struct FileViewerPane: View {
             openLink: { destination in
                 // External targets are untrusted document text — the
                 // link sheet decides, exactly like a pane press. A
-                // scheme-less relative target is in-document
-                // navigation (docs/setup.md), which stays inside the
-                // already-confirmed viewer.
-                if let link = TerminalLink.resolve(destination) {
+                // scheme-less target is in-document navigation by
+                // markdown's own definition (a relative reference), so
+                // the pane-press schemeless-host reading is opted out —
+                // `api.v2/index.md` navigates, it does not become a URL.
+                if let link = TerminalLink.resolve(destination, schemelessHosts: false) {
                     confirmingLink = link
                 } else if !destination.contains(":"),
                           let current = controller.lastDocument {

--- a/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
+++ b/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
@@ -29,27 +29,21 @@ struct TerminalFilePathSheet: View {
         self.hostName = hostName
         self.onView = onView
         self.onCopy = onCopy
-        _text = State(initialValue: Self.editorText(for: target))
+        // The field starts at the model's canonical spelling, so an
+        // untouched field re-resolves to the same target.
+        _text = State(initialValue: target.spelling)
     }
-
-    /// What the field starts with: the classified path, plus the `:line`
-    /// suffix if the press carried one — the spelling the viewer accepts
-    /// back, so an untouched field re-resolves to the same target.
-    private static func editorText(for target: TerminalPathTarget) -> String {
-        guard let line = target.line else { return target.path }
-        return "\(target.path):\(line)"
-    }
-
-    /// The edited target, or nil while the field holds nothing that
-    /// classifies — VIEW goes quiet rather than opening the pressed path
-    /// behind the person's back.
-    private var edited: TerminalPathTarget? { TerminalPathTarget.resolve(text) }
 
     var body: some View {
+        // Resolved once per body pass — the field re-resolves per
+        // keystroke, and every row below reads the same verdict. nil while
+        // the field holds nothing that classifies; VIEW then goes quiet
+        // rather than opening the pressed path behind the person's back.
+        let edited = TerminalPathTarget.resolve(text)
         NavigationStack {
             ScrollView {
                 VStack(spacing: 18) {
-                    TallyFormSection(sectionTitle, detail: detail) {
+                    TallyFormSection(sectionTitle(edited), detail: detail(edited)) {
                         TallyFormRow {
                             VStack(alignment: .leading, spacing: 12) {
                                 VStack(alignment: .leading, spacing: 4) {
@@ -71,7 +65,7 @@ struct TerminalFilePathSheet: View {
                                 // tail), so when the opened path is not the
                                 // field's text, say so — verbatim, mono:
                                 // a path is screen content.
-                                if let divergence = resolvedDivergence {
+                                if let divergence = resolvedDivergence(edited) {
                                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                                         ChassisLabel("OPENS", size: 9, color: Theme.caution)
                                         Text(divergence)
@@ -125,13 +119,13 @@ struct TerminalFilePathSheet: View {
     /// field holds — trailing punctuation trimmed, a prose tail shed from a
     /// spaced press. nil while they agree (the common case) or nothing
     /// resolves (the note already says so).
-    private var resolvedDivergence: String? {
+    private func resolvedDivergence(_ edited: TerminalPathTarget?) -> String? {
         guard let edited else { return nil }
-        let resolved = Self.editorText(for: edited)
+        let resolved = edited.spelling
         return resolved == text.trimmingCharacters(in: .whitespaces) ? nil : resolved
     }
 
-    private var sectionTitle: String {
+    private func sectionTitle(_ edited: TerminalPathTarget?) -> String {
         switch edited?.base {
         case .absolute: "A path on \(hostName)"
         case .home: "In \(hostName)'s home"
@@ -140,7 +134,7 @@ struct TerminalFilePathSheet: View {
         }
     }
 
-    private var detail: String {
+    private func detail(_ edited: TerminalPathTarget?) -> String {
         guard let edited else {
             return "The field holds nothing the viewer can resolve — a "
                 + "relative path needs a directory in it, and spaces only "

--- a/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
+++ b/Multiplex/Views/Terminal/TerminalFilePathSheet.swift
@@ -66,6 +66,20 @@ struct TerminalFilePathSheet: View {
                                         : nil
                                 )
 
+                                // Resolution can shed what it reads as prose
+                                // (a spaced press arrives with its sentence
+                                // tail), so when the opened path is not the
+                                // field's text, say so — verbatim, mono:
+                                // a path is screen content.
+                                if let divergence = resolvedDivergence {
+                                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                        ChassisLabel("OPENS", size: 9, color: Theme.caution)
+                                        Text(divergence)
+                                            .font(.mono(11))
+                                            .foregroundStyle(Theme.signal2)
+                                    }
+                                }
+
                                 if let line = edited?.line {
                                     HStack(spacing: 8) {
                                         ChassisLabel("LINE", size: 9, color: Theme.signal3)
@@ -107,6 +121,16 @@ struct TerminalFilePathSheet: View {
         }
     }
 
+    /// The spelling VIEW will actually open when it differs from what the
+    /// field holds — trailing punctuation trimmed, a prose tail shed from a
+    /// spaced press. nil while they agree (the common case) or nothing
+    /// resolves (the note already says so).
+    private var resolvedDivergence: String? {
+        guard let edited else { return nil }
+        let resolved = Self.editorText(for: edited)
+        return resolved == text.trimmingCharacters(in: .whitespaces) ? nil : resolved
+    }
+
     private var sectionTitle: String {
         switch edited?.base {
         case .absolute: "A path on \(hostName)"
@@ -118,9 +142,10 @@ struct TerminalFilePathSheet: View {
 
     private var detail: String {
         guard let edited else {
-            return "The field holds nothing the viewer can resolve — a path "
-                + "needs a directory in it, and no spaces. Edit it, or copy "
-                + "the text if it's still useful."
+            return "The field holds nothing the viewer can resolve — a "
+                + "relative path needs a directory in it, and spaces only "
+                + "work behind /, ~/, ./ or $HOME/. Edit it, or copy the "
+                + "text if it's still useful."
         }
         var text = "VIEW opens it read-only in the file viewer, beside this "
             + "session — nothing runs, nothing is written. The path is "

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -550,18 +550,22 @@ struct TerminalWindowRoot: View {
         for row in 0..<terminal.rows {
             var col = 0
             while col < terminal.cols {
-                guard let target = terminal.link(
+                // Same seam-carrying lookup the long-press route uses, so
+                // this hook proves the wrapped-glue cut headlessly too.
+                guard let result = terminal.linkWithRowTexts(
                     at: .screen(Position(col: col, row: row)),
                     mode: .explicitAndImplicit
                 ) else {
                     col += 1
                     continue
                 }
-                if controller.activateLink(target) { return }
-                // A declined match (a filesystem path) must not stall the
-                // scan on its own cells — step past the whole match's worth
-                // of columns rather than re-resolving each one.
-                col += max(1, target.count)
+                if controller.activateLink(result.text, rowFragments: result.rowTexts) {
+                    return
+                }
+                // A declined match must not stall the scan on its own
+                // cells — step past the whole match's worth of columns
+                // rather than re-resolving each one.
+                col += max(1, result.text.count)
             }
         }
     }

--- a/MultiplexTests/FileKindTests.swift
+++ b/MultiplexTests/FileKindTests.swift
@@ -97,8 +97,58 @@ final class TerminalPathTargetTests: XCTestCase {
     }
 
     func testInteriorWhitespaceIsProse() {
+        // Bare-relative keeps the prose guard: without a base marker,
+        // whitespace is what separates a path from a sentence about one.
         XCTAssertNil(TerminalPathTarget.resolve("(see src/foo.ts)"))
         XCTAssertNil(TerminalPathTarget.resolve("path with space/file.txt"))
+        // Tabs and line breaks never resolve, marker or not.
+        XCTAssertNil(TerminalPathTarget.resolve("/tmp/a\tb"))
+        XCTAssertNil(TerminalPathTarget.resolve("/tmp/a\nb"))
+    }
+
+    func testSpacedPathsBehindABaseMarkerResolve() {
+        let absolute = TerminalPathTarget.resolve("/Users/me/My Documents/file.txt")
+        XCTAssertEqual(absolute?.base, .absolute)
+        XCTAssertEqual(absolute?.path, "/Users/me/My Documents/file.txt")
+        let home = TerminalPathTarget.resolve("~/My Folder/notes.md")
+        XCTAssertEqual(home?.base, .home)
+        XCTAssertEqual(home?.relativePart, "My Folder/notes.md")
+        XCTAssertEqual(
+            TerminalPathTarget.resolve("./My File.md")?.base,
+            .workingDirectory
+        )
+        XCTAssertEqual(
+            TerminalPathTarget.resolve("$HOME/My Docs/x.txt")?.relativePart,
+            "My Docs/x.txt"
+        )
+    }
+
+    func testSpacedProseTailIsShed() {
+        // The matcher's space-segment branches swallow trailing prose
+        // whenever the first chunk is dot-free — "/etc/hosts is missing"
+        // arrives whole — so prose-shaped tail chunks are shed.
+        XCTAssertEqual(
+            TerminalPathTarget.resolve("/etc/hosts is missing")?.path,
+            "/etc/hosts"
+        )
+        XCTAssertEqual(
+            TerminalPathTarget.resolve("/Users/me/My Documents/file.txt now really")?.path,
+            "/Users/me/My Documents/file.txt"
+        )
+        XCTAssertEqual(
+            TerminalPathTarget.resolve("/tmp/a b c/d.log ok")?.path,
+            "/tmp/a b c/d.log"
+        )
+        XCTAssertEqual(
+            TerminalPathTarget.resolve("~/My Folder/notes.md today, fine.")?.path,
+            "~/My Folder/notes.md"
+        )
+    }
+
+    func testSpacedLineSuffixSurvives() {
+        let target = TerminalPathTarget.resolve("/tmp/My Dir/app.swift:42")
+        XCTAssertEqual(target?.path, "/tmp/My Dir/app.swift")
+        XCTAssertEqual(target?.line, 42)
     }
 
     /// A hard-wrapped row glues a sentence's tail to the path below it (no

--- a/MultiplexTests/FileKindTests.swift
+++ b/MultiplexTests/FileKindTests.swift
@@ -48,6 +48,62 @@ final class FileKindTests: XCTestCase {
     }
 }
 
+final class WrappedRowGlueTests: XCTestCase {
+    func testProseGluedToThePathBelowIsCutAtTheSeam() {
+        // A source line ending `…and` above `local-plan/x` reaches the
+        // resolvers as one joined match; the seam is the only tell.
+        XCTAssertEqual(
+            WrappedRowGlue.cutTarget(fragments: ["and", "local-plan/terminal-links.md"]),
+            "local-plan/terminal-links.md"
+        )
+        // Glue above an absolute path, and above a schemeless URL.
+        XCTAssertEqual(
+            WrappedRowGlue.cutTarget(fragments: ["and", "/etc/hosts"]),
+            "/etc/hosts"
+        )
+        XCTAssertEqual(
+            WrappedRowGlue.cutTarget(fragments: ["table", "docs.example.com/x"]),
+            "docs.example.com/x"
+        )
+        // The chunk test looks after the prefix's last space, so a spaced
+        // marker path keeps only its own text when prose glues mid-match.
+        XCTAssertEqual(
+            WrappedRowGlue.cutTarget(fragments: ["/Users/x and", "local-plan/y"]),
+            "local-plan/y"
+        )
+    }
+
+    func testGenuineWrappedTargetsKeepTheirJoin() {
+        // Structure before the seam — a slash or a dot — is a wrapped
+        // target continuing, never prose.
+        XCTAssertNil(WrappedRowGlue.cutTarget(fragments: ["/Users/jhen/wor", "kspace2/x.swift"]))
+        XCTAssertNil(WrappedRowGlue.cutTarget(fragments: ["https://exam", "ple.com/x"]))
+        XCTAssertNil(WrappedRowGlue.cutTarget(fragments: ["example.c", "om/docs"]))
+        XCTAssertNil(WrappedRowGlue.cutTarget(fragments: ["Sources/Fo", "o/Bar.swift"]))
+        // A row ending on a space is no glue evidence — a spaced path can
+        // wrap right after its space.
+        XCTAssertNil(WrappedRowGlue.cutTarget(fragments: ["/tmp/My ", "Folder/x.txt"]))
+        // One row means no seam at all.
+        XCTAssertNil(WrappedRowGlue.cutTarget(fragments: ["src/foo.ts"]))
+        XCTAssertNil(WrappedRowGlue.cutTarget(fragments: []))
+    }
+
+    func testLaterSeamsAreExaminedWhenTheFirstIsClean() {
+        // A long path wraps once more below the glue: cut at the first
+        // qualifying seam, keep the rest joined.
+        XCTAssertEqual(
+            WrappedRowGlue.cutTarget(fragments: ["and", "local-plan/very-long-", "name.md"]),
+            "local-plan/very-long-name.md"
+        )
+        // First seam is a genuine wrap (dot before it), second butts prose
+        // — the cut takes the suffix from the seam that qualifies.
+        XCTAssertEqual(
+            WrappedRowGlue.cutTarget(fragments: ["example.c", "om and", "/etc/hosts"]),
+            "/etc/hosts"
+        )
+    }
+}
+
 final class TerminalPathTargetTests: XCTestCase {
     func testAbsoluteHomeAndRelative() {
         XCTAssertEqual(TerminalPathTarget.resolve("/etc/hosts")?.base, .absolute)

--- a/MultiplexTests/TerminalLinkTests.swift
+++ b/MultiplexTests/TerminalLinkTests.swift
@@ -170,11 +170,21 @@ final class TerminalLinkTests: XCTestCase {
 
     func testSchemelessTrailingPunctuationIsTrimmed() {
         // Path-branch matches keep sentence punctuation the URL branch's
-        // own guard would have dropped.
+        // own guard would have dropped. raw is the composed URL — the
+        // sheet must show the scheme this resolution chose.
         XCTAssertEqual(
             TerminalLink.resolve("example.com/foo.")?.raw,
-            "example.com/foo"
+            "https://example.com/foo"
         )
+    }
+
+    func testSchemelessReadingCanBeOptedOut() {
+        // Markdown destinations are relative references by spec — the file
+        // viewer resolves with schemelessHosts: false so `api.v2/index.md`
+        // navigates in-document instead of becoming a URL.
+        XCTAssertNil(TerminalLink.resolve("example.com/docs", schemelessHosts: false))
+        // Real schemes are unaffected by the opt-out.
+        XCTAssertNotNil(TerminalLink.resolve("https://example.com/docs", schemelessHosts: false))
     }
 
     func testBareDottedWordsStayDeclined() {

--- a/MultiplexTests/TerminalLinkTests.swift
+++ b/MultiplexTests/TerminalLinkTests.swift
@@ -125,6 +125,86 @@ final class TerminalLinkTests: XCTestCase {
         XCTAssertNil(TerminalLink.resolve("https://example.com/a b"))
     }
 
+    // MARK: Schemeless
+
+    func testSchemelessDomainsWithPathsResolve() {
+        // Implicit detection hands these over through its bare-relative
+        // *path* branch (the dotted lookahead guarantees the dot), so
+        // without the schemeless reading they confirmed as files.
+        for (target, expected) in [
+            ("example.com/docs/setup", "https://example.com/docs/setup"),
+            ("docs.rs/serde/latest", "https://docs.rs/serde/latest"),
+            ("en.wikipedia.org/wiki/Tmux", "https://en.wikipedia.org/wiki/Tmux"),
+            ("www.example.com/foo?q=1", "https://www.example.com/foo?q=1"),
+        ] {
+            guard case .openable(let url)? = TerminalLink.resolve(target)?.kind else {
+                return XCTFail("expected \(target) to be openable")
+            }
+            XCTAssertEqual(url.absoluteString, expected)
+        }
+    }
+
+    func testWWWIsEvidenceEnoughWithoutAPath() {
+        guard case .openable(let url)? = TerminalLink.resolve("www.example.com")?.kind else {
+            return XCTFail("expected www.example.com to be openable")
+        }
+        XCTAssertEqual(url.absoluteString, "https://www.example.com")
+    }
+
+    func testSchemelessSchemeFollowsReach() {
+        // The viewport's typed-input rule: dev servers are cleartext, so
+        // LAN/loopback addresses default http; everything else https.
+        for (target, expected) in [
+            ("192.168.1.5:3000/app", "http://192.168.1.5:3000/app"),
+            ("devbox.local/status", "http://devbox.local/status"),
+            ("127.0.0.1:5173/", "http://127.0.0.1:5173/"),
+            ("example.com:8080/x", "https://example.com:8080/x"),
+        ] {
+            XCTAssertEqual(
+                TerminalLink.resolve(target)?.openableURL?.absoluteString,
+                expected,
+                "for \(target)"
+            )
+        }
+    }
+
+    func testSchemelessTrailingPunctuationIsTrimmed() {
+        // Path-branch matches keep sentence punctuation the URL branch's
+        // own guard would have dropped.
+        XCTAssertEqual(
+            TerminalLink.resolve("example.com/foo.")?.raw,
+            "example.com/foo"
+        )
+    }
+
+    func testBareDottedWordsStayDeclined() {
+        // A markdown link's `setup.md` is a sibling document, not a URL —
+        // the file viewer's relative navigation depends on this. A dot is
+        // not evidence; a path, query, or `www.` is.
+        for target in [
+            "setup.md",
+            "example.com",
+            "v1.2/notes",
+            "a.b/c.d",
+            "node_modules/.bin/tsc",
+        ] {
+            XCTAssertNil(TerminalLink.resolve(target), "expected \(target) to be declined")
+        }
+    }
+
+    func testSchemelessUserinfoIsDeclined() {
+        // `github.com@evil.example/x` without a scheme must not become a
+        // link whose label reads as GitHub.
+        XCTAssertNil(TerminalLink.resolve("github.com@evil.example/x"))
+    }
+
+    func testSchemelessSingleLabelsAndBadPortsAreDeclined() {
+        XCTAssertNil(TerminalLink.resolve("localhost/x"))
+        XCTAssertNil(TerminalLink.resolve("build/output.js"))
+        XCTAssertNil(TerminalLink.resolve("example.com:99999/x"))
+        XCTAssertNil(TerminalLink.resolve("example.com:80a/x"))
+    }
+
     // MARK: Malformed
 
     func testHostlessWebLinksAreMalformed() {

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -948,7 +948,14 @@ extension TerminalView {
         }
     }
 
-    func linkForClick(at position: Position, hasCommandModifier: Bool) -> (link: String, params: [String:String])?
+    // Multiplex patch: `rowTexts` is its own element — an implicit match
+    // that crossed a hard-wrap seam carries its per-row fragments so the
+    // app can tell a wrapped path from prose glued to the path below it.
+    // Deliberately NOT smuggled through `params`: on the explicit branch
+    // that dictionary is parsed straight out of the remote-authored OSC 8
+    // payload, and the app's structured channel must not share a keyspace
+    // with it.
+    func linkForClick(at position: Position, hasCommandModifier: Bool) -> (link: String, params: [String:String], rowTexts: [String])?
     {
         guard let match = terminal.linkMatch(at: .buffer(position), mode: .explicitAndImplicit) else {
             return nil
@@ -959,17 +966,9 @@ extension TerminalView {
         if match.isExplicit,
            let payload = payloadString(at: position),
            let (url, params) = urlAndParamsFrom(payload: payload) {
-            return (url, params)
+            return (url, params, [])
         }
-        // Multiplex patch: an implicit match that crossed a hard-wrap seam
-        // carries its per-row fragments so the app can tell a wrapped path
-        // from prose glued to the path below it. Newline is the one safe
-        // separator — buffer cells cannot hold it, so it never appears in
-        // matched text.
-        if match.rowTexts.count > 1 {
-            return (match.text, ["rowTexts": match.rowTexts.joined(separator: "\n")])
-        }
-        return (match.text, [:])
+        return (match.text, [:], match.rowTexts)
     }
     
     /// Returns the selection range for the specified row, if any.

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Apple/AppleTerminalView.swift
@@ -961,6 +961,14 @@ extension TerminalView {
            let (url, params) = urlAndParamsFrom(payload: payload) {
             return (url, params)
         }
+        // Multiplex patch: an implicit match that crossed a hard-wrap seam
+        // carries its per-row fragments so the app can tell a wrapped path
+        // from prose glued to the path below it. Newline is the one safe
+        // separator — buffer cells cannot hold it, so it never appears in
+        // matched text.
+        if match.rowTexts.count > 1 {
+            return (match.text, ["rowTexts": match.rowTexts.joined(separator: "\n")])
+        }
         return (match.text, [:])
     }
     

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
@@ -6213,20 +6213,28 @@ open class Terminal {
             // seams. `lineMap.cells` maps 1:1 onto the text's characters,
             // so grouping consecutive matched characters by their cell's
             // row reassembles exactly what each visual row contributed.
+            // Built only for matches that actually span rows (`rowBounds`
+            // already counted them) — single-row matches, the overwhelming
+            // majority on hot callers like the gaze-region rebuild, pay
+            // nothing — and sliced in one O(match) walk, never by
+            // materializing the whole logical line.
             var rowTexts: [String] = []
-            var currentRow: Int?
-            var currentFragment = ""
-            let characters = Array(lineMap.text)
-            for idx in startOffset..<boundedEndOffset {
-                let cellRow = lineMap.cells[idx].row
-                if cellRow != currentRow {
-                    if currentRow != nil { rowTexts.append(currentFragment) }
-                    currentRow = cellRow
-                    currentFragment = ""
+            if rowBounds.count > 1 {
+                var cursor = textRange.lowerBound
+                var fragment = ""
+                var currentRow = lineMap.cells[startOffset].row
+                for idx in startOffset..<boundedEndOffset {
+                    let cellRow = lineMap.cells[idx].row
+                    if cellRow != currentRow {
+                        rowTexts.append(fragment)
+                        fragment = ""
+                        currentRow = cellRow
+                    }
+                    fragment.append(lineMap.text[cursor])
+                    lineMap.text.formIndex(after: &cursor)
                 }
-                currentFragment.append(characters[idx])
+                rowTexts.append(fragment)
             }
-            if currentRow != nil { rowTexts.append(currentFragment) }
 
             return LinkMatch(
                 text: String(lineMap.text[textRange]),

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/Terminal.swift
@@ -5927,6 +5927,14 @@ open class Terminal {
         let range: Range<Int>
         let isExplicit: Bool
         let rowRanges: [RowRange]
+        // Multiplex patch: the matched text split at hard-wrap seams,
+        // topmost row first (`text` is these joined). A wrapped-row join
+        // glues a sentence's tail to the path or address below it with no
+        // space at the seam; only the seam positions can tell the two
+        // apart, so the activation path carries them instead of flattening
+        // the match. Empty for explicit (OSC 8) matches — their target is
+        // the payload, not the rendered rows.
+        var rowTexts: [String] = []
     }
 
     func bufferFromKind (kind: BufferKind) -> Buffer
@@ -5972,6 +5980,17 @@ open class Terminal {
     public func link(at location: LinkLookupLocation, mode: LinkLookupMode) -> String?
     {
         return linkMatch(at: location, mode: mode)?.text
+    }
+
+    // Multiplex patch: the same lookup with the match's hard-wrap seams
+    // kept — `rowTexts` is the text split at row boundaries, topmost first
+    // (empty for explicit matches and single-row implicit ones). Callers
+    // that resolve targets need the seams to tell a wrapped target from
+    // prose glued to the path below it.
+    public func linkWithRowTexts(at location: LinkLookupLocation, mode: LinkLookupMode) -> (text: String, rowTexts: [String])?
+    {
+        guard let match = linkMatch(at: location, mode: mode) else { return nil }
+        return (match.text, match.rowTexts)
     }
 
     // Multiplex patch: gaze link regions (visionOS). The system renders gaze
@@ -6190,12 +6209,32 @@ open class Terminal {
                     return .init(row: row, range: bounds.start..<bounds.end)
                 }
 
+            // Multiplex patch: split the matched text at its hard-wrap
+            // seams. `lineMap.cells` maps 1:1 onto the text's characters,
+            // so grouping consecutive matched characters by their cell's
+            // row reassembles exactly what each visual row contributed.
+            var rowTexts: [String] = []
+            var currentRow: Int?
+            var currentFragment = ""
+            let characters = Array(lineMap.text)
+            for idx in startOffset..<boundedEndOffset {
+                let cellRow = lineMap.cells[idx].row
+                if cellRow != currentRow {
+                    if currentRow != nil { rowTexts.append(currentFragment) }
+                    currentRow = cellRow
+                    currentFragment = ""
+                }
+                currentFragment.append(characters[idx])
+            }
+            if currentRow != nil { rowTexts.append(currentFragment) }
+
             return LinkMatch(
                 text: String(lineMap.text[textRange]),
                 row: lineMap.targetRow,
                 range: rowStart..<rowEnd,
                 isExplicit: false,
-                rowRanges: rowRanges
+                rowRanges: rowRanges,
+                rowTexts: rowTexts
             )
         }
         return nil

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -212,13 +212,17 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     ///
     /// With no handler installed, upstream behavior stands: the delegate's
     /// `requestOpenLink` is called and the gesture is consumed.
-    public var linkActivationHandler: ((_ link: String, _ params: [String: String]) -> Bool)?
+    ///
+    /// `rowTexts` is the implicit match split at its hard-wrap seams
+    /// (empty for explicit links and single-row matches) — the app-side
+    /// glue detector's evidence.
+    public var linkActivationHandler: ((_ link: String, _ params: [String: String], _ rowTexts: [String]) -> Bool)?
 
     /// Multiplex patch: shared activation path for tap and long press.
-    func activateLink(_ result: (link: String, params: [String: String])) -> Bool
+    func activateLink(_ result: (link: String, params: [String: String], rowTexts: [String])) -> Bool
     {
         if let linkActivationHandler {
-            return linkActivationHandler(result.link, result.params)
+            return linkActivationHandler(result.link, result.params, result.rowTexts)
         }
         terminalDelegate?.requestOpenLink(source: self, link: result.link, params: result.params)
         return true

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -172,3 +172,16 @@ https.
   opens as http.
 - setup.md in a rendered markdown doc still navigates inside the file
   viewer; src/foo.ts still confirms as a file, not a link.
+
+WRAPPED PROSE STOPS GLUING TO PATHS — and<newline>local-plan/x opens local-plan/x
+
+A hard-wrapped line ending in a plain word above a path used to press as one
+glued target (andlocal-plan/…). The press now cuts at the wrap seam when the
+text butting it is a word with no slash or dot, so the path below opens as
+itself. Genuinely wrapped long paths and URLs still join.
+
+- cat a doc whose line ends exactly at the pane edge with a word, path on
+  the next line: long-press the path — the sheet shows the path alone.
+- A long absolute path wrapped mid-segment still presses as the full path.
+- A schemeless URL below wrapped prose raises the link sheet, not a glued
+  file path.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -142,3 +142,33 @@ each ask is a slow round trip. It is now asked once per launch.
 - The App lock row still names your device's real method ("Require Face
   ID" on a Face ID phone, "Require device passcode" without biometry), and
   the lock itself still prompts correctly when you turn it on.
+
+PATHS WITH SPACES OPEN — and prose stops riding along
+
+Long-pressing a path that contains spaces (/Users/me/My Documents/x.txt,
+~/My Folder/notes.md) now raises the file-viewer sheet instead of doing
+nothing. Rooted paths followed by a sentence ("/etc/hosts is missing") shed
+the prose and open the path alone; when the opened spelling differs from
+the field, the sheet says OPENS with the exact path.
+
+- Print a spaced path (ls a directory with spaces), long-press it: the
+  sheet shows the full path, ▤ VIEW opens it.
+- Long-press /etc/hosts inside "error: /etc/hosts is missing": PATH reads
+  /etc/hosts, no prose.
+- "see src/foo.ts and lib/bar.rs" still falls through to text selection —
+  bare relative paths never absorb spaces.
+
+BARE URLS ARE LINKS — example.com/docs stops opening as a file
+
+A URL printed without its scheme (example.com/docs, docs.rs/serde,
+www.example.com, 192.168.1.5:3000/app) now raises the link sheet — OPEN,
+⌗ VIEWPORT, the host line — instead of the file-viewer sheet or nothing.
+LAN and loopback addresses open as http (dev servers), everything else as
+https.
+
+- echo example.com/anything, long-press it: link sheet, HOST example.com,
+  OPEN goes to https.
+- A LAN dev server address (192.168.x.x:3000/app) offers the viewport and
+  opens as http.
+- setup.md in a rendered markdown doc still navigates inside the file
+  viewer; src/foo.ts still confirms as a file, not a link.


### PR DESCRIPTION
## Summary

Two terminal press-classification fixes:

**Paths with spaces couldn't open.** The fork's ghostty matcher already hands spaced paths over, but `TerminalPathTarget` declined all interior whitespace. Spaced targets now resolve when they root themselves with a base marker (`/`, `~/`, `./`, `$HOME/`); bare relatives keep the prose guard ("see src/foo.ts and lib/bar.rs" must not classify as one spaced path). The matcher also swallows unbounded trailing prose whenever the first space-chunk is dot-free (`/etc/hosts is missing` arrives whole — so even unspaced paths followed by prose opened nothing before), so resolution now sheds end chunks carrying neither `/` nor `.`. When the resolved spelling differs from the field, the file sheet shows a verbatim mono **OPENS** row — nothing opens silently different from what's shown.

**Schemeless URLs confirmed as files.** `example.com/docs`, `docs.rs/serde`, `www.example.com`, `192.168.1.5:3000/app` reach the app through the matcher's bare-relative *path* branch. `TerminalLink` now reads schemeless targets as links behind a narrow gate — domain-shaped (≥2 ASCII labels, alphabetic ≥2-char TLD) or IPv4 authority, URL evidence beyond the dot (a `/?#` rest or `www.` prefix, so a markdown link's `setup.md` stays a sibling document and file-viewer relative navigation keeps working), userinfo rejected outright — with the scheme defaulted by reach exactly like the viewport's typed input (http for LAN/loopback, https elsewhere). A dotted non-allowlisted scheme candidate (`example.com:99999/x`) now declines instead of presenting a nonsense "A example.com: link" blocked-scheme sheet.

AGENTS.md's load-bearing bullets and the TestFlight changelog ride along.

## Verification

- 712/712 unit tests pass (8 new: spaced-path resolution, prose-tail shedding, schemeless resolves/declines); visionOS and iPad both build.
- End-to-end on the visionOS simulator against the harness via `debug.link`:
  - pressing `/tmp/My Test Dir/report file.txt is missing` raises the file sheet with PATH `/tmp/My Test Dir/report file.txt` (spaces kept, prose shed);
  - `example.com/docs/setup` mid-sentence raises the link sheet with HOST `example.com`, REACH `INTERNET`, ⌗ VIEWPORT / OPEN / COPY;
  - a live server-log line `GET /v1/sessions 200 76ms` resolves to a clean `/v1/sessions` (previously fell through to selection).

## Known trades (documented in AGENTS.md)

- A spaced directory whose last segment is markerless (`~/My Folder`) loses that segment to the prose-tail rule; the OPENS row + editable field are the recovery.
- `dist.prod/main.js`-shaped names with a real-TLD final label classify as links; the confirmation sheet (never auto-open) is the safety net.