### PR TITLE
Fix regressions found in the deep review of the UIKit migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,7 +322,9 @@ headlessly; `SwiftTermView` logs each decision to the unified log
 ## Architecture
 
 ```
-SwiftUI: classic Deck window + N Terminal windows, or one adaptive Shell
+UIKit scene runtime (`MultiplexSceneDelegate` + `UIKitSceneRootViewController`;
+         SwiftUI survives ONLY where visionOS's public ornament API needs a
+         `View`): classic Deck window + N Terminal windows, or one adaptive Shell
          Shell = real FleetWall + one ordered TerminalWindowRoute tab set
          a terminal window/shell = ordered tabs; each tab a TerminalRoute
   BindController     Bind Host: the candidates Add Host ▸ BIND renders,
@@ -1206,12 +1208,19 @@ views.
   still connects on demand. Free host plumbing, not an agent-helper surface;
   the free-tier host limit remains an add-flow check, so disabling never
   buys back a host slot.
-- **"Back to deck" reuses the one deck scene**: the data-driven `WindowGroup`
-  always opens `DeckWindowRoute.main`, so `openWindow(id:value:)` raises the
-  matching deck instead of minting another; `DeckScene` also destroys a second
-  legacy/restored session. Keep visionOS on this SwiftUI route too — activating
-  its `UISceneSession` directly can reset a user-resized deck to the scene's
-  default size.
+- **"Back to deck" reuses the one deck scene**: `UIKitSceneRouting` resolves
+  DECK to `.activateExisting` whenever a deck session exists (legacy SwiftUI
+  and native restoration activities both decode), so the press raises the
+  matching deck instead of minting another; `DeckScene` also destroys a
+  second legacy/restored session. Raising an existing scene can never resize
+  it — a `UISceneSessionActivationRequest` cannot carry geometry (SDK
+  headers) — and only a scene *creation* (the activity's
+  `sceneRequestsInitialGeometry` marker) runs `configureGeometry`, which
+  resolves DEBUG env override → that kind's remembered last size
+  (`SceneWindowSizeStore`, fed by effective-geometry updates) → the authored
+  default. That ordering is what preserves SwiftUI `.defaultSize`'s advisory
+  semantics: an imperative `requestGeometryUpdate` on every create was
+  snapping user-resized windows back to the default.
   Symmetrically, a deck tile press focuses the window already attached to that
   session
   (`TerminalWorkspace.focusTab` → `WindowEntry.reveal` → controller
@@ -1897,18 +1906,24 @@ unchosen candidates stay here under `docs/landing/`.
   Paper/Ivory alternates recorded there). `chassis` stays an asset color so
   the launch screen hands off in either polarity. The user's appearance
   choice (`ThemeStore.appearance`: SYSTEM/LIGHT/DARK, Settings) is applied by
-  `PlatformChrome` through each scene window's `overrideUserInterfaceStyle` —
-  **never `preferredColorScheme`, which stops at presentation boundaries**:
-  with it, an open Settings sheet kept stale traits and the tokens inside
-  never flipped (user-reported). Window traits also drive the keyboard and
-  UIKit-hosted popovers. One nuance: **a visionOS sheet/popover hosts in its
-  own window, which follows a live override change but misses the override
-  already in place when it presents** — a fresh launch with LIGHT pinned
-  opened Settings dark (user-reported). Presented chassis surfaces therefore
-  carry `followsAppAppearance()` (bundled into `chassisSheetGround()`;
-  applicator in `Design/AppearanceApplicator.swift`), which re-applies the
-  same choice to whatever window hosts them — a no-op where presentations
-  share the scene window.
+  `UIKitSceneRootViewController.applyAppearance` through each scene window's
+  `overrideUserInterfaceStyle` — **never a mechanism that stops at
+  presentation boundaries** (SwiftUI's `preferredColorScheme` did; an open
+  Settings sheet kept stale traits, user-reported). Window traits also drive
+  the keyboard and UIKit-hosted popovers. Two nuances: **a visionOS
+  sheet/popover hosts in its own window, which misses the override already
+  in place when it presents** — a fresh launch with LIGHT pinned opened
+  Settings dark (user-reported) — and **a presented controller's own
+  override wins over its window's**, so an appearance snapshotted at present
+  time goes stale on the next flip. Presented chassis surfaces therefore
+  adopt `AppAppearanceFollowing` (Chassis.swift, the UIKit heir of the
+  retired `followsAppAppearance()`): `followAppAppearance(themes)` observes
+  `ThemeStore.appearance` and re-applies it live to the controller, its
+  navigation stack, and whatever window hosts them; a presenter with no
+  store seeds from the scene window's applied style instead. Never write
+  `.unspecified` over a scene window that carries a pinned override — the
+  deck's guide sheets shipped doing exactly that and reset the whole
+  window's appearance.
   Components live in `Chassis.swift`: `ChassisLabel` (compressed caps
   — rails, tile names, UMD titles), `ChassisChip`/`ChassisBadge` (square
   actions), `TallyLamp` (captioned state lamp), `ChassisSwitch` (compact square
@@ -1925,15 +1940,18 @@ unchosen candidates stay here under `docs/landing/`.
   byte-identically). `ChassisLabel` scales its size+kerning together, and
   type-locked accents (badge icon slot, lamp dot) ride the same scale while
   control geometry (padding, key sizes, switch tracks) deliberately stays
-  authored. Semantic text styles (`.footnote`…) keep Dynamic Type and get
-  the equivalent Mac boost once at the scene root (`PlatformChrome`'s
-  `dynamicTypeSize(.xxLarge)`); fixed-size fonts ignore Dynamic Type, so
-  the two mechanisms never compound.
-- **visionOS hover**: use `chassisHover(_:)` on every custom Button/Menu —
-  and it must sit on the Button itself, NOT its label (the system resolves
-  the hover shape where the effect attaches; a label-level
-  `contentShape(.hoverEffect,…)` is silently ignored and you get the default
-  rounded platter).
+  authored. Semantic text styles (`.footnote`…) keep Dynamic Type — in
+  UIKit that means `preferredFont(forTextStyle:)` PLUS
+  `adjustsFontForContentSizeCategory = true` on the label — and get the
+  equivalent Mac boost once at the scene root (the root controller's
+  `traitOverrides.preferredContentSizeCategory`); fixed-size fonts ignore
+  Dynamic Type, so the two mechanisms never compound.
+- **visionOS hover**: set `hoverStyle` (`UIHoverStyle`, square
+  `.rect(cornerRadius: 2)` for chassis controls) on every custom
+  button/menu — and it must sit on the CONTROL itself, NOT a subview or
+  label (the system resolves the hover shape where the style attaches; a
+  label-level shape is silently ignored and you get the default rounded
+  platter — the same trap SwiftUI's `chassisHover(_:)` guarded).
 - **Terminal surface colors are user preference, not identity**: they come
   from the selected `TerminalTheme` (wall SETTINGS chip), never `Theme`
   tokens. **Each appearance keeps its own selection** —
@@ -1943,9 +1961,9 @@ unchosen candidates stay here under `docs/landing/`.
   house trio `tallyFrost`/`tallyPaper`/`tallyIvory` is contrast-tested in
   `TerminalThemeTests`). Settings rows edit the slot of the appearance on
   screen; chrome keeps the chassis whatever the theme. Open terminals re-skin
-  live — `SwiftTermView.updateUIView` re-applies when the theme value
-  changes, and a scheme flip re-resolves the slot through `TerminalPane`'s
-  `colorScheme`. `keyboardAppearance` stays `.default` — the keyboard belongs
+  live — the terminal container re-applies when the theme value changes,
+  and a scheme flip re-resolves the slot through the pane's trait
+  collection (`TerminalPaneUIKit`). `keyboardAppearance` stays `.default` — the keyboard belongs
   to the chassis appearance, not the terminal theme (a light theme under dark
   chrome keeps a dark keyboard; user-reported). tmux's own status line is
   left to the user's config on purpose (no `status-style` injection).

--- a/Multiplex/App/MultiplexApp.swift
+++ b/Multiplex/App/MultiplexApp.swift
@@ -59,22 +59,21 @@ final class MultiplexApplicationDelegate: UIResponder, UIApplicationDelegate {
         }
         let liveName = scene.delegate.map { NSStringFromClass(type(of: $0)) }
         guard UIKitLegacySceneMigrationPolicy.requiresAdoption(
+            nativeDelegateClassName: NSStringFromClass(MultiplexSceneDelegate.self),
             configuredDelegateClassName: configuredName,
-            liveDelegateClassName: liveName,
-            restorationActivity: session.stateRestorationActivity
+            liveDelegateClassName: liveName
         ) else { return }
 
         let nativeDelegate = MultiplexSceneDelegate()
         scene.delegate = nativeDelegate
-        // On current UIKit the notification precedes the delegate callback,
-        // so that callback supplies every connection option normally. Older
-        // runtimes can post it after the serialized delegate's callback; the
-        // next-turn fallback mounts from the session's public restoration
-        // activity only when UIKit did not call the native delegate itself.
-        DispatchQueue.main.async { [weak scene, weak nativeDelegate] in
-            guard let scene, let nativeDelegate else { return }
-            nativeDelegate.connectPersistedLegacySceneIfNeeded(scene)
-        }
+        // Mount immediately from the session's own persisted state. This
+        // notification can arrive either side of the serialized delegate's
+        // `willConnect`, and deferring a turn leaves the sole foreground scene
+        // inert meanwhile. When UIKit does reach this delegate afterwards, the
+        // `connectedSession` guard keeps the mount single and hands that
+        // callback's connection options — the cold-launch widget tap, URL, or
+        // Shortcut — to `adoptLateConnectionOptions` instead of dropping them.
+        nativeDelegate.connectPersistedLegacySceneIfNeeded(scene)
         sceneLog.notice(
             "Adopted persisted SwiftUI scene \(session.persistentIdentifier, privacy: .public) into UIKit"
         )
@@ -104,12 +103,6 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
 
-        func setReduceMotion(_ reduceMotion: Bool) {
-            if case .shell(let controller) = self {
-                controller.setReduceMotion(reduceMotion)
-            }
-        }
-
         func prepareForRemoval() {
             switch self {
             case .deck(let controller): controller.prepareForRemoval()
@@ -125,9 +118,19 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
     private var payload: ScenePayload?
     private var connectionPhase: UIKitSceneConnectionPhase = .awaitingRestoration
     private var urlBuffer = UIKitSceneURLBuffer()
+    /// Scene callbacks that landed before this delegate connected. The legacy
+    /// adoption path installs the delegate mid-connection, so UIKit can offer
+    /// restored state or activate the scene while there is still nothing to
+    /// apply it to. Dropping either is what leaves a restored terminal window
+    /// coming back as a bare deck, or a scene parked on its placeholder.
+    private var pendingRestorationActivity: NSUserActivity?
+    private var pendingActivation = false
     private var preservesDeckIdentity = true
     private weak var connectedSession: UISceneSession?
     private var reduceMotionObserver: NSObjectProtocol?
+    #if os(visionOS)
+    private let windowSizes = SceneWindowSizeStore()
+    #endif
 
     private var runtime: AppRuntime {
         guard let delegate = UIApplication.shared.delegate
@@ -166,15 +169,27 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
         activationActivities: [NSUserActivity],
         initialURLs: [URL]
     ) {
-        guard connectedSession == nil else { return }
+        guard connectedSession == nil else {
+            adoptLateConnectionOptions(
+                activationActivities: activationActivities,
+                initialURLs: initialURLs,
+                in: windowScene
+            )
+            return
+        }
         connectedSession = session
+        // A legacy session may not have handed over its restoration activity
+        // yet (UISceneSession documents that), but it always carries the same
+        // SwiftUI envelope in `userInfo`.
+        let restorationActivity = session.stateRestorationActivity
+            ?? SceneActivityCodec.legacySessionActivity(from: session.userInfo)
         let resolution = UIKitScenePayloadResolver.resolution(
             activationActivities: activationActivities,
-            restorationActivity: session.stateRestorationActivity
+            restorationActivity: restorationActivity
         )
         connectionPhase = UIKitSceneConnectionPhase.initial(
             resolution: resolution,
-            restorationActivityWasSupplied: session.stateRestorationActivity != nil
+            restorationActivityWasSupplied: restorationActivity != nil
         )
 
         let router = UIKitSceneRouter(scene: windowScene)
@@ -195,6 +210,7 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
             configureGeometry(for: resolution.payload, in: windowScene)
         }
         installReduceMotionObserver()
+        drainPendingSceneCallbacks(in: windowScene)
 
         for url in initialURLs.sorted(by: {
             $0.absoluteString < $1.absoluteString
@@ -203,26 +219,73 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
+    /// UIKit's `scene(_:willConnectTo:)` can reach a session this delegate
+    /// already connected from `willConnectNotification`. The mount is done, but
+    /// the options it brings are the launch itself — a widget tap, a
+    /// `multiplex://` URL, a Shortcut — and are the one thing still owed.
+    private func adoptLateConnectionOptions(
+        activationActivities: [NSUserActivity],
+        initialURLs: [URL],
+        in windowScene: UIWindowScene
+    ) {
+        let resolution = UIKitScenePayloadResolver.resolution(
+            activationActivities: activationActivities,
+            restorationActivity: nil
+        )
+        if resolution.source == .activation {
+            activate(resolution.payload, in: windowScene)
+        }
+        for url in initialURLs.sorted(by: {
+            $0.absoluteString < $1.absoluteString
+        }) {
+            receiveOrBuffer(url)
+        }
+    }
+
+    private func drainPendingSceneCallbacks(in windowScene: UIWindowScene) {
+        // Restored state first: it is what activation would otherwise
+        // overwrite with the fresh value-less deck.
+        if let activity = pendingRestorationActivity {
+            pendingRestorationActivity = nil
+            applyRestoration(activity, in: windowScene)
+        }
+        if pendingActivation {
+            pendingActivation = false
+            promoteAwaitingRestorationIfNeeded(in: windowScene)
+            mountedContent?.setSceneActive(true)
+        }
+    }
+
     func sceneDidBecomeActive(_ scene: UIScene) {
-        if connectionPhase == .awaitingRestoration,
-           let windowScene = scene as? UIWindowScene,
-           let sceneRouter {
-            // UIKit promises restoreInteractionState before activation. If
-            // no callback arrived by this point, this is genuinely the fresh
-            // value-less deck/shell scene rather than protected delayed state.
-            connectionPhase = .freshDefault
-            replaceContent(
-                with: .deck(.main),
-                in: windowScene,
-                routing: sceneRouter.routing
-            )
-            configureGeometry(for: .deck(.main), in: windowScene)
+        if sceneRouter == nil {
+            pendingActivation = true
+        } else if let windowScene = scene as? UIWindowScene {
+            promoteAwaitingRestorationIfNeeded(in: windowScene)
         }
         mountedContent?.setSceneActive(true)
         Task { await runtime.appLock.autoUnlock() }
     }
 
+    private func promoteAwaitingRestorationIfNeeded(in windowScene: UIWindowScene) {
+        guard connectionPhase == .awaitingRestoration, let sceneRouter else {
+            return
+        }
+        // UIKit promises restoreInteractionState before activation. If
+        // no callback arrived by this point, this is genuinely the fresh
+        // value-less deck/shell scene rather than protected delayed state.
+        connectionPhase = .freshDefault
+        replaceContent(
+            with: .deck(.main),
+            in: windowScene,
+            routing: sceneRouter.routing
+        )
+        configureGeometry(for: .deck(.main), in: windowScene)
+    }
+
     func sceneWillResignActive(_ scene: UIScene) {
+        #if os(visionOS)
+        recordSceneGeometry()
+        #endif
         mountedContent?.setSceneActive(false)
     }
 
@@ -235,11 +298,16 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
+        #if os(visionOS)
+        recordSceneGeometry()
+        #endif
         mountedContent?.prepareForRemoval()
         rootController?.prepareForRemoval()
         mountedContent = nil
         rootController = nil
         sceneRouter = nil
+        pendingRestorationActivity = nil
+        pendingActivation = false
         if let reduceMotionObserver {
             NotificationCenter.default.removeObserver(reduceMotionObserver)
             self.reduceMotionObserver = nil
@@ -259,9 +327,13 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         guard let incoming = SceneActivityCodec.payload(from: userActivity),
-              let windowScene = scene as? UIWindowScene,
-              let sceneRouter
+              let windowScene = scene as? UIWindowScene
         else { return }
+        activate(incoming, in: windowScene)
+    }
+
+    private func activate(_ incoming: ScenePayload, in windowScene: UIWindowScene) {
+        guard let sceneRouter else { return }
         connectionPhase = .activation
         if let current = payload,
            !UIKitSceneContentReplacementPolicy.requiresReplacement(
@@ -281,12 +353,23 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
         _ scene: UIScene,
         restoreInteractionStateWith stateRestorationActivity: NSUserActivity
     ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        guard sceneRouter != nil else {
+            pendingRestorationActivity = stateRestorationActivity
+            return
+        }
+        applyRestoration(stateRestorationActivity, in: windowScene)
+    }
+
+    private func applyRestoration(
+        _ activity: NSUserActivity,
+        in windowScene: UIWindowScene
+    ) {
         guard connectionPhase.acceptsInitialRestorationCallback,
-              let windowScene = scene as? UIWindowScene,
               let sceneRouter
         else { return }
         let restored: ScenePayload
-        if let decoded = SceneActivityCodec.payload(from: stateRestorationActivity) {
+        if let decoded = SceneActivityCodec.payload(from: activity) {
             restored = decoded
         } else if connectionPhase == .awaitingRestoration {
             restored = .deck(.main)
@@ -302,7 +385,13 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func stateRestorationActivity(for scene: UIScene) -> NSUserActivity? {
-        guard connectionPhase != .awaitingRestoration, let payload else { return nil }
+        // Nothing is mounted yet, so this delegate has nothing to say about
+        // the window — but UIKit is free to snapshot here, and answering nil
+        // would erase the session's own persisted activity, i.e. the window
+        // the person actually left open. Hand back what is already on file.
+        guard connectionPhase != .awaitingRestoration, let payload else {
+            return connectedSession?.stateRestorationActivity
+        }
         return try? SceneActivityCodec.makeActivity(for: payload)
     }
 
@@ -371,17 +460,12 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
         let content: UIViewController
         switch plan {
         case .deck:
-            let controller = DeckWindowViewController(configuration: deckConfiguration(
-                routing: routing,
-                terminalOpener: TerminalRouteOpener(
-                    destination: .window,
-                    action: routing.openTerminal
-                ),
-                presentation: .standard,
-                selectedTerminal: nil,
-                shellSafeArea: .zero,
-                sceneIsActive: windowScene.activationState == .foregroundActive
-            ))
+            let controller = DeckWindowViewController(
+                configuration: classicDeckConfiguration(
+                    routing: routing,
+                    sceneIsActive: windowScene.activationState == .foregroundActive
+                )
+            )
             mountedContent = .deck(controller)
             content = controller
 
@@ -424,16 +508,33 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
             content = controller
         }
 
+        // visionOS's terminal scene was declared `.windowStyle(.plain)`: no
+        // system glass platter, so the pane stack's own 24pt rounded chassis
+        // (`TerminalWindowUIKitRootView`) is the window's silhouette against
+        // the room. UIKit spells the same thing
+        // `preferredContainerBackgroundStyle == .hidden`, and it only reads
+        // as plain while nothing opaque is painted behind that rounded rect —
+        // hence the clear root view and window backing below. The deck keeps
+        // the platter, exactly as `.windowStyle` left it.
+        let plainWindowBackground: Bool = {
+            #if os(visionOS)
+            if case .terminal = plan { return true }
+            #endif
+            return false
+        }()
+
         let root = UIKitSceneRootViewController(
             content: content,
             themes: runtime.themes,
             appLock: runtime.appLock,
             externalActions: runtime.externalActions,
             bind: runtime.bind,
-            sceneWindows: routing
+            sceneWindows: routing,
+            plainWindowBackground: plainWindowBackground
         )
         rootController = root
         window?.rootViewController = root
+        window?.backgroundColor = plainWindowBackground ? .clear : nil
         windowScene.title = title(for: payload)
         log(plan: plan, in: windowScene)
     }
@@ -465,6 +566,25 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
             bind: runtime.bind,
             openURL: Self.openSystemURL,
             sceneWindows: routing
+        )
+    }
+
+    /// The one shape a deck scene of its own mounts with. Both the mount and
+    /// the Reduce Motion refresh build it here so the two can never drift.
+    private func classicDeckConfiguration(
+        routing: SceneWindowRouting,
+        sceneIsActive: Bool
+    ) -> DeckWindowConfiguration {
+        deckConfiguration(
+            routing: routing,
+            terminalOpener: TerminalRouteOpener(
+                destination: .window,
+                action: routing.openTerminal
+            ),
+            presentation: .standard,
+            selectedTerminal: nil,
+            shellSafeArea: .zero,
+            sceneIsActive: sceneIsActive
         )
     }
 
@@ -547,9 +667,21 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
         #else
         let environment: [String: String] = [:]
         #endif
-        let size = UIKitSceneGeometryPolicy.preferredSize(
-            for: payload,
-            environment: environment
+        // SwiftUI's `.defaultSize` was a hint: visionOS reopens a window group
+        // at whatever size the user last left it and only reaches for the
+        // declared default when it remembers nothing. This request runs on
+        // every scene UIKit creates, so it answers the same question in the
+        // same order — otherwise one resized terminal is undone by the next
+        // attach. Raising an existing scene still requests no geometry at all.
+        let kind = SceneGeometryKind(payload)
+        let size = SceneGeometryPolicy.chooseInitialSize(
+            environmentOverride: environment[kind.debugSizeEnvironmentKey]
+                .flatMap(UIKitSceneGeometryPolicy.parseSize),
+            remembered: windowSizes.lastSize(for: kind),
+            default: UIKitSceneGeometryPolicy.preferredSize(
+                for: payload,
+                environment: [:]
+            )
         )
         scene.requestGeometryUpdate(UIWindowScene.GeometryPreferences.Vision(
             size: size,
@@ -562,6 +694,35 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
         #endif
     }
 
+    #if os(visionOS)
+    /// `UIWindowSceneGeometry` exposes no size on visionOS (only the app's own
+    /// minimum/maximum and resizing restriction), so the live size is read
+    /// from the scene coordinate space where that exists and from the window
+    /// UIKit keeps spanning the scene everywhere else.
+    private func currentSceneSize() -> CGSize? {
+        if #available(visionOS 26.0, *), let scene = window?.windowScene {
+            return scene.effectiveGeometry.coordinateSpace.bounds.size
+        }
+        return window?.bounds.size
+    }
+
+    private func recordSceneGeometry() {
+        guard let payload, let size = currentSceneSize() else { return }
+        windowSizes.record(size, for: SceneGeometryKind(payload))
+    }
+
+    /// The resize signal itself. Older visionOS has no such callback, so
+    /// there the scene lifecycle captures (resign active, disconnect) are
+    /// what carry a resize into the next window of the same kind.
+    @available(visionOS 26.0, *)
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        didUpdateEffectiveGeometry previousEffectiveGeometry: UIWindowScene.Geometry
+    ) {
+        recordSceneGeometry()
+    }
+    #endif
+
     private func installReduceMotionObserver() {
         reduceMotionObserver = NotificationCenter.default.addObserver(
             forName: UIAccessibility.reduceMotionStatusDidChangeNotification,
@@ -569,10 +730,31 @@ final class MultiplexSceneDelegate: UIResponder, UIWindowSceneDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.mountedContent?.setReduceMotion(
-                    UIAccessibility.isReduceMotionEnabled
-                )
+                self?.applyReduceMotion()
             }
+        }
+    }
+
+    private func applyReduceMotion() {
+        guard let mountedContent else { return }
+        switch mountedContent {
+        case .deck(let controller):
+            // The classic deck takes Reduce Motion through its immutable
+            // configuration (the rail's LINKING pulse, the tile-grid
+            // crossfade), where the SwiftUI wall read it from the
+            // environment and followed it live. Rebuilding the same
+            // configuration re-reads the current value and lands as a wall
+            // re-render: every dependency reference is identical, so no part
+            // of the deck's lifecycle restarts.
+            guard let routing = sceneRouter?.routing else { return }
+            controller.update(configuration: classicDeckConfiguration(
+                routing: routing,
+                sceneIsActive: controller.sceneIsActive
+            ))
+        case .terminal:
+            break
+        case .shell(let controller):
+            controller.setReduceMotion(UIAccessibility.isReduceMotionEnabled)
         }
     }
 

--- a/Multiplex/App/UIKitSceneRootViewController.swift
+++ b/Multiplex/App/UIKitSceneRootViewController.swift
@@ -58,6 +58,11 @@ final class UIKitSceneRootViewController: UIViewController {
     private let sceneWindows: SceneWindowRouting
     private let platformChrome: UIKitPlatformChromePolicy
     private let handlesExternalActions: Bool
+    /// The UIKit equivalent of SwiftUI's `.windowStyle(.plain)`, which the
+    /// visionOS terminal scene shipped with: the system glass container is
+    /// hidden and this root paints nothing, so the content's own rounded
+    /// chassis is the whole window. Deck scenes keep the glass platter.
+    private let plainWindowBackground: Bool
 
     private var lockViewController: AppLockViewController?
     private var lockShieldWindow: UIWindow?
@@ -77,7 +82,8 @@ final class UIKitSceneRootViewController: UIViewController {
         bind: BindController,
         sceneWindows: SceneWindowRouting,
         platformChrome: UIKitPlatformChromePolicy = .current,
-        handlesExternalActions: Bool = true
+        handlesExternalActions: Bool = true,
+        plainWindowBackground: Bool = false
     ) {
         contentViewController = content
         self.themes = themes
@@ -87,6 +93,7 @@ final class UIKitSceneRootViewController: UIViewController {
         self.sceneWindows = sceneWindows
         self.platformChrome = platformChrome
         self.handlesExternalActions = handlesExternalActions
+        self.plainWindowBackground = plainWindowBackground
         lastHandledPendingSignal = externalActions.pendingSignal
         super.init(nibName: nil, bundle: nil)
     }
@@ -96,7 +103,13 @@ final class UIKitSceneRootViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIKitChassis.chassis
+        view.backgroundColor = plainWindowBackground ? .clear : UIKitChassis.chassis
+        #if os(visionOS)
+        // The window resolves the container style from its root view
+        // controller, which is this one. The preference is fixed at init, so
+        // one request as the view loads under that window is enough.
+        setNeedsUpdateOfPreferredContainerBackgroundStyle()
+        #endif
         applyPlatformChrome()
         addChild(contentViewController)
         view.addSubview(contentViewController.view)
@@ -136,6 +149,16 @@ final class UIKitSceneRootViewController: UIViewController {
             hasContext: externalActions.hasContext
         )
     }
+
+    #if os(visionOS)
+    /// `.hidden` is what `.windowStyle(.plain)` compiled down to: the scene
+    /// drops its glass container and only what the app draws is visible.
+    /// `childViewControllerForPreferredContainerBackgroundStyle` stays nil,
+    /// so no mounted content controller can hand the platter back.
+    override var preferredContainerBackgroundStyle: UIContainerBackgroundStyle {
+        plainWindowBackground ? .hidden : super.preferredContainerBackgroundStyle
+    }
+    #endif
 
     deinit {
         observationGeneration &+= 1

--- a/Multiplex/Design/Chassis.swift
+++ b/Multiplex/Design/Chassis.swift
@@ -1,3 +1,4 @@
+import Observation
 import UIKit
 
 // MARK: - UIKit chassis primitives
@@ -357,4 +358,175 @@ final class UIKitTallyFormSectionView: UIView {
         detailContainer.isHidden = detail == nil
     }
 
+}
+
+// MARK: - Appearance follow-through
+
+extension AppAppearance {
+    /// The style a scene carries for this choice — what
+    /// `UIKitSceneRootViewController` writes onto its root and window.
+    var interfaceStyle: UIUserInterfaceStyle {
+        switch resolvedOverride {
+        case nil: return .unspecified
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+
+    /// Reads the choice back off a scene window. The scene root writes exactly
+    /// the three styles above, so the mapping is exact in both directions —
+    /// which is what lets a presenter with no `ThemeStore` in hand still hand
+    /// a sheet the choice the scene is painting with.
+    init(sceneWindowStyle style: UIUserInterfaceStyle) {
+        switch style {
+        case .light: self = .light
+        case .dark: self = .dark
+        default: self = .system
+        }
+    }
+}
+
+/// Keeps one presented surface in step with `ThemeStore.appearance`.
+/// Observation callbacks are one-shot, so each pass registers the next — the
+/// same loop `UIKitSceneRootViewController` runs for the scene window.
+@MainActor
+final class AppAppearanceFollower {
+    private weak var themes: ThemeStore?
+    private var apply: ((AppAppearance) -> Void)?
+    private var generation = 0
+
+    /// Applies the current choice now and re-applies it on every later change.
+    func follow(_ themes: ThemeStore, apply: @escaping (AppAppearance) -> Void) {
+        self.themes = themes
+        self.apply = apply
+        generation &+= 1
+        observe(generation: generation)
+    }
+
+    /// Drops the link — a surface handed a one-off appearance instead.
+    func stop() {
+        generation &+= 1
+        themes = nil
+        apply = nil
+    }
+
+    private func observe(generation: Int) {
+        guard generation == self.generation, let themes, let apply else { return }
+        let appearance = withObservationTracking {
+            themes.appearance
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.observe(generation: generation)
+            }
+        }
+        apply(appearance)
+    }
+}
+
+/// A presented chassis surface that follows the app's appearance choice — the
+/// UIKit counterpart of the retired SwiftUI `followsAppAppearance()`.
+///
+/// Two things make this structural rather than per-call-site. A sheet's own
+/// `overrideUserInterfaceStyle` outranks its window's, so a surface that only
+/// snapshots the choice as it is presented never hears a flip made while it is
+/// open (Settings in another iPad window, or the debug appearance hook). And a
+/// presenter that forgets to hand the choice over leaves the default `.system`
+/// writing `.unspecified` over the scene's pinned override, dropping LIGHT or
+/// DARK for the whole window. Conformers keep their `appAppearance` property —
+/// assigning it directly still works; the link just keeps assigning it.
+@MainActor
+protocol AppAppearanceFollowing: AnyObject {
+    /// The choice this surface paints with.
+    var appAppearance: AppAppearance { get set }
+    /// Storage for the link — one line per conformer:
+    /// `let appAppearanceFollower = AppAppearanceFollower()`.
+    var appAppearanceFollower: AppAppearanceFollower { get }
+}
+
+extension AppAppearanceFollowing where Self: UIViewController {
+    /// Live link: the surface paints the current choice and keeps following it.
+    func followAppAppearance(_ themes: ThemeStore) {
+        appAppearanceFollower.follow(themes) { [weak self] appearance in
+            self?.appAppearance = appearance
+        }
+    }
+
+    /// Store-free seed for a presenter that has no `ThemeStore` in hand: the
+    /// scene window the presenter lives in already carries the applied choice.
+    /// Exact, but a snapshot — it cannot follow a later flip.
+    func adoptAppAppearance(presentedFrom presenter: UIViewController) {
+        appAppearanceFollower.stop()
+        appAppearance = AppAppearance(
+            sceneWindowStyle: presenter.viewIfLoaded?.window?.overrideUserInterfaceStyle
+                ?? .unspecified
+        )
+    }
+
+    /// Whichever of the two the presenter can supply.
+    func followAppAppearance(_ themes: ThemeStore?, presentedFrom presenter: UIViewController) {
+        if let themes {
+            followAppAppearance(themes)
+        } else {
+            adoptAppAppearance(presentedFrom: presenter)
+        }
+    }
+
+    /// The write a presented chassis surface makes: pin itself and the
+    /// navigation controller it is hosted in, then re-tint the opaque sheet
+    /// navigation bar. `pinsHostingChrome` is false for a pushed screen, whose
+    /// hosting chrome belongs to the root of that stack.
+    func applyAppAppearance(pinsHostingChrome: Bool = true) {
+        let style = appAppearance.interfaceStyle
+        overrideUserInterfaceStyle = style
+        if pinsHostingChrome {
+            navigationController?.overrideUserInterfaceStyle = style
+            pinHostingWindow(to: style)
+        }
+        if let navigationBar = navigationController?.navigationBar {
+            UIKitChassis.configureSheetNavigationBar(navigationBar)
+        }
+    }
+
+    /// visionOS hosts a sheet in a window of its own, which misses the override
+    /// already in place when it presents — that window needs the write. A sheet
+    /// sharing the scene's window (every iOS presentation) must not clear an
+    /// override it does not own; the scene root writes that one.
+    private func pinHostingWindow(to style: UIUserInterfaceStyle) {
+        guard let window = viewIfLoaded?.window else { return }
+        guard style != .unspecified
+            || window !== presentingViewController?.viewIfLoaded?.window
+        else { return }
+        window.overrideUserInterfaceStyle = style
+    }
+}
+
+// MARK: - Keyboard clearance
+
+extension UIViewController {
+    /// Spends a docked keyboard as CONTENT inset on a form's scroll view, never
+    /// as that scroll view's frame — the one shape every chassis form shares.
+    ///
+    /// The trap it replaces: `keyboardLayoutGuide` rests on the BOTTOM
+    /// SAFE-AREA edge while no keyboard is up, so a scroll view whose frame is
+    /// pinned to the guide ends there — content clipped mid-glyph above a dead
+    /// home-indicator band (user-reported on the New Session sheet). The frame
+    /// spans the window instead and `contentInsetAdjustmentBehavior` already
+    /// pays the safe area, so only the overlap BEYOND that band is added here
+    /// and the two can never charge for it twice. Undocked keyboards leave the
+    /// guide where it is (`followsUndockedKeyboard` is false), which is the
+    /// app's floating-keyboard rule for free.
+    ///
+    /// Call it from `viewDidLayoutSubviews`: the guide's own constants dirty
+    /// this view's layout, so the pass runs inside the keyboard's animation and
+    /// the inset rides along with it.
+    func applyKeyboardContentInset(to scrollView: UIScrollView) {
+        let guideTop = view.keyboardLayoutGuide.layoutFrame.minY
+        // A guide the engine has not measured yet reports an empty frame; a
+        // resting one always sits below the window's own top edge.
+        guard !view.bounds.isEmpty, guideTop > 0 else { return }
+        let inset = max(0, view.bounds.maxY - guideTop - view.safeAreaInsets.bottom)
+        guard abs(scrollView.contentInset.bottom - inset) > 0.5 else { return }
+        scrollView.contentInset.bottom = inset
+        scrollView.verticalScrollIndicatorInsets.bottom = inset
+    }
 }

--- a/Multiplex/Design/Chassis.swift
+++ b/Multiplex/Design/Chassis.swift
@@ -51,7 +51,7 @@ enum UIKitChassis {
 final class UIKitChassisLabel: UILabel {
     private var sourceText: String
     private let pointSize: CGFloat
-    private let ink: UIColor
+    private var ink: UIColor
 
     init(_ text: String, size: CGFloat = 12, color: UIColor? = nil) {
         sourceText = text
@@ -70,6 +70,14 @@ final class UIKitChassisLabel: UILabel {
     func setText(_ text: String) {
         sourceText = text
         accessibilityLabel = text
+        refreshAttributedText()
+    }
+
+    /// Changes only the label's ink while preserving its UIKit identity and
+    /// layout subtree. Interactive controls use this instead of replacing a
+    /// label that may still be participating in the current touch/layout pass.
+    func setInk(_ color: UIColor) {
+        ink = color
         refreshAttributedText()
     }
 

--- a/Multiplex/Models/ScenePayload.swift
+++ b/Multiplex/Models/ScenePayload.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 /// Restorable identity and value for one application window. This is kept
@@ -80,8 +81,6 @@ enum SceneActivityCodec {
     /// hash is compiler-private and deliberately ignored; the stable scene ID
     /// plus the app's Codable route bytes are the migration boundary.
     static let legacyStateRestorationActivityType = "com.apple.SwiftUI.stateRestoration"
-    static let legacyOpenWindowActivityType =
-        "app.multiplexterm.multiplex.openWindowByID"
     static let legacySceneIDKey = "com.apple.SwiftUI.sceneID"
     static let legacySceneValueKey = "com.apple.SwiftUI.sceneValue"
     static let legacyPresentedSceneValueKey =
@@ -132,9 +131,36 @@ enum SceneActivityCodec {
             && activity.userInfo?[newSceneRequestKey] as? Bool == true
     }
 
+    /// Every shipped SwiftUI scene session carries its scene ID and value in
+    /// `UISceneSession.userInfo` as well, and that slot is populated the
+    /// moment the session exists. UIKit warns that `stateRestorationActivity`
+    /// "may not be immediately available when the scene is connected", so this
+    /// reads the same legacy envelope from the slot that always answers — the
+    /// difference between an adopted legacy window coming back as itself and
+    /// coming back as an inert placeholder waiting for a callback.
+    static func legacySessionActivity(
+        from userInfo: [String: Any]?
+    ) -> NSUserActivity? {
+        guard let userInfo,
+              let sceneID = userInfo[legacySceneIDKey] as? String
+        else { return nil }
+        var entries: [AnyHashable: Any] = [legacySceneIDKey: sceneID]
+        if let presented = userInfo[legacyPresentedSceneValueKey] as? Data {
+            entries[legacyPresentedSceneValueKey] = presented
+        }
+        if let value = userInfo[legacySceneValueKey] as? Data {
+            entries[legacySceneValueKey] = value
+        }
+        guard entries.count > 1 else { return nil }
+        let activity = NSUserActivity(
+            activityType: legacyStateRestorationActivityType
+        )
+        activity.addUserInfoEntries(from: entries)
+        return activity
+    }
+
     private static func legacyPayload(from activity: NSUserActivity) -> ScenePayload? {
-        guard activity.activityType == legacyStateRestorationActivityType
-                || activity.activityType == legacyOpenWindowActivityType,
+        guard activity.activityType == legacyStateRestorationActivityType,
               let userInfo = activity.userInfo,
               let sceneID = userInfo[legacySceneIDKey] as? String
         else { return nil }
@@ -162,5 +188,99 @@ enum SceneActivityCodec {
             }
         }
         return nil
+    }
+}
+
+/// The kind of window a payload opens, which is the grain visionOS window
+/// geometry is remembered at — a deck and a terminal are sized for different
+/// jobs, while two terminals are the same kind of window.
+enum SceneGeometryKind: String, CaseIterable {
+    case deck
+    case terminal
+
+    init(_ payload: ScenePayload) {
+        switch payload {
+        case .deck: self = .deck
+        case .terminal: self = .terminal
+        }
+    }
+
+    /// The DEBUG-only size override a headless screenshot run passes. These
+    /// are the same keys `UIKitSceneGeometryPolicy.preferredSize` reads; the
+    /// pair is pinned together by a unit test so the two cannot drift.
+    var debugSizeEnvironmentKey: String {
+        switch self {
+        case .deck: "MULTIPLEX_DECK_SIZE"
+        case .terminal: "MULTIPLEX_TERM_SIZE"
+        }
+    }
+
+    fileprivate var lastSizeStorageKey: String { "scene.lastSize.\(rawValue)" }
+}
+
+/// Pure `.defaultSize` parity for the UIKit port.
+///
+/// The shipped visionOS scenes were SwiftUI `WindowGroup`s carrying
+/// `.defaultSize`, which is advisory: visionOS remembers the size a person
+/// resized a window group's window to and opens the *next* window of that
+/// group at it, falling back to the declared default only when it has nothing
+/// better. UIKit asks for geometry imperatively, on every scene it creates, so
+/// the same question has to be answered here — otherwise a terminal resized to
+/// 1600×1000 snaps every later terminal back to the authored default.
+enum SceneGeometryPolicy {
+    /// A size is only worth remembering while it could plausibly be a window
+    /// someone left that way. A scene sampled mid-teardown (or before its
+    /// window has laid out) reports zero, and that must never become the size
+    /// the next window opens at.
+    static let minimumRecordableEdge: CGFloat = 200
+
+    static func isRecordable(_ size: CGSize) -> Bool {
+        size.width.isFinite
+            && size.height.isFinite
+            && size.width >= minimumRecordableEdge
+            && size.height >= minimumRecordableEdge
+    }
+
+    /// Order of authority: a DEBUG override is what a screenshot run
+    /// explicitly asked for, then what a window of this kind was last left
+    /// at, then the authored default.
+    static func chooseInitialSize(
+        environmentOverride: CGSize?,
+        remembered: CGSize?,
+        default fallback: CGSize
+    ) -> CGSize {
+        if let environmentOverride { return environmentOverride }
+        if let remembered, isRecordable(remembered) { return remembered }
+        return fallback
+    }
+}
+
+/// Device-local memory of the size a window of each kind was last seen at.
+/// Window geometry belongs to the device it was sized on — never the synced
+/// host records, never the widget projection.
+struct SceneWindowSizeStore {
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func lastSize(for kind: SceneGeometryKind) -> CGSize? {
+        let key = kind.lastSizeStorageKey
+        guard let stored = defaults.array(forKey: key) as? [Double],
+              stored.count == 2
+        else { return nil }
+        let size = CGSize(width: stored[0], height: stored[1])
+        return SceneGeometryPolicy.isRecordable(size) ? size : nil
+    }
+
+    func record(_ size: CGSize, for kind: SceneGeometryKind) {
+        guard SceneGeometryPolicy.isRecordable(size),
+              lastSize(for: kind) != size
+        else { return }
+        defaults.set(
+            [Double(size.width), Double(size.height)],
+            forKey: kind.lastSizeStorageKey
+        )
     }
 }

--- a/Multiplex/Models/UIKitScenePresentationPlan.swift
+++ b/Multiplex/Models/UIKitScenePresentationPlan.swift
@@ -203,29 +203,44 @@ struct UIKitSceneURLBuffer {
     }
 }
 
-/// A UISceneSession persists the delegate class that originally created it.
-/// After an in-place upgrade from the former SwiftUI lifecycle, UIKit can
-/// therefore reconnect `SwiftUI.AppSceneDelegate` even though the executable
-/// now has a UIKit `@main`, producing a permanently empty scene. The app
-/// delegate uses this pure policy to adopt only those legacy live scenes with
-/// a native delegate while every newly created session uses the manifest's
-/// UIKit configuration.
+/// A UISceneSession persists the delegate class that originally created it,
+/// and `UISceneSession.configuration` is read-only — that name is never
+/// rewritten. After an in-place upgrade from the former SwiftUI lifecycle
+/// UIKit therefore keeps trying to reconnect `SwiftUI.AppSceneDelegate` even
+/// though the executable now has a UIKit `@main`, producing a permanently
+/// empty scene unless the app delegate adopts it.
+///
+/// The question this answers is **who owns the scene**, deliberately not
+/// "which legacy fingerprint does it match". Fingerprint matching cannot hold:
+/// `configuration.delegateClass` resolves the persisted name through the ObjC
+/// runtime and answers *nil* whenever SwiftUI is not loaded in the process,
+/// and SwiftUI's presence here is accidental — the Release iOS binary does not
+/// link it directly and it arrives transitively through WidgetKit, one
+/// dependency change away from disappearing. A legacy-activity-type fallback
+/// erases itself for the same reason: the first adoption rewrites
+/// `stateRestorationActivity` to this app's own type, so the second launch
+/// matches nothing, installs no delegate, and leaves a blank window that only
+/// deleting the app can clear. What stays true in every one of those worlds is
+/// that a window scene no *native* delegate owns is this delegate's to adopt.
 enum UIKitLegacySceneMigrationPolicy {
     static let swiftUIDelegateClassName = "SwiftUI.AppSceneDelegate"
 
     static func requiresAdoption(
+        nativeDelegateClassName: String,
         configuredDelegateClassName: String?,
-        liveDelegateClassName: String?,
-        restorationActivity: NSUserActivity?
+        liveDelegateClassName: String?
     ) -> Bool {
-        if configuredDelegateClassName == swiftUIDelegateClassName
-            || liveDelegateClassName == swiftUIDelegateClassName {
-            return true
-        }
-        return configuredDelegateClassName == nil
-            && liveDelegateClassName == nil
-            && restorationActivity?.activityType
-                == SceneActivityCodec.legacyStateRestorationActivityType
+        // Already connected natively: UIKit drives this scene through
+        // `scene(_:willConnectTo:)` and adoption would fight its own delegate.
+        if liveDelegateClassName == nativeDelegateClassName { return false }
+        // Configured natively but not yet instantiated. Still UIKit's to
+        // connect, and replacing the delegate it is about to install would
+        // orphan the connection options that arrive with it.
+        if configuredDelegateClassName == nativeDelegateClassName { return false }
+        // Anything else — SwiftUI's serialized delegate, or a persisted class
+        // name this process can no longer resolve — leaves the scene with no
+        // owner at all. That is the blank-window case, and it is ours.
+        return true
     }
 }
 

--- a/Multiplex/Views/AppLockVeil.swift
+++ b/Multiplex/Views/AppLockVeil.swift
@@ -248,6 +248,14 @@ final class AppLockView: UIView {
             right: Metrics.chipHorizontalPadding
         )
         unlockButton.layer.borderWidth = 1
+        // The gaze/pointer highlight resolves where the effect is attached, so
+        // it belongs on the control itself. Square it to the chip's own border
+        // box: the default visionOS platter is heavily rounded and fights the
+        // chassis geometry (the SwiftUI veil applied `chassisHover(2)` here).
+        unlockButton.hoverStyle = UIHoverStyle(
+            effect: .highlight,
+            shape: .rect(cornerRadius: 2)
+        )
         unlockButton.accessibilityLabel = "Unlock"
         unlockButton.accessibilityHint = "Unlocks Multiplex with \(AppLockStore.methodName)"
         unlockButton.addTarget(self, action: #selector(unlockPressed), for: .touchUpInside)

--- a/Multiplex/Views/Deck/AddHostSheet.swift
+++ b/Multiplex/Views/Deck/AddHostSheet.swift
@@ -210,7 +210,8 @@ struct AddHostFormState {
 /// roads within one controller; editing an existing host is manual-only.
 @MainActor
 final class AddHostViewController: UIViewController, UITextFieldDelegate,
-    UIGestureRecognizerDelegate, UIAdaptivePresentationControllerDelegate {
+    UIGestureRecognizerDelegate, UIAdaptivePresentationControllerDelegate,
+    AppAppearanceFollowing {
     enum Mode: Hashable {
         case bind
         case manual
@@ -250,6 +251,7 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     var appAppearance = AppAppearance.system {
         didSet { applyAppearance() }
     }
+    let appAppearanceFollower = AppAppearanceFollower()
 
     private(set) var contentStack = UIStackView()
     private(set) var manualStack = UIStackView()
@@ -373,16 +375,14 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         navigationController?.presentationController?.delegate = self
-        if pendingPaywallPresentation {
-            pendingPaywallPresentation = false
-            presentPaywall()
-        }
+        drainPendingPaywall()
         scheduleDebugScrollIfNeeded()
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateBindHeight()
+        applyKeyboardContentInset(to: scrollView)
     }
 
     func presentationControllerShouldDismiss(
@@ -574,7 +574,17 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
         let container = UIView()
         container.addSubview(controller.view)
         controller.view.translatesAutoresizingMaskIntoConstraints = false
-        let height = container.heightAnchor.constraint(equalToConstant: 1)
+        // The pane's own view is required-pinned to this container, so a
+        // REQUIRED placeholder height crushes everything inside it until
+        // `updateBindHeight()` can measure — and that measurement is refused
+        // until the container has a real width, so the pane's first solve is
+        // always the degenerate one. Auto Layout resolves the impossible
+        // height by breaking the pane's internal pins instead, which is what
+        // renders its sections as empty grey bars. A near-required placeholder
+        // yields to the pane's own content when it cannot hold, and still
+        // outranks every content priority once the measured height lands.
+        let height = container.heightAnchor.constraint(equalToConstant: 240)
+        height.priority = UILayoutPriority(999)
         bindHeightConstraint = height
         NSLayoutConstraint.activate([
             controller.view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
@@ -620,6 +630,16 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
         let enabled = form.isValid
         saveItem?.isEnabled = enabled
         saveItem?.tintColor = enabled ? UIKitChassis.signal : UIKitChassis.signal3
+        updateTestAvailability()
+    }
+
+    /// Save and the Signal check answer to the same validity, so the chip has
+    /// to follow every identity/transport edit. Its enabled state is otherwise
+    /// baked at `renderTestSection()` time, which never re-runs while the test
+    /// state is idle — the state a brand-new (invalid) form starts in.
+    private func updateTestAvailability() {
+        guard let testChip else { return }
+        setChip(testChip, enabled: form.isValid && testState != .running)
     }
 
     private func updateDismissPolicy() {
@@ -629,18 +649,15 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     }
 
     private func applyAppearance() {
-        let style: UIUserInterfaceStyle
-        switch appAppearance.resolvedOverride {
-        case nil: style = .unspecified
-        case .light: style = .light
-        case .dark: style = .dark
-        }
-        overrideUserInterfaceStyle = style
-        navigationController?.overrideUserInterfaceStyle = style
-        viewIfLoaded?.window?.overrideUserInterfaceStyle = style
-        if let navigationBar = navigationController?.navigationBar {
-            UIKitChassis.configureSheetNavigationBar(navigationBar)
-        }
+        applyAppAppearance()
+        // The paywall this sheet raises is a sheet-on-a-sheet with no store of
+        // its own: hand the choice down so a flip reaches it too.
+        presentedPaywall?.appAppearance = appAppearance
+    }
+
+    private var presentedPaywall: ProPaywallViewController? {
+        (presentedViewController as? UINavigationController)?
+            .viewControllers.first as? ProPaywallViewController
     }
 
     // MARK: Manual form construction
@@ -978,8 +995,7 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
             self?.runTest()
         }
         testChip = chip
-        let canTest = form.isValid && testState != .running
-        setChip(chip, enabled: canTest)
+        updateTestAvailability()
         let testRowStack = UIStackView(arrangedSubviews: [chip, addHostFlexibleSpacer()])
         testRowStack.axis = .horizontal
         testRowStack.alignment = .center
@@ -1492,12 +1508,28 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
             pendingPaywallPresentation = true
             return
         }
-        guard presentedViewController == nil else { return }
+        // The bind flow consumes its host-limit request before it reaches here,
+        // so a busy presentation slot — normally the QR scanner still animating
+        // out under the confirm that raised this — must park the intent instead
+        // of dropping it, then present once that modal has finished leaving.
+        if let presented = presentedViewController {
+            pendingPaywallPresentation = true
+            presented.transitionCoordinator?.animate(alongsideTransition: nil) { [weak self] _ in
+                self?.drainPendingPaywall()
+            }
+            return
+        }
         let controller = ProPaywallViewController(entitlements: entitlements)
         controller.appAppearance = appAppearance
         let navigation = UINavigationController(rootViewController: controller)
         controller.onDone = { [weak navigation] in navigation?.dismiss(animated: true) }
         present(navigation, animated: true)
+    }
+
+    private func drainPendingPaywall() {
+        guard pendingPaywallPresentation else { return }
+        pendingPaywallPresentation = false
+        presentPaywall()
     }
 
     // MARK: Save / cancel

--- a/Multiplex/Views/Deck/AgentPromptSheet.swift
+++ b/Multiplex/Views/Deck/AgentPromptSheet.swift
@@ -59,15 +59,17 @@ struct AgentPromptFormState {
 /// immediately focuses the optional first prompt, and resubmits the action
 /// only when Launch is pressed.
 @MainActor
-final class AgentPromptSheetViewController: UIViewController, UITextFieldDelegate {
+final class AgentPromptSheetViewController: UIViewController, UITextFieldDelegate,
+    AppAppearanceFollowing {
     static let contentMaximumWidth: CGFloat = 680
     static let outerInset: CGFloat = 18
     static let sectionSpacing: CGFloat = 18
 
     var onDismiss: (() -> Void)?
     var appAppearance = AppAppearance.system {
-        didSet { applyAppearance() }
+        didSet { applyAppAppearance() }
     }
+    let appAppearanceFollower = AppAppearanceFollower()
 
     private(set) var contentStack = UIStackView()
 
@@ -127,7 +129,7 @@ final class AgentPromptSheetViewController: UIViewController, UITextFieldDelegat
         navigationItem.rightBarButtonItem = launch
 
         configureContent()
-        applyAppearance()
+        applyAppAppearance()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -140,6 +142,9 @@ final class AgentPromptSheetViewController: UIViewController, UITextFieldDelegat
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updatePromptHeight()
+        // This sheet opens with its prompt already focused, so the inset is
+        // what keeps the sections below reachable under a standing keyboard.
+        applyKeyboardContentInset(to: scrollView)
     }
 
     private func configureContent() {
@@ -151,7 +156,7 @@ final class AgentPromptSheetViewController: UIViewController, UITextFieldDelegat
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             scrollView.contentLayoutGuide.widthAnchor.constraint(
                 equalTo: scrollView.frameLayoutGuide.widthAnchor
             ),
@@ -442,21 +447,6 @@ final class AgentPromptSheetViewController: UIViewController, UITextFieldDelegat
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
-    }
-
-    private func applyAppearance() {
-        let style: UIUserInterfaceStyle
-        switch appAppearance.resolvedOverride {
-        case nil: style = .unspecified
-        case .light: style = .light
-        case .dark: style = .dark
-        }
-        overrideUserInterfaceStyle = style
-        navigationController?.overrideUserInterfaceStyle = style
-        viewIfLoaded?.window?.overrideUserInterfaceStyle = style
-        if let navigationBar = navigationController?.navigationBar {
-            UIKitChassis.configureSheetNavigationBar(navigationBar)
-        }
     }
 
     @objc private func cancelPressed() {

--- a/Multiplex/Views/Deck/BindPane.swift
+++ b/Multiplex/Views/Deck/BindPane.swift
@@ -154,19 +154,12 @@ final class BindPaneViewController: UIViewController {
         bind.bindSurfaceOpen = false
     }
 
-    /// `contentStack` is required-pinned to all four edges of `paneView`, so
-    /// its width already follows the pane. Requiring a second width on top of
-    /// those pins is what breaks them whenever the pane has not been laid out
-    /// at this width yet — the engine drops a pin rather than the required
-    /// fitting width, and the sections solve to zero size (empty grey bars).
-    /// So refuse a degenerate proposal outright, and leave the fitting width
-    /// non-required so a residual mismatch degrades the measurement instead.
     func fittingSize(for width: CGFloat) -> CGSize {
         guard width > 0 else { return CGSize(width: max(0, width), height: 0) }
         let target = CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
         let size = contentStack.systemLayoutSizeFitting(
             target,
-            withHorizontalFittingPriority: .defaultHigh,
+            withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: width, height: ceil(size.height))
@@ -502,7 +495,7 @@ private final class BindPaneRootView: UIView {
         }
         let size = measuredContent.systemLayoutSizeFitting(
             CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .defaultHigh,
+            withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: UIView.noIntrinsicMetric, height: ceil(size.height))

--- a/Multiplex/Views/Deck/BindPane.swift
+++ b/Multiplex/Views/Deck/BindPane.swift
@@ -82,6 +82,7 @@ final class BindPaneViewController: UIViewController {
     private let incomingSection = BindIncomingSectionView()
     private let passphraseField = BindRevealableSecretField()
     private let pasteFailureLabel = UILabel()
+    private let pasteSlot = UIView()
     private var elsewhereSection: UIView!
     private var candidateRows: [String: BindCandidateRowView] = [:]
     private var orderedCandidateIDs: [String] = []
@@ -153,11 +154,19 @@ final class BindPaneViewController: UIViewController {
         bind.bindSurfaceOpen = false
     }
 
+    /// `contentStack` is required-pinned to all four edges of `paneView`, so
+    /// its width already follows the pane. Requiring a second width on top of
+    /// those pins is what breaks them whenever the pane has not been laid out
+    /// at this width yet — the engine drops a pin rather than the required
+    /// fitting width, and the sections solve to zero size (empty grey bars).
+    /// So refuse a degenerate proposal outright, and leave the fitting width
+    /// non-required so a residual mismatch degrades the measurement instead.
     func fittingSize(for width: CGFloat) -> CGSize {
+        guard width > 0 else { return CGSize(width: max(0, width), height: 0) }
         let target = CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
         let size = contentStack.systemLayoutSizeFitting(
             target,
-            withHorizontalFittingPriority: .required,
+            withHorizontalFittingPriority: .defaultHigh,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: width, height: ceil(size.height))
@@ -322,20 +331,14 @@ final class BindPaneViewController: UIViewController {
         }
         #endif
 
-        let pasteConfiguration = UIPasteControl.Configuration()
-        pasteConfiguration.displayMode = .iconAndLabel
-        #if os(iOS)
-        pasteConfiguration.cornerStyle = .fixed
-        pasteConfiguration.cornerRadius = 4
-        #endif
-        pasteConfiguration.baseBackgroundColor = UIKitChassis.bezelHi
-        pasteConfiguration.baseForegroundColor = UIKitChassis.signal
-        let paste = BindPasteControl(configuration: pasteConfiguration)
-        paste.target = pasteTarget
-        paste.accessibilityIdentifier = "bind.paste"
-        paste.setContentHuggingPriority(.required, for: .horizontal)
-        paste.setContentCompressionResistancePriority(.required, for: .horizontal)
-        actions.addArrangedSubview(paste)
+        pasteSlot.setContentHuggingPriority(.required, for: .horizontal)
+        pasteSlot.setContentCompressionResistancePriority(.required, for: .horizontal)
+        installPasteControl()
+        pasteSlot.registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+            [weak self] (_: UIView, _: UITraitCollection) in
+            self?.installPasteControl()
+        }
+        actions.addArrangedSubview(pasteSlot)
         actions.addArrangedSubview(UIView())
 
         pasteFailureLabel.font = UIKitChassis.uiFont(10)
@@ -357,6 +360,38 @@ final class BindPaneViewController: UIViewController {
             detail: BindPaneCopy.elsewhereDetail,
             contentView: content
         )
+    }
+
+    /// `UIPasteControl` consumes its configuration at init and offers no way to
+    /// re-apply one, so the chassis colors it is built with are baked for the
+    /// control's lifetime — a LIGHT/DARK flip would otherwise leave the chip's
+    /// ink from the old polarity. Rebuilding the control in its slot is the
+    /// heal path, driven by the same trait registration the file's hand-drawn
+    /// chrome uses.
+    private func installPasteControl() {
+        pasteSlot.subviews.forEach { $0.removeFromSuperview() }
+
+        let pasteConfiguration = UIPasteControl.Configuration()
+        pasteConfiguration.displayMode = .iconAndLabel
+        #if os(iOS)
+        pasteConfiguration.cornerStyle = .fixed
+        pasteConfiguration.cornerRadius = 4
+        #endif
+        pasteConfiguration.baseBackgroundColor = UIKitChassis.bezelHi
+        pasteConfiguration.baseForegroundColor = UIKitChassis.signal
+        let paste = BindPasteControl(configuration: pasteConfiguration)
+        paste.target = pasteTarget
+        paste.accessibilityIdentifier = "bind.paste"
+        paste.setContentHuggingPriority(.required, for: .horizontal)
+        paste.setContentCompressionResistancePriority(.required, for: .horizontal)
+        pasteSlot.addSubview(paste)
+        paste.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            paste.leadingAnchor.constraint(equalTo: pasteSlot.leadingAnchor),
+            paste.trailingAnchor.constraint(equalTo: pasteSlot.trailingAnchor),
+            paste.topAnchor.constraint(equalTo: pasteSlot.topAnchor),
+            paste.bottomAnchor.constraint(equalTo: pasteSlot.bottomAnchor),
+        ])
     }
 
     private func makeFooter() -> UIView {
@@ -467,7 +502,7 @@ private final class BindPaneRootView: UIView {
         }
         let size = measuredContent.systemLayoutSizeFitting(
             CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .required,
+            withHorizontalFittingPriority: .defaultHigh,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: UIView.noIntrinsicMetric, height: ceil(size.height))
@@ -782,6 +817,7 @@ final class BindCandidateRowView: UIView {
         actionRow.alignment = .center
         actionRow.spacing = 8
 
+        busySpinner.color = UIKitChassis.signal2
         busySpinner.transform = CGAffineTransform(scaleX: 0.65, y: 0.65)
         let spinnerSlot = UIView()
         spinnerSlot.addSubview(busySpinner)

--- a/Multiplex/Views/Deck/DeckWindow.swift
+++ b/Multiplex/Views/Deck/DeckWindow.swift
@@ -302,6 +302,7 @@ final class DeckWindowViewController: UIViewController {
     private var lastDenialRevision: Int?
     private var lastSceneActive: Bool?
     private var lifecycleTasks: [Task<Void, Never>] = []
+    private var cloudRefreshTask: Task<Void, Never>?
     private var externalActionCoordinator: ExternalActionUIKitCoordinator?
     #if DEBUG
     private var debugAutomationStarted = false
@@ -310,6 +311,13 @@ final class DeckWindowViewController: UIViewController {
     var pendingPresentationKinds: [PresentationKind] {
         pendingPresentations.map(\.kind)
     }
+
+    /// The adaptive shell owns the external-action coordinator, so a nested
+    /// deck builds none of its own (its opener destination is `.shell`). Its
+    /// sheets still occupy the shell's presenter, so the owner hears every
+    /// deck dismissal here and drains the queue the classic path drains
+    /// through `externalActionCoordinator` in `finishPresentation`.
+    var presentationDidEnd: (() -> Void)?
 
     var sceneIsActive: Bool { configuration.sceneIsActive }
     var isPreparedForRemoval: Bool { lifecycleStopped }
@@ -351,6 +359,7 @@ final class DeckWindowViewController: UIViewController {
 
     deinit {
         lifecycleTasks.forEach { $0.cancel() }
+        cloudRefreshTask?.cancel()
     }
 
     /// One update seam for classic scenes and the adaptive shell. Dependency
@@ -423,6 +432,8 @@ final class DeckWindowViewController: UIViewController {
         observationGeneration += 1
         lifecycleTasks.forEach { $0.cancel() }
         lifecycleTasks.removeAll()
+        cloudRefreshTask?.cancel()
+        cloudRefreshTask = nil
         configuration.lifecycleDriver.suspendLocalNetwork()
         configuration.lifecycleDriver.suspendNetworkChanges()
         configuration.lifecycleDriver.endBindDiscovery()
@@ -458,6 +469,7 @@ final class DeckWindowViewController: UIViewController {
             hub: configuration.hub,
             networkChanges: configuration.networkChanges,
             workspace: configuration.workspace,
+            themes: configuration.themes,
             terminalOpener: configuration.terminalOpener,
             presentation: configuration.presentation,
             selectedTerminal: configuration.selectedTerminal,
@@ -492,10 +504,19 @@ final class DeckWindowViewController: UIViewController {
             guard let self else { return }
             await self.configuration.lifecycleDriver.rotatePendingBindKeys()
         })
-        lifecycleTasks.append(Task { [weak self] in
+        refreshHostsFromCloud()
+    }
+
+    /// Every foreground refreshes, and the scene reports one for each system
+    /// alert, app-switcher peek, and Control Center pull. One replaceable
+    /// handle keeps that from retaining a finished task per activation for
+    /// the life of the deck.
+    private func refreshHostsFromCloud() {
+        cloudRefreshTask?.cancel()
+        cloudRefreshTask = Task { [weak self] in
             guard let self else { return }
             await self.configuration.lifecycleDriver.refreshHostsFromCloud()
-        })
+        }
     }
 
     private func restartLifecycleServices(previous: DeckWindowConfiguration) {
@@ -622,10 +643,7 @@ final class DeckWindowViewController: UIViewController {
         defer { lastSceneActive = active }
         guard lastSceneActive != active else { return }
         if active {
-            lifecycleTasks.append(Task { [weak self] in
-                guard let self else { return }
-                await self.configuration.lifecycleDriver.refreshHostsFromCloud()
-            })
+            refreshHostsFromCloud()
         } else {
             configuration.lifecycleDriver.flushSnapshots()
         }
@@ -737,7 +755,7 @@ final class DeckWindowViewController: UIViewController {
             bind: configuration.bind,
             editing: host
         )
-        controller.appAppearance = configuration.themes.appearance
+        controller.followAppAppearance(configuration.themes)
         controller.onDismiss = { [weak self] in self?.dismissActivePresentation() }
         controller.onPresentationDismissed = { [weak self] in
             self?.presentationEndedExternally()
@@ -766,7 +784,7 @@ final class DeckWindowViewController: UIViewController {
 
     private func presentFAQ() {
         let controller = FAQViewController()
-        controller.appAppearance = configuration.themes.appearance
+        controller.followAppAppearance(configuration.themes)
         controller.onDone = { [weak self] in self?.dismissActivePresentation() }
         let navigation = makeNavigation(root: controller)
         beginPresentation(navigation, kind: .faq, usesOwnerDelegate: true)
@@ -774,7 +792,7 @@ final class DeckWindowViewController: UIViewController {
 
     private func presentPaywall() {
         let controller = ProPaywallViewController(entitlements: configuration.entitlements)
-        controller.appAppearance = configuration.themes.appearance
+        controller.followAppAppearance(configuration.themes)
         controller.onDone = { [weak self] in self?.dismissActivePresentation() }
         let navigation = makeNavigation(root: controller)
         beginPresentation(navigation, kind: .paywall, usesOwnerDelegate: true)
@@ -857,6 +875,7 @@ final class DeckWindowViewController: UIViewController {
         activePresentationKind = nil
         schedulePresentationRetry()
         externalActionCoordinator?.presenterDidBecomeAvailable()
+        presentationDidEnd?()
     }
 
     private func schedulePresentationRetry() {

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -1991,21 +1991,13 @@ private final class FleetTileGridView: UIView {
             let row = items[index..<end]
             var heights: [CGFloat] = []
             for item in row {
-                // Tiles are framed by hand, so their autoresizing masks stay
-                // translated and UIKit synthesizes REQUIRED width/height
-                // constraints from whatever frame they carry right now —
-                // .zero for a tile added in this pass. Measuring against that
-                // at a required fitting width is unsatisfiable, and the engine
-                // resolves it by breaking the tile's own required content pins
-                // instead: the labels solve to zero size at the tile's
-                // top-left over an empty ground. Seed the real width first,
-                // and leave the fitting width non-required so any residual
-                // conflict degrades this measurement, never the tile's
-                // internal layout.
-                item.view.frame.size.width = tileWidth
+                // Width is the grid's contract, not a hint. Lowering this
+                // priority lets a newly added tile solve at its compressed
+                // width; framing the outer tile afterwards does not repair the
+                // already-collapsed content stack (labels remain at origin).
                 let size = item.view.systemLayoutSizeFitting(
                     CGSize(width: tileWidth, height: UIView.layoutFittingCompressedSize.height),
-                    withHorizontalFittingPriority: .defaultHigh,
+                    withHorizontalFittingPriority: .required,
                     verticalFittingPriority: .fittingSizeLevel
                 )
                 heights.append(max(1, ceil(size.height)))

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -16,6 +16,10 @@ struct FleetWallConfiguration {
     let hub: ConnectionHub
     let networkChanges: NetworkChangeMonitor
     let workspace: TerminalWorkspace
+    /// Present when the scene can supply it: the wall's own guide sheets then
+    /// follow a live appearance change instead of snapshotting the choice
+    /// (`AppAppearanceFollowing`). Without it they read the scene window.
+    var themes: ThemeStore? = nil
     var terminalOpener: TerminalRouteOpener
     var presentation: FleetWall.Presentation
     var selectedTerminal: TerminalRoute?
@@ -225,11 +229,6 @@ final class FleetWallViewController: UIViewController {
         let passphraseChallenge: SSHKeyPassphraseChallenge?
     }
 
-    private struct FeedIdentity: Equatable {
-        let hosts: [Host]
-        let active: Bool
-    }
-
     private static let feedInterval: Duration = .seconds(5)
 
     private var configuration: FleetWallConfiguration
@@ -252,7 +251,7 @@ final class FleetWallViewController: UIViewController {
     private var latestSnapshot: WallSnapshot?
     private var observationGeneration = 0
     private var feedTask: Task<Void, Never>?
-    private var feedIdentity: FeedIdentity?
+    private var feedIdentity: FleetFeedID?
     private var availableColumnCount: Int?
     private var resolvedColumnCount = 1
     private var keyPassphraseHostID: UUID?
@@ -411,6 +410,14 @@ final class FleetWallViewController: UIViewController {
             summary: fleetSummary,
             actions: headerActions
         )
+
+        // The shell spends the bottom safe area and its panes hand back the
+        // clearance exactly once: the wall restores it as scroll padding
+        // below. Letting UIKit adjust the viewport's content inset for the
+        // same band would count it twice, so the shell viewport opts out —
+        // the classic deck passes a zero shell inset and keeps the automatic
+        // adjustment (its nav bar and home indicator ride on it).
+        scrollView.contentInsetAdjustmentBehavior = shell ? .never : .automatic
 
         let wallPadding: CGFloat = presentation == .shellRail ? 12 : 26
         let safe = configuration.shellSafeArea
@@ -615,28 +622,17 @@ final class FleetWallViewController: UIViewController {
             setEnabled: { [weak self] enabled in self?.setEnabled(enabled, for: host) },
             editHost: { [weak self] in self?.configuration.editHost(host) },
             removeHost: { [weak self] in self?.confirmRemove(host) },
+            // The store mutation on its own animates nothing — the new order
+            // only reaches the grid through the section's re-render and the
+            // layout pass after it. The section therefore owns the animation
+            // block (see its `droppedSession`), which is where that pass runs.
             reorderSession: { [weak self] source, target, sessions in
-                guard let self else { return }
-                let move = {
-                    self.configuration.store.moveSession(
-                        source,
-                        to: target,
-                        for: host.id,
-                        available: sessions
-                    )
-                }
-                if self.configuration.reduceMotion {
-                    move()
-                } else {
-                    UIView.animate(
-                        withDuration: 0.32,
-                        delay: 0,
-                        usingSpringWithDamping: 1,
-                        initialSpringVelocity: 0,
-                        options: [.beginFromCurrentState],
-                        animations: move
-                    )
-                }
+                self?.configuration.store.moveSession(
+                    source,
+                    to: target,
+                    for: host.id,
+                    available: sessions
+                )
             },
             modelDidChange: { [weak self] in
                 self?.synchronizePassphrasePrompt()
@@ -676,15 +672,18 @@ final class FleetWallViewController: UIViewController {
     private func restartFeedIfNeeded(force: Bool) {
         guard isViewLoaded else { return }
         let hosts = latestSnapshot?.hosts ?? configuration.store.hosts
-        let identity = FeedIdentity(
-            hosts: hosts,
-            active: configuration.sceneIsActive && isOnScreen
-        )
+        let active = configuration.sceneIsActive && isOnScreen
+        // `FleetFeedID` normalizes every host through
+        // `connectionModelConfiguration`, so command-setup, setup-script,
+        // launch-model, and tmux-conf edits (and the `updatedAt` bump any save
+        // carries) deliberately keep the running feed instead of cancelling
+        // every host's probe and resetting its connect-retry backoff.
+        let identity = FleetFeedID(hosts: hosts, active: active)
         guard force || feedIdentity != identity else { return }
         feedTask?.cancel()
         feedTask = nil
         feedIdentity = identity
-        guard identity.active else { return }
+        guard active else { return }
         feedTask = Task { [weak self] in await self?.runFeed(hosts: hosts) }
     }
 
@@ -806,6 +805,7 @@ final class FleetWallViewController: UIViewController {
 
     private func presentTmuxGuide(for host: Host) {
         let controller = TmuxInstallViewController(host: host)
+        controller.followAppAppearance(configuration.themes, presentedFrom: self)
         let navigation = UINavigationController(rootViewController: controller)
         UIKitChassis.configureSheetNavigationBar(navigation.navigationBar)
         navigation.modalPresentationStyle = .formSheet
@@ -815,6 +815,7 @@ final class FleetWallViewController: UIViewController {
 
     private func presentKeychainGuide(for host: Host, sessionNames: [String]) {
         let controller = KeychainUnlockViewController(host: host, sessionNames: sessionNames)
+        controller.followAppAppearance(configuration.themes, presentedFrom: self)
         let navigation = UINavigationController(rootViewController: controller)
         UIKitChassis.configureSheetNavigationBar(navigation.navigationBar)
         navigation.modalPresentationStyle = .formSheet
@@ -1376,11 +1377,29 @@ private final class FleetHostSectionView: UIView {
                     },
                     droppedSession: { [weak self] source in
                         guard let self else { return }
-                        self.configuration.reorderSession(source, session.name, sessions)
-                        // Session order is device-local HostStore state, not a
-                        // probe change. Re-arm its Observation read now so the
-                        // native grid settles immediately after the drop.
-                        self.observeModel()
+                        let move = {
+                            self.configuration.reorderSession(source, session.name, sessions)
+                            // Session order is device-local HostStore state,
+                            // not a probe change. Re-arm its Observation read
+                            // now so the native grid settles immediately after
+                            // the drop — and run the grid's layout pass inside
+                            // the animation block, since that pass is the only
+                            // thing that moves a tile.
+                            self.observeModel()
+                            self.grid.layoutIfNeeded()
+                        }
+                        if self.configuration.reduceMotion {
+                            move()
+                        } else {
+                            UIView.animate(
+                                withDuration: 0.32,
+                                delay: 0,
+                                usingSpringWithDamping: 1,
+                                initialSpringVelocity: 0,
+                                options: [.beginFromCurrentState],
+                                animations: move
+                            )
+                        }
                     }
                 ))
                 items.append(FleetGridItem(id: key, view: tile))
@@ -1972,9 +1991,21 @@ private final class FleetTileGridView: UIView {
             let row = items[index..<end]
             var heights: [CGFloat] = []
             for item in row {
+                // Tiles are framed by hand, so their autoresizing masks stay
+                // translated and UIKit synthesizes REQUIRED width/height
+                // constraints from whatever frame they carry right now —
+                // .zero for a tile added in this pass. Measuring against that
+                // at a required fitting width is unsatisfiable, and the engine
+                // resolves it by breaking the tile's own required content pins
+                // instead: the labels solve to zero size at the tile's
+                // top-left over an empty ground. Seed the real width first,
+                // and leave the fitting width non-required so any residual
+                // conflict degrades this measurement, never the tile's
+                // internal layout.
+                item.view.frame.size.width = tileWidth
                 let size = item.view.systemLayoutSizeFitting(
                     CGSize(width: tileWidth, height: UIView.layoutFittingCompressedSize.height),
-                    withHorizontalFittingPriority: .required,
+                    withHorizontalFittingPriority: .defaultHigh,
                     verticalFittingPriority: .fittingSizeLevel
                 )
                 heights.append(max(1, ceil(size.height)))
@@ -2215,6 +2246,22 @@ struct FleetSessionTileConfiguration {
     let attachNewWindow: () -> Void
     let delete: () -> Void
     let droppedSession: (String) -> Void
+
+    /// Data equality of everything the tile draws. The actions are the only
+    /// exclusions: equal data means their captured host/session inputs are
+    /// equivalent, while the closures receive a fresh identity on every pass.
+    func hasSameContent(as other: FleetSessionTileConfiguration) -> Bool {
+        hostID == other.hostID
+            && session == other.session
+            && lines == other.lines
+            && attention == other.attention
+            && hasLiveAgentState == other.hasLiveAgentState
+            && hasOpenTab == other.hasOpenTab
+            && compact == other.compact
+            && selected == other.selected
+            && duplicateAttachTitle == other.duplicateAttachTitle
+            && openTabAccessibilityText == other.openTabAccessibilityText
+    }
 }
 
 @MainActor
@@ -2228,6 +2275,12 @@ final class FleetSessionTileView: FleetPressView,
 
     private let contentStack = UIStackView()
     private var configuration: FleetSessionTileConfiguration?
+    private var isDropTarget = false {
+        didSet {
+            guard oldValue != isDropTarget else { return }
+            applyBorder()
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -2252,10 +2305,14 @@ final class FleetSessionTileView: FleetPressView,
     }
 
     func configure(_ configuration: FleetSessionTileConfiguration) {
+        // Every pass hands over freshly captured closures, so the stored
+        // configuration and the actions always take the new ones. Only the
+        // view tree is gated: rebuilding a tile's ~20 views and their
+        // constraints because another host's probe ticked is exactly what the
+        // pre-UIKit `.equatable()` tile gate existed to prevent.
+        let unchanged = self.configuration?.hasSameContent(as: configuration) ?? false
         self.configuration = configuration
         pressAction = configuration.attach
-        tallyBorderColor = configuration.selected ? UIKitChassis.signal2 : UIKitChassis.bezelHi
-        layer.borderWidth = configuration.selected ? 1.5 : 1
         menuProvider = { [weak self] in
             guard let configuration = self?.configuration else { return nil }
             return UIMenu(children: [
@@ -2267,6 +2324,8 @@ final class FleetSessionTileView: FleetPressView,
                 },
             ])
         }
+        applyBorder()
+        guard !unchanged else { return }
         rebuildContent()
         let running = agentRunning(configuration)
         let needsYou = agentNeedsYou(configuration)
@@ -2297,21 +2356,53 @@ final class FleetSessionTileView: FleetPressView,
         _ interaction: UIDropInteraction,
         sessionDidUpdate session: UIDropSession
     ) -> UIDropProposal {
-        guard let configuration,
-              session.items.contains(where: {
-                  ($0.localObject as? DragPayload)?.hostID == configuration.hostID
-              })
-        else { return UIDropProposal(operation: .forbidden) }
+        guard accepts(session) else { return UIDropProposal(operation: .forbidden) }
         return UIDropProposal(operation: .move)
     }
 
+    // A drop lands in the tile it is released over, so the pending
+    // destination has to be visible while the finger is still down.
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidEnter session: UIDropSession) {
+        isDropTarget = accepts(session)
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidExit session: UIDropSession) {
+        isDropTarget = false
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidEnd session: UIDropSession) {
+        isDropTarget = false
+    }
+
     func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
+        isDropTarget = false
         guard let configuration,
               let item = session.items.first,
               let payload = item.localObject as? DragPayload,
               payload.hostID == configuration.hostID
         else { return }
         configuration.droppedSession(payload.sessionName)
+    }
+
+    /// Only this host's own session tiles reorder each other.
+    private func accepts(_ session: UIDropSession) -> Bool {
+        guard let configuration else { return false }
+        return session.items.contains {
+            ($0.localObject as? DragPayload)?.hostID == configuration.hostID
+        }
+    }
+
+    private func applyBorder() {
+        // While a compatible drag hovers, the pending destination outranks
+        // selection — it is the one thing the drop needs to say.
+        if isDropTarget {
+            tallyBorderColor = UIKitChassis.signal2
+            layer.borderWidth = 2
+            return
+        }
+        let selected = configuration?.selected ?? false
+        tallyBorderColor = selected ? UIKitChassis.signal2 : UIKitChassis.bezelHi
+        layer.borderWidth = selected ? 1.5 : 1
     }
 
     private func rebuildContent() {
@@ -2624,6 +2715,12 @@ private final class FleetNewSessionTileView: FleetPressView {
             label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
             heightConstraint!,
         ])
+        // A CALayer stroke is a resolved CGColor: it needs re-resolving on an
+        // appearance flip, which alone changes no bounds and triggers no layout.
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+            (tile: FleetNewSessionTileView, _: UITraitCollection) in
+            tile.refreshDash()
+        }
     }
 
     func configure(hostName: String, compact: Bool, action: @escaping () -> Void) {
@@ -2637,6 +2734,10 @@ private final class FleetNewSessionTileView: FleetPressView {
         super.layoutSubviews()
         dashLayer.frame = bounds
         dashLayer.path = UIBezierPath(rect: bounds.insetBy(dx: 0.5, dy: 0.5)).cgPath
+        refreshDash()
+    }
+
+    private func refreshDash() {
         dashLayer.fillColor = UIColor.clear.cgColor
         dashLayer.strokeColor = UIKitChassis.bezelHi.resolvedColor(with: traitCollection).cgColor
         dashLayer.lineWidth = 1
@@ -2734,11 +2835,17 @@ private final class FleetNoSignalTileView: FleetPressView {
 @MainActor
 private final class FleetAcquiringTileView: UIKitTallyBorderedView {
     private let spinner = UIActivityIndicatorView(style: .medium)
+    private let screen = UIView()
     private var heightConstraint: NSLayoutConstraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = TallyPalette.screen
+        // Same chassis anatomy as every tile beside it: the screen sits inside
+        // a five-point bezel frame, never painted out to the border.
+        backgroundColor = UIKitChassis.bezel
+        screen.backgroundColor = TallyPalette.screen
+        addSubview(screen)
+        screen.translatesAutoresizingMaskIntoConstraints = false
         let label = UIKitChassisLabel(
             "Acquiring signal", size: 10, color: UIKitChassis.signal3
         )
@@ -2746,14 +2853,20 @@ private final class FleetAcquiringTileView: UIKitTallyBorderedView {
         stack.axis = .vertical
         stack.alignment = .center
         stack.spacing = 8
-        addSubview(stack)
+        screen.addSubview(stack)
         stack.translatesAutoresizingMaskIntoConstraints = false
-        heightConstraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 138)
+        heightConstraint = screen.heightAnchor.constraint(greaterThanOrEqualToConstant: 138)
         NSLayoutConstraint.activate([
-            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
-            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
-            stack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 10),
-            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
+            screen.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
+            screen.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
+            screen.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            screen.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
+            stack.centerXAnchor.constraint(equalTo: screen.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: screen.centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: screen.leadingAnchor, constant: 10),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: screen.trailingAnchor, constant: -10),
+            stack.topAnchor.constraint(greaterThanOrEqualTo: screen.topAnchor, constant: 10),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: screen.bottomAnchor, constant: -10),
             heightConstraint!,
         ])
         spinner.color = UIKitChassis.signal2
@@ -2783,7 +2896,11 @@ private final class FleetTmuxMissingTileView: UIKitTallyBorderedView {
             "No tmux on host", size: 11, color: UIKitChassis.signal3
         )
         let body = UILabel()
+        // A semantic role keeps Dynamic Type and the scene root's
+        // iOS-on-Mac content-size override; the chassis label above it is
+        // fixed chrome type and already carries `Theme.typeScale`.
         body.font = .preferredFont(forTextStyle: .footnote)
+        body.adjustsFontForContentSizeCategory = true
         body.textColor = UIKitChassis.signal2
         body.text = "You can still use a plain shell — press SHELL."
         body.numberOfLines = 0
@@ -2857,6 +2974,7 @@ private final class FleetAwaitingSignalView: UIView {
         )
         let body = UILabel()
         body.font = .preferredFont(forTextStyle: .footnote)
+        body.adjustsFontForContentSizeCategory = true
         body.textColor = UIKitChassis.signal2
         body.text = "Every tmux session, its own window in space."
         body.textAlignment = .center
@@ -3140,6 +3258,11 @@ final class NewSessionViewController: UIViewController,
         renderForm()
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        applyKeyboardContentInset(to: scrollView)
+    }
+
     private func configureContent() {
         scrollView.alwaysBounceVertical = true
         scrollView.backgroundColor = UIKitChassis.chassis
@@ -3149,7 +3272,7 @@ final class NewSessionViewController: UIViewController,
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             scrollView.contentLayoutGuide.widthAnchor.constraint(
                 equalTo: scrollView.frameLayoutGuide.widthAnchor
             ),

--- a/Multiplex/Views/Deck/HostGuideSheets.swift
+++ b/Multiplex/Views/Deck/HostGuideSheets.swift
@@ -129,15 +129,16 @@ final class UIKitCopyableCommandField: UIKitTallyBorderedView {
 /// appearance switching are the exact UIKit counterparts of the former
 /// `NavigationStack` + `ScrollView` composition.
 @MainActor
-class UIKitHostGuideSheetViewController: UIViewController {
+class UIKitHostGuideSheetViewController: UIViewController, AppAppearanceFollowing {
     static let contentMaximumWidth: CGFloat = 560
     static let outerInset: CGFloat = 18
     static let sectionSpacing: CGFloat = 18
 
     var onDone: (() -> Void)?
     var appAppearance = AppAppearance.system {
-        didSet { applyAppearance() }
+        didSet { applyAppAppearance() }
     }
+    let appAppearanceFollower = AppAppearanceFollower()
 
     private let sheetTitle: String
     private let scrollView = UIScrollView()
@@ -171,12 +172,12 @@ class UIKitHostGuideSheetViewController: UIViewController {
         navigationItem.rightBarButtonItem = done
 
         configureContent()
-        applyAppearance()
+        applyAppAppearance()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        applyAppearance()
+        applyAppAppearance()
     }
 
     func addSection(_ section: UIView) {
@@ -242,22 +243,6 @@ class UIKitHostGuideSheetViewController: UIViewController {
             ),
             fillVisibleWidth,
         ])
-    }
-
-    private func applyAppearance() {
-        let style: UIUserInterfaceStyle
-        switch appAppearance.resolvedOverride {
-        case nil: style = .unspecified
-        case .light: style = .light
-        case .dark: style = .dark
-        }
-
-        overrideUserInterfaceStyle = style
-        navigationController?.overrideUserInterfaceStyle = style
-        viewIfLoaded?.window?.overrideUserInterfaceStyle = style
-        if let navigationBar = navigationController?.navigationBar {
-            UIKitChassis.configureSheetNavigationBar(navigationBar)
-        }
     }
 
     @objc private func donePressed() {

--- a/Multiplex/Views/Settings/FAQView.swift
+++ b/Multiplex/Views/Settings/FAQView.swift
@@ -5,12 +5,13 @@ import UIKit
 /// Frequently asked questions, opened from the deck's FAQ chip. The screen and
 /// all of its content are UIKit.
 @MainActor
-final class FAQViewController: UIViewController {
+final class FAQViewController: UIViewController, AppAppearanceFollowing {
     var onDone: (() -> Void)?
 
     var appAppearance = AppAppearance.system {
-        didSet { applyAppearance() }
+        didSet { applyAppAppearance() }
     }
+    let appAppearanceFollower = AppAppearanceFollower()
 
     private let scrollView = UIScrollView()
     private let contentStack = UIStackView()
@@ -37,12 +38,12 @@ final class FAQViewController: UIViewController {
         navigationItem.rightBarButtonItem = done
 
         configureContent()
-        applyAppearance()
+        applyAppAppearance()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        applyAppearance()
+        applyAppAppearance()
     }
 
     private func configureContent() {
@@ -122,22 +123,6 @@ final class FAQViewController: UIViewController {
             detail: entry.postscript,
             contentView: rowStack
         )
-    }
-
-    private func applyAppearance() {
-        let style: UIUserInterfaceStyle
-        switch appAppearance.resolvedOverride {
-        case nil: style = .unspecified
-        case .light: style = .light
-        case .dark: style = .dark
-        }
-
-        overrideUserInterfaceStyle = style
-        navigationController?.overrideUserInterfaceStyle = style
-        viewIfLoaded?.window?.overrideUserInterfaceStyle = style
-        if let navigationBar = navigationController?.navigationBar {
-            UIKitChassis.configureSheetNavigationBar(navigationBar)
-        }
     }
 
     @objc private func donePressed() {

--- a/Multiplex/Views/Settings/ProPaywallView.swift
+++ b/Multiplex/Views/Settings/ProPaywallView.swift
@@ -9,7 +9,7 @@ import UIKit
 /// only presentation, scene-anchored purchase intent, restoration intent, and
 /// a live UIKit rendering of the store's observable state.
 @MainActor
-final class ProPaywallViewController: UIViewController {
+final class ProPaywallViewController: UIViewController, AppAppearanceFollowing {
     enum Metrics {
         static let contentMaximumWidth: CGFloat = 620
         static let outerInset: CGFloat = 26
@@ -32,8 +32,9 @@ final class ProPaywallViewController: UIViewController {
     var onDone: (() -> Void)?
 
     var appAppearance = AppAppearance.system {
-        didSet { applyAppearance() }
+        didSet { applyAppAppearance() }
     }
+    let appAppearanceFollower = AppAppearanceFollower()
 
     private(set) var contentStack = UIStackView()
     private(set) var purchaseButton = ProPaywallPurchaseButton()
@@ -61,7 +62,7 @@ final class ProPaywallViewController: UIViewController {
         configureNavigation()
         configureContent()
         observeEntitlements()
-        applyAppearance()
+        applyAppAppearance()
 
         storefrontTask = Task { @MainActor [weak entitlementStore = self.entitlements] in
             await entitlementStore?.loadStorefront()
@@ -70,7 +71,7 @@ final class ProPaywallViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        applyAppearance()
+        applyAppAppearance()
     }
 
     deinit {
@@ -419,22 +420,6 @@ final class ProPaywallViewController: UIViewController {
                 : "No Multiplex Pro purchase was found for this Apple ID."
         case .failed(let message):
             return message
-        }
-    }
-
-    private func applyAppearance() {
-        let style: UIUserInterfaceStyle
-        switch appAppearance.resolvedOverride {
-        case nil: style = .unspecified
-        case .light: style = .light
-        case .dark: style = .dark
-        }
-
-        overrideUserInterfaceStyle = style
-        navigationController?.overrideUserInterfaceStyle = style
-        viewIfLoaded?.window?.overrideUserInterfaceStyle = style
-        if let navigationBar = navigationController?.navigationBar {
-            UIKitChassis.configureSheetNavigationBar(navigationBar)
         }
     }
 

--- a/Multiplex/Views/Settings/SettingsView.swift
+++ b/Multiplex/Views/Settings/SettingsView.swift
@@ -593,7 +593,7 @@ final class SettingsViewController: UIViewController {
         let controller = ThemeEditorViewController(theme: theme) { [weak self] edited in
             self?.save(edited)
         }
-        controller.appAppearance = themes.appearance
+        controller.followAppAppearance(themes)
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -613,7 +613,7 @@ final class SettingsViewController: UIViewController {
         }
         guard presentedViewController == nil else { return }
         let controller = ProPaywallViewController(entitlements: entitlements)
-        controller.appAppearance = themes.appearance
+        controller.followAppAppearance(themes)
         let navigation = UINavigationController(rootViewController: controller)
         controller.onDone = { [weak navigation] in
             navigation?.dismiss(animated: true)
@@ -959,7 +959,10 @@ final class SettingsBooleanRow: UIControl {
         self.accessibilityLabel = accessibilityLabel ?? title
         self.accessibilityHint = accessibilityHint
         isAccessibilityElement = true
-        accessibilityTraits = .button
+        // The SwiftUI row represented itself to assistive technology as a real
+        // `Toggle`; `.toggleButton` is UIKit's equivalent identity, so the
+        // switch rotor and the spoken On/Off state survive the port.
+        accessibilityTraits = [.button, .toggleButton]
 
         titleLabel.text = title
         titleLabel.font = UIKitChassis.uiFont(12, weight: .semibold)
@@ -1009,55 +1012,70 @@ final class SettingsBooleanRow: UIControl {
         let requestedValue = !isOn
         if optimisticallyUpdates {
             isOn = requestedValue
-            refresh()
+            refresh(animated: true)
         }
         changed(requestedValue)
     }
 
-    private func refresh() {
-        indicator.setOn(isOn)
+    private func refresh(animated: Bool = false) {
+        indicator.setOn(isOn, animated: animated)
         accessibilityValue = isOn ? "On" : "Off"
     }
 }
 
 @MainActor
 private final class SettingsSwitchIndicator: UIKitTallyBorderedView {
+    /// The SwiftUI switch slid its thumb with `.easeOut(duration: 0.14)`; the
+    /// appearance choice bar above it still uses exactly that timing, so the
+    /// two controls must not disagree.
+    private static let slideDuration: TimeInterval = 0.14
+
     private let thumb = UIView()
+    private var thumbLeading: NSLayoutConstraint!
+    private var thumbTrailing: NSLayoutConstraint!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = UIKitChassis.chassis
         addSubview(thumb)
         thumb.translatesAutoresizingMaskIntoConstraints = false
+        thumbLeading = thumb.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4)
+        thumbTrailing = thumb.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4)
         NSLayoutConstraint.activate([
             widthAnchor.constraint(equalToConstant: 36),
             heightAnchor.constraint(equalToConstant: 20),
             thumb.widthAnchor.constraint(equalToConstant: 12),
             thumb.heightAnchor.constraint(equalToConstant: 12),
             thumb.centerYAnchor.constraint(equalTo: centerYAnchor),
+            thumbLeading,
         ])
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
 
-    func setOn(_ isOn: Bool) {
-        NSLayoutConstraint.deactivate(thumb.constraints.filter {
-            $0.firstAttribute == .leading || $0.firstAttribute == .trailing
-        })
-        for constraint in constraints where
-            (constraint.firstItem as? UIView) === thumb
-                && (constraint.firstAttribute == .leading || constraint.firstAttribute == .trailing) {
-            constraint.isActive = false
+    func setOn(_ isOn: Bool, animated: Bool = false) {
+        thumbLeading.isActive = false
+        thumbTrailing.isActive = false
+        (isOn ? thumbTrailing : thumbLeading).isActive = true
+        let apply = {
+            self.backgroundColor = isOn ? UIKitChassis.bezelHi : UIKitChassis.screen
+            self.thumb.backgroundColor = isOn ? UIKitChassis.signal : UIKitChassis.signal3
+            self.tallyBorderColor = isOn ? UIKitChassis.signal2 : UIKitChassis.bezelHi
+            // The swapped constraint only moves the thumb inside an animation
+            // transaction if the layout pass runs there too.
+            self.layoutIfNeeded()
         }
-        if isOn {
-            thumb.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4).isActive = true
-        } else {
-            thumb.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4).isActive = true
+        guard animated, window != nil, !UIAccessibility.isReduceMotionEnabled else {
+            apply()
+            return
         }
-        backgroundColor = isOn ? UIKitChassis.bezelHi : UIKitChassis.screen
-        thumb.backgroundColor = isOn ? UIKitChassis.signal : UIKitChassis.signal3
-        tallyBorderColor = isOn ? UIKitChassis.signal2 : UIKitChassis.bezelHi
+        UIView.animate(
+            withDuration: Self.slideDuration,
+            delay: 0,
+            options: [.curveEaseOut, .beginFromCurrentState],
+            animations: apply
+        )
     }
 }
 

--- a/Multiplex/Views/Settings/ThemeEditorView.swift
+++ b/Multiplex/Views/Settings/ThemeEditorView.swift
@@ -5,7 +5,8 @@ import UIKit
 /// Edits a private draft and commits only through Save. Popping the controller
 /// leaves the store untouched, matching the former NavigationStack behavior.
 @MainActor
-final class ThemeEditorViewController: UIViewController, UITextFieldDelegate {
+final class ThemeEditorViewController: UIViewController, UITextFieldDelegate,
+    AppAppearanceFollowing {
     enum Metrics {
         static let contentMaximumWidth: CGFloat = 680
         static let outerInset: CGFloat = 18
@@ -20,6 +21,7 @@ final class ThemeEditorViewController: UIViewController, UITextFieldDelegate {
     var appAppearance = AppAppearance.system {
         didSet { applyAppearance() }
     }
+    let appAppearanceFollower = AppAppearanceFollower()
 
     private(set) var preview: UIKitThemePreviewView!
     private(set) var nameField = UITextField()
@@ -56,6 +58,13 @@ final class ThemeEditorViewController: UIViewController, UITextFieldDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         applyAppearance()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // Editing the theme name raises a keyboard over the color table below
+        // it, so this form pays for the overlap the way the sheets do.
+        applyKeyboardContentInset(to: scrollView)
     }
 
     private func configureNavigation() {
@@ -351,21 +360,12 @@ final class ThemeEditorViewController: UIViewController, UITextFieldDelegate {
         return true
     }
 
+    /// A pushed editor shares Settings' navigation stack, whose chrome and
+    /// window belong to that root — only a standalone editor pins them.
     private func applyAppearance() {
-        let style: UIUserInterfaceStyle
-        switch appAppearance.resolvedOverride {
-        case nil: style = .unspecified
-        case .light: style = .light
-        case .dark: style = .dark
-        }
-        overrideUserInterfaceStyle = style
-        if navigationController?.viewControllers.first === self {
-            navigationController?.overrideUserInterfaceStyle = style
-            viewIfLoaded?.window?.overrideUserInterfaceStyle = style
-        }
-        if let navigationBar = navigationController?.navigationBar {
-            UIKitChassis.configureSheetNavigationBar(navigationBar)
-        }
+        applyAppAppearance(
+            pinsHostingChrome: navigationController?.viewControllers.first === self
+        )
     }
 
     @objc private func nameChanged() {

--- a/Multiplex/Views/Shell/ExternalActionHost.swift
+++ b/Multiplex/Views/Shell/ExternalActionHost.swift
@@ -134,7 +134,7 @@ final class ExternalActionUIKitCoordinator: NSObject,
                 request: request,
                 submit: { [weak router] action in router?.submit(action) }
             )
-            prompt.appAppearance = themes.appearance
+            prompt.followAppAppearance(themes)
             let navigation = UINavigationController(rootViewController: prompt)
             navigation.navigationBar.prefersLargeTitles = false
             navigation.view.backgroundColor = UIKitChassis.chassis

--- a/Multiplex/Views/Shell/SingleWindowShell.swift
+++ b/Multiplex/Views/Shell/SingleWindowShell.swift
@@ -234,6 +234,8 @@ final class SingleWindowShellViewController: UIViewController {
     private var externalCoordinator: ExternalActionUIKitCoordinator?
     private var routeObservationGeneration = 0
     private var layoutAnimator: UIViewPropertyAnimator?
+    private var layoutCompletion: (() -> Void)?
+    private var isApplyingLayoutChanges = false
     private var targetLayoutMetrics: SingleWindowShellLayoutMetrics?
     private var testLayoutInput: (
         size: CGSize,
@@ -447,6 +449,7 @@ final class SingleWindowShellViewController: UIViewController {
         routeObservationGeneration &+= 1
         layoutAnimator?.stopAnimation(true)
         layoutAnimator = nil
+        layoutCompletion = nil
         externalCoordinator?.detach()
         externalCoordinator = nil
         #if os(iOS)
@@ -602,7 +605,14 @@ final class SingleWindowShellViewController: UIViewController {
         let controller = deckFactory(shellState, actions)
         deckController = controller
         install(controller, in: shellRootView.deckContainer)
-        (controller as? DeckWindowViewController)?.setAppLocked(appLocked)
+        if let deck = controller as? DeckWindowViewController {
+            deck.setAppLocked(appLocked)
+            // Deck sheets present from this shell's presenter, so their
+            // dismissal is what frees the shell-owned external-action queue.
+            deck.presentationDidEnd = { [weak self] in
+                self?.externalCoordinator?.presenterDidBecomeAvailable()
+            }
+        }
         updateNativeDeckController()
     }
 
@@ -615,6 +625,20 @@ final class SingleWindowShellViewController: UIViewController {
             let controller = terminalFactory(shellState, actions)
             terminalController = controller
             install(controller, in: shellRootView.terminalContainer)
+            // Every caller here follows with an animated `applyLayout`, whose
+            // changes block resolves this subtree's first layout pass inside a
+            // UIViewPropertyAnimator — so every freshly installed subview
+            // would spring out of `.zero` at the container's top-left (labels
+            // stacked on the origin, the rail riding high, a clipped panel).
+            // Settle its resting geometry first; only the slide animates.
+            // The flag keeps a layout pass this resolution reaches from
+            // committing the caller's still-pending animated transition
+            // unanimated — the same re-entrancy `applyLayout` already guards.
+            isApplyingLayoutChanges = true
+            UIView.performWithoutAnimation {
+                shellRootView.terminalContainer.layoutIfNeeded()
+            }
+            isApplyingLayoutChanges = false
             (controller as? TerminalWindowViewController)?.setAppLocked(appLocked)
         } else {
             if let controller = terminalController {
@@ -651,6 +675,7 @@ final class SingleWindowShellViewController: UIViewController {
     /// interactive visionOS chrome behind the veil.
     func setAppLocked(_ locked: Bool) {
         appLocked = locked
+        externalCoordinator?.setAppLocked(locked)
         (deckController as? DeckWindowViewController)?.setAppLocked(locked)
         (terminalController as? TerminalWindowViewController)?.setAppLocked(locked)
     }
@@ -716,7 +741,10 @@ final class SingleWindowShellViewController: UIViewController {
         animated: Bool,
         completion: (() -> Void)? = nil
     ) {
-        guard isViewLoaded else { return }
+        // Resolving the containers' children inside the transition below runs
+        // a layout pass, whose containment bookkeeping re-enters here with the
+        // geometry already committed above it.
+        guard isViewLoaded, !isApplyingLayoutChanges else { return }
         let metrics = resolvedLayoutMetrics()
         if !animated,
            layoutAnimator?.isRunning == true,
@@ -743,7 +771,31 @@ final class SingleWindowShellViewController: UIViewController {
 
         let changes = { [weak self] in
             guard let self else { return }
+            self.isApplyingLayoutChanges = true
             self.shellRootView.apply(metrics)
+            // The deck and terminal controller views are pinned to those
+            // containers with constraints, so a container's new bounds reach
+            // them only at the next layout pass — outside this transaction.
+            // Resolve it here or the rail toggle snaps their content to its
+            // final width while the container is still sliding.
+            self.shellRootView.layoutIfNeeded()
+            self.isApplyingLayoutChanges = false
+        }
+        // `stopAnimation(true)` retires an animator without running its
+        // completions, so an interrupted transition would strand the caller's
+        // state cleanup. Carry it to whichever pass finally settles the
+        // layout — the interruption coverage SwiftUI's `.removed` completion
+        // criteria gave this transition before.
+        let pending = layoutCompletion
+        layoutCompletion = nil
+        let settled: (() -> Void)?
+        if pending != nil || completion != nil {
+            settled = {
+                pending?()
+                completion?()
+            }
+        } else {
+            settled = nil
         }
         let shouldAnimate = animated
             && !shellState.reduceMotion
@@ -752,7 +804,7 @@ final class SingleWindowShellViewController: UIViewController {
             layoutAnimator?.stopAnimation(true)
             layoutAnimator = nil
             changes()
-            completion?()
+            settled?()
             return
         }
 
@@ -763,10 +815,12 @@ final class SingleWindowShellViewController: UIViewController {
             animations: changes
         )
         layoutAnimator = animator
+        layoutCompletion = settled
         animator.addCompletion { [weak self] _ in
             guard let self, self.layoutAnimator === animator else { return }
             self.layoutAnimator = nil
-            completion?()
+            self.layoutCompletion = nil
+            settled?()
         }
         animator.startAnimation()
     }
@@ -946,8 +1000,35 @@ extension SingleWindowShellViewController: UIGestureRecognizerDelegate {
         guard gestureRecognizer === backSwipeRecognizer,
               backSwipeRecognizer.isEnabled
         else { return false }
+        // The recognizer lives on the window and cancels touches in view, so
+        // everything sitting inside the left grab region is its to steal —
+        // including the tab strip's leading cells and the UMD's own ‹ DECK
+        // control, which a press with a few points of rightward drift then
+        // never reaches. Those two are app chrome with their own actions, so
+        // the edge gesture declines them outright; over the terminal pane it
+        // keeps its first refusal on horizontal movement.
+        if isShellChromeTouch(touch.view) {
+            initialTouchTerminal = nil
+            return false
+        }
         initialTouchTerminal = terminalView(containing: touch.view)
         return initialTouchTerminal?.hasActiveSelection != true
+    }
+
+    /// Walks up from the touched view: a cell is nested several levels inside
+    /// its strip, and a UMD control inside its bar's stacks.
+    private func isShellChromeTouch(_ view: UIView?) -> Bool {
+        var candidate = view
+        while let current = candidate {
+            if current is TerminalTabStripView
+                || current is TerminalTabScrollView
+                || current is UMDBarRootView
+                || current is ViewportUMDRootView {
+                return true
+            }
+            candidate = current.superview
+        }
+        return false
     }
 
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
@@ -1107,6 +1188,7 @@ final class SingleWindowShellEmptyTerminalView: UIView {
         let detail = UILabel()
         detail.text = "Choose a session from the deck to attach it here."
         detail.font = .preferredFont(forTextStyle: .footnote)
+        detail.adjustsFontForContentSizeCategory = true
         detail.textColor = UIKitChassis.signal2
         detail.textAlignment = .center
         detail.numberOfLines = 0

--- a/Multiplex/Views/Shell/SingleWindowShell.swift
+++ b/Multiplex/Views/Shell/SingleWindowShell.swift
@@ -235,7 +235,6 @@ final class SingleWindowShellViewController: UIViewController {
     private var routeObservationGeneration = 0
     private var layoutAnimator: UIViewPropertyAnimator?
     private var layoutCompletion: (() -> Void)?
-    private var isApplyingLayoutChanges = false
     private var targetLayoutMetrics: SingleWindowShellLayoutMetrics?
     private var testLayoutInput: (
         size: CGSize,
@@ -625,20 +624,6 @@ final class SingleWindowShellViewController: UIViewController {
             let controller = terminalFactory(shellState, actions)
             terminalController = controller
             install(controller, in: shellRootView.terminalContainer)
-            // Every caller here follows with an animated `applyLayout`, whose
-            // changes block resolves this subtree's first layout pass inside a
-            // UIViewPropertyAnimator — so every freshly installed subview
-            // would spring out of `.zero` at the container's top-left (labels
-            // stacked on the origin, the rail riding high, a clipped panel).
-            // Settle its resting geometry first; only the slide animates.
-            // The flag keeps a layout pass this resolution reaches from
-            // committing the caller's still-pending animated transition
-            // unanimated — the same re-entrancy `applyLayout` already guards.
-            isApplyingLayoutChanges = true
-            UIView.performWithoutAnimation {
-                shellRootView.terminalContainer.layoutIfNeeded()
-            }
-            isApplyingLayoutChanges = false
             (controller as? TerminalWindowViewController)?.setAppLocked(appLocked)
         } else {
             if let controller = terminalController {
@@ -741,10 +726,7 @@ final class SingleWindowShellViewController: UIViewController {
         animated: Bool,
         completion: (() -> Void)? = nil
     ) {
-        // Resolving the containers' children inside the transition below runs
-        // a layout pass, whose containment bookkeeping re-enters here with the
-        // geometry already committed above it.
-        guard isViewLoaded, !isApplyingLayoutChanges else { return }
+        guard isViewLoaded else { return }
         let metrics = resolvedLayoutMetrics()
         if !animated,
            layoutAnimator?.isRunning == true,
@@ -769,17 +751,15 @@ final class SingleWindowShellViewController: UIViewController {
         updateChildPresentation(metrics)
         updateBackSwipeAvailability(expanded: metrics.expanded)
 
-        let changes = { [weak self] in
-            guard let self else { return }
-            self.isApplyingLayoutChanges = true
-            self.shellRootView.apply(metrics)
-            // The deck and terminal controller views are pinned to those
-            // containers with constraints, so a container's new bounds reach
-            // them only at the next layout pass — outside this transaction.
-            // Resolve it here or the rail toggle snaps their content to its
-            // final width while the container is still sliding.
-            self.shellRootView.layoutIfNeeded()
-            self.isApplyingLayoutChanges = false
+        // Animate only the shell's frame/alpha contract. Forcing
+        // `layoutIfNeeded()` on the root here also resolves every pending
+        // descendant constraint inside this property animator. A probe tick or
+        // second tab can install fresh tile/cell content during that window;
+        // UIKit then preserves its zero-origin presentation geometry, piling
+        // labels into the corner. Descendants own their ordinary next layout
+        // pass, exactly as they did on the working #23 base.
+        let changes: () -> Void = { [weak self] in
+            self?.shellRootView.apply(metrics)
         }
         // `stopAnimation(true)` retires an animator without running its
         // completions, so an interrupted transition would strand the caller's

--- a/Multiplex/Views/Terminal/AgentHelperStrip.swift
+++ b/Multiplex/Views/Terminal/AgentHelperStrip.swift
@@ -53,6 +53,14 @@ final class AgentHelperStripViewController: UIViewController,
         let safeAreaRight: CGFloat
     }
 
+    /// What the live Observation registration is armed against. Everything
+    /// else a configuration carries is read at render time, so only a move
+    /// here needs a fresh — and uncancellable — tracking.
+    private struct ObservationKey: Equatable {
+        let agent: AgentKind
+        let historyController: ObjectIdentifier?
+    }
+
     nonisolated static let dockedHeight: CGFloat = 48
     nonisolated static let chipHeight: CGFloat = 22
     nonisolated static let maximumFloatingWidth: CGFloat = 760
@@ -65,6 +73,7 @@ final class AgentHelperStripViewController: UIViewController,
     private weak var customPanelController: CustomAgentCommandPanelViewController?
     private weak var historyPanelController: AgentHistoryPanelViewController?
     private var observationGeneration = 0
+    private var observedKey: ObservationKey?
     private var renderedKey: RenderKey?
     private(set) var historyAvailable = false
     #if DEBUG
@@ -94,6 +103,15 @@ final class AgentHelperStripViewController: UIViewController,
             dismissOpenPanels(animated: false)
         }
         guard isViewLoaded else { return }
+        // A tracking is one-shot and cannot be cancelled, while the parent
+        // re-renders on every probe tick — re-arming here stranded one dead
+        // registration per render on a controller whose status stays `.live`
+        // for hours. The live one still speaks for an unchanged identity, so
+        // routine updates only re-render.
+        guard observationKey != observedKey else {
+            renderIfNeeded(available: historyAvailable)
+            return
+        }
         observationGeneration &+= 1
         renderAndObserve(generation: observationGeneration)
     }
@@ -105,6 +123,8 @@ final class AgentHelperStripViewController: UIViewController,
 
     func prepareForRemoval() {
         observationGeneration &+= 1
+        // The bump retires the live chain, so a later update must re-arm.
+        observedKey = nil
         dismissOpenPanels(animated: false)
         #if DEBUG
         for observer in debugObservers {
@@ -199,12 +219,21 @@ final class AgentHelperStripViewController: UIViewController,
         renderIfNeeded(available: available)
     }
 
+    private var observationKey: ObservationKey {
+        ObservationKey(
+            agent: configuration.agent,
+            historyController: configuration.historyController
+                .map(ObjectIdentifier.init)
+        )
+    }
+
     private func renderAndObserve(generation: Int? = nil) {
         let generation = generation ?? {
             observationGeneration &+= 1
             return observationGeneration
         }()
         guard generation == observationGeneration else { return }
+        observedKey = observationKey
 
         let available = withObservationTracking {
             configuration.agent == .claudeCode
@@ -307,7 +336,7 @@ final class AgentHelperStripViewController: UIViewController,
         rail.alignment = .center
         rail.spacing = 6
 
-        let scroll = UIScrollView()
+        let scroll = AgentHelperCommandScrollView()
         scroll.showsHorizontalScrollIndicator = false
         scroll.showsVerticalScrollIndicator = false
         scroll.alwaysBounceHorizontal = false
@@ -642,6 +671,28 @@ private final class AgentHelperStripRootView: UIKitTallyBorderedView {
             width: proposedWidth ?? ceil(measured.width + horizontalInsets),
             height: AgentHelperStripViewController.dockedHeight
         )
+    }
+}
+
+/// The command rail's scroller. Same contract as the tab rail's: a scroll
+/// view delays content touches by 150 ms and drops them if the finger drifts
+/// during that window, so an overflowing chip row loses ordinary presses.
+/// Track at once, and keep drag-to-scroll from a chip by answering the cancel
+/// question for controls, whose UIKit default (false) would otherwise pin the
+/// rail once touches are undelayed.
+@MainActor
+final class AgentHelperCommandScrollView: UIScrollView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        delaysContentTouches = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    override func touchesShouldCancel(in view: UIView) -> Bool {
+        if view is UIButton { return true }
+        return super.touchesShouldCancel(in: view)
     }
 }
 

--- a/Multiplex/Views/Terminal/AgentHistoryPanel.swift
+++ b/Multiplex/Views/Terminal/AgentHistoryPanel.swift
@@ -357,7 +357,7 @@ final class AgentHistoryPanelViewController: UIViewController {
             let listWidth = max(0, panelWidth)
             let measured = stack.systemLayoutSizeFitting(
                 CGSize(width: listWidth, height: UIView.layoutFittingCompressedSize.height),
-                withHorizontalFittingPriority: .defaultHigh,
+                withHorizontalFittingPriority: .required,
                 verticalFittingPriority: .fittingSizeLevel
             ).height
             let height = min(max(ceil(measured), 44), Self.maximumListHeight)
@@ -411,21 +411,11 @@ private final class AgentHistoryPanelRootView: UIView {
         fittingSize(for: width)
     }
 
-    /// The fitting width is a proposal, never a requirement: `rootStack` is
-    /// required-pinned to all four edges of this view, whose own width is set
-    /// by the popover (its autoresizing mask stays translated, so UIKit
-    /// synthesizes a REQUIRED width from the frame it currently has — zero
-    /// before the first layout, and the previous width for one pass after a
-    /// width change). Requiring a second, different width on top of those pins
-    /// is unsatisfiable, and Auto Layout resolves it by breaking the pins
-    /// instead: rows and headers solve to zero size and render as empty bars
-    /// until a later clean pass heals them. A non-required proposal degrades
-    /// the measurement rather than the panel's layout.
     func fittingSize(for proposedWidth: CGFloat) -> CGSize {
         guard let rootStack else { return CGSize(width: proposedWidth, height: 0) }
         let measured = rootStack.systemLayoutSizeFitting(
             CGSize(width: proposedWidth, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .defaultHigh,
+            withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: proposedWidth, height: ceil(measured.height))

--- a/Multiplex/Views/Terminal/AgentHistoryPanel.swift
+++ b/Multiplex/Views/Terminal/AgentHistoryPanel.swift
@@ -208,6 +208,10 @@ final class AgentHistoryPanelViewController: UIViewController {
         switch status {
         case nil, .loading:
             let spinner = UIActivityIndicatorView(style: .medium)
+            // An unstyled indicator resolves to the system gray and ignores the
+            // window tint, so the TALLY ink must be assigned directly — the same
+            // token every other busy indicator in the app uses.
+            spinner.color = UIKitChassis.signal2
             spinner.startAnimating()
             spinner.accessibilityLabel = "Reading session file"
             let label = UIKitChassisLabel(
@@ -353,7 +357,7 @@ final class AgentHistoryPanelViewController: UIViewController {
             let listWidth = max(0, panelWidth)
             let measured = stack.systemLayoutSizeFitting(
                 CGSize(width: listWidth, height: UIView.layoutFittingCompressedSize.height),
-                withHorizontalFittingPriority: .required,
+                withHorizontalFittingPriority: .defaultHigh,
                 verticalFittingPriority: .fittingSizeLevel
             ).height
             let height = min(max(ceil(measured), 44), Self.maximumListHeight)
@@ -407,11 +411,21 @@ private final class AgentHistoryPanelRootView: UIView {
         fittingSize(for: width)
     }
 
+    /// The fitting width is a proposal, never a requirement: `rootStack` is
+    /// required-pinned to all four edges of this view, whose own width is set
+    /// by the popover (its autoresizing mask stays translated, so UIKit
+    /// synthesizes a REQUIRED width from the frame it currently has — zero
+    /// before the first layout, and the previous width for one pass after a
+    /// width change). Requiring a second, different width on top of those pins
+    /// is unsatisfiable, and Auto Layout resolves it by breaking the pins
+    /// instead: rows and headers solve to zero size and render as empty bars
+    /// until a later clean pass heals them. A non-required proposal degrades
+    /// the measurement rather than the panel's layout.
     func fittingSize(for proposedWidth: CGFloat) -> CGSize {
         guard let rootStack else { return CGSize(width: proposedWidth, height: 0) }
         let measured = rootStack.systemLayoutSizeFitting(
             CGSize(width: proposedWidth, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .required,
+            withHorizontalFittingPriority: .defaultHigh,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: proposedWidth, height: ceil(measured.height))

--- a/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
+++ b/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
@@ -592,7 +592,7 @@ final class CustomAgentCommandPanelViewController: UIViewController {
                 width: contentWidth,
                 height: UIView.layoutFittingCompressedSize.height
             ),
-            withHorizontalFittingPriority: .defaultHigh,
+            withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         ).height + 24
         let estimate = CGFloat(max(1, drafts.commands.count)) * 102 + 60
@@ -666,17 +666,6 @@ private final class CustomAgentCommandPanelRootView: UIKitTallyBorderedView {
         fittingSize(for: width)
     }
 
-    /// The fitting width is a proposal, never a requirement: `rootStack` is
-    /// required-pinned to all four edges of this view, whose own width is set
-    /// by the popover (its autoresizing mask stays translated, so UIKit
-    /// synthesizes a REQUIRED width from the frame it currently has — zero
-    /// before the first layout, and the previous width for one pass after a
-    /// width change). Requiring a second, different width on top of those pins
-    /// is unsatisfiable, and Auto Layout resolves it by breaking the pins
-    /// instead: rows and section headers solve to zero size and render as
-    /// empty bars until a later clean pass heals them. A non-required proposal
-    /// degrades the measurement rather than the editor's layout — the same
-    /// reason `updateEditorHeight` measures its list that way.
     func fittingSize(for proposedWidth: CGFloat) -> CGSize {
         guard let rootStack else { return CGSize(width: proposedWidth, height: 0) }
         let measured = rootStack.systemLayoutSizeFitting(
@@ -684,7 +673,7 @@ private final class CustomAgentCommandPanelRootView: UIKitTallyBorderedView {
                 width: proposedWidth,
                 height: UIView.layoutFittingCompressedSize.height
             ),
-            withHorizontalFittingPriority: .defaultHigh,
+            withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: proposedWidth, height: ceil(measured.height))

--- a/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
+++ b/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
@@ -53,6 +53,9 @@ final class CustomAgentCommandDrafts {
 final class CustomAgentCommandPanelViewController: UIViewController {
     nonisolated static let preferredWidth: CGFloat = 500
     nonisolated static let maximumEditorHeight: CGFloat = 430
+    /// Below the footer legend's own resistance (see `legendRow`), so a
+    /// shortened popover spends the scroll viewport before any chrome.
+    private static let listHeightPriority = UILayoutPriority(650)
 
     let agent: AgentKind
     private(set) var panelWidth: CGFloat
@@ -71,11 +74,13 @@ final class CustomAgentCommandPanelViewController: UIViewController {
     private let listScrollView = UIScrollView()
     private let listStack = UIStackView()
     private var listHeightConstraint: NSLayoutConstraint?
+    private var listHeightCeilingConstraint: NSLayoutConstraint?
     private weak var accordionControl: CustomCommandAccordionControl?
     private var rowViews: [UUID: CustomCommandRowView] = [:]
     private var renderedColumnCount = 0
     private var renderedCompactControls: Bool?
     private var rebuildingList = false
+    private var listContentExceedsCap = false
 
     init(
         agent: AgentKind,
@@ -116,6 +121,7 @@ final class CustomAgentCommandPanelViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        refreshListScrollEnabled()
         let columns = builtInColumnCount(for: panelView.bounds.width)
         let compact = usesCompactControls(for: panelView.bounds.width)
         guard !rebuildingList,
@@ -212,9 +218,13 @@ final class CustomAgentCommandPanelViewController: UIViewController {
     }
 
     func deleteCommand(id: UUID) {
+        // Only the deleted row hands back its editor. Another row being typed
+        // into keeps the keyboard and its caret across the rebuild, and because
+        // focus is restored by command UUID it can never land on whichever row
+        // slid into the deleted one's position.
         rowViews[id]?.resignEditor()
         drafts.remove(id: id)
-        rebuildCommandList()
+        rebuildCommandList(preservingFocus: true)
     }
 
     func updateCommand(_ command: CustomAgentCommand) {
@@ -326,8 +336,26 @@ final class CustomAgentCommandPanelViewController: UIViewController {
                 constant: -24
             ),
         ])
+        // The viewport's height is a ceiling that must hold and a resting
+        // height that may give way. UIKit shortens an anchored popover above a
+        // docked keyboard, and the SwiftUI panel this replaced spelled the same
+        // rule `.frame(minHeight: 0, idealHeight:, maxHeight:)`: only the list
+        // contracts, so the header and the ADD/CANCEL/DONE footer stay on
+        // screen instead of being clipped out of reach.
+        let ceiling = listScrollView.heightAnchor.constraint(
+            lessThanOrEqualToConstant: 0
+        )
+        ceiling.identifier = "customCommands.listHeightCeiling"
+        ceiling.isActive = true
+        listHeightCeilingConstraint = ceiling
+        // Contracting stops at zero: past that the legend gives way, never the
+        // stack's arithmetic.
+        listScrollView.heightAnchor.constraint(
+            greaterThanOrEqualToConstant: 0
+        ).isActive = true
         let height = listScrollView.heightAnchor.constraint(equalToConstant: 0)
         height.identifier = "customCommands.listHeight"
+        height.priority = Self.listHeightPriority
         height.isActive = true
         listHeightConstraint = height
         return listScrollView
@@ -410,7 +438,10 @@ final class CustomAgentCommandPanelViewController: UIViewController {
         label.font = UIKitChassis.monoFont(8, weight: .medium)
         label.textColor = UIKitChassis.signal2
         label.numberOfLines = 0
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        // Above the list viewport's resting height, below required: the legend
+        // is the last thing in the panel to give way, and a required floor here
+        // would make a popover shorter than the whole panel unsatisfiable.
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
         let row = UIStackView(arrangedSubviews: [dot, label])
         row.axis = .horizontal
@@ -434,8 +465,9 @@ final class CustomAgentCommandPanelViewController: UIViewController {
         rebuildingList = true
         defer { rebuildingList = false }
 
-        let focusedID = preservingFocus
-            ? rowViews.first(where: { $0.value.isEditing })?.key
+        let focused: (id: UUID, selection: NSRange)? = preservingFocus
+            ? rowViews.first(where: { $0.value.isEditing })
+                .map { (id: $0.key, selection: $0.value.editorSelection) }
             : nil
         listStack.arrangedSubviews.forEach {
             listStack.removeArrangedSubview($0)
@@ -504,9 +536,9 @@ final class CustomAgentCommandPanelViewController: UIViewController {
 
         listStack.layoutIfNeeded()
         refreshPreferredContentSize()
-        if let focusedID {
+        if let focused {
             DispatchQueue.main.async { [weak self] in
-                self?.rowViews[focusedID]?.focusEditor()
+                self?.rowViews[focused.id]?.focusEditor(selection: focused.selection)
             }
         }
     }
@@ -560,7 +592,7 @@ final class CustomAgentCommandPanelViewController: UIViewController {
                 width: contentWidth,
                 height: UIView.layoutFittingCompressedSize.height
             ),
-            withHorizontalFittingPriority: .required,
+            withHorizontalFittingPriority: .defaultHigh,
             verticalFittingPriority: .fittingSizeLevel
         ).height + 24
         let estimate = CGFloat(max(1, drafts.commands.count)) * 102 + 60
@@ -569,10 +601,12 @@ final class CustomAgentCommandPanelViewController: UIViewController {
             ceil(measured > 24 ? measured : estimate)
         )
         listHeightConstraint?.constant = resolved
-        listScrollView.isScrollEnabled = measured > Self.maximumEditorHeight
+        listHeightCeilingConstraint?.constant = resolved
+        listContentExceedsCap = measured > Self.maximumEditorHeight
         panelView.invalidateIntrinsicContentSize()
         view.setNeedsLayout()
         view.layoutIfNeeded()
+        refreshListScrollEnabled()
 
         let size = panelView.fittingSize(for: width)
         guard preferredContentSize != size else { return }
@@ -580,6 +614,15 @@ final class CustomAgentCommandPanelViewController: UIViewController {
         if notifiesParent {
             parent?.preferredContentSizeDidChange(forChildContentContainer: self)
         }
+    }
+
+    /// The resting height is what the content wants; the frame is what the
+    /// popover was given. A contracted viewport has to scroll even when the
+    /// content would otherwise have fit.
+    private func refreshListScrollEnabled() {
+        let contracted = listScrollView.bounds.height + 0.5
+            < listScrollView.contentSize.height
+        listScrollView.isScrollEnabled = listContentExceedsCap || contracted
     }
 
     private func refreshPreferredContentSize() {
@@ -623,6 +666,17 @@ private final class CustomAgentCommandPanelRootView: UIKitTallyBorderedView {
         fittingSize(for: width)
     }
 
+    /// The fitting width is a proposal, never a requirement: `rootStack` is
+    /// required-pinned to all four edges of this view, whose own width is set
+    /// by the popover (its autoresizing mask stays translated, so UIKit
+    /// synthesizes a REQUIRED width from the frame it currently has — zero
+    /// before the first layout, and the previous width for one pass after a
+    /// width change). Requiring a second, different width on top of those pins
+    /// is unsatisfiable, and Auto Layout resolves it by breaking the pins
+    /// instead: rows and section headers solve to zero size and render as
+    /// empty bars until a later clean pass heals them. A non-required proposal
+    /// degrades the measurement rather than the editor's layout — the same
+    /// reason `updateEditorHeight` measures its list that way.
     func fittingSize(for proposedWidth: CGFloat) -> CGSize {
         guard let rootStack else { return CGSize(width: proposedWidth, height: 0) }
         let measured = rootStack.systemLayoutSizeFitting(
@@ -630,7 +684,7 @@ private final class CustomAgentCommandPanelRootView: UIKitTallyBorderedView {
                 width: proposedWidth,
                 height: UIView.layoutFittingCompressedSize.height
             ),
-            withHorizontalFittingPriority: .required,
+            withHorizontalFittingPriority: .defaultHigh,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: proposedWidth, height: ceil(measured.height))
@@ -1135,8 +1189,14 @@ private final class CustomCommandRowView: UIView, UITextViewDelegate {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
 
-    func focusEditor() {
+    var editorSelection: NSRange { editor.selectedRange }
+
+    func focusEditor(selection: NSRange? = nil) {
         editor.becomeFirstResponder()
+        guard let selection,
+              selection.location + selection.length <= (editor.text as NSString).length
+        else { return }
+        editor.selectedRange = selection
     }
 
     func resignEditor() {
@@ -1284,7 +1344,10 @@ private final class CustomCommandSwitch: UIControl {
         )
         super.init(frame: .zero)
         isAccessibilityElement = true
-        accessibilityTraits = .button
+        // The SwiftUI row was a real `Toggle`; `.toggleButton` is UIKit's
+        // equivalent identity, so the switch rotor and the spoken On/Off
+        // state survive the port.
+        accessibilityTraits = [.button, .toggleButton]
         self.accessibilityLabel = accessibilityLabel
         accessibilityIdentifier = "customCommands.switch.\(label.lowercased())"
         addTarget(self, action: #selector(pressed), for: .touchUpInside)
@@ -1313,12 +1376,12 @@ private final class CustomCommandSwitch: UIControl {
 
     @objc private func pressed() {
         isOn.toggle()
-        render()
+        render(animated: true)
         changed(isOn)
     }
 
-    private func render() {
-        track.setOn(isOn)
+    private func render(animated: Bool = false) {
+        track.setOn(isOn, animated: animated)
         caption.setColor(isOn ? UIKitChassis.signal : UIKitChassis.signal2)
         accessibilityValue = isOn ? "On" : "Off"
         if isOn {
@@ -1358,13 +1421,28 @@ private final class CustomCommandSwitchTrack: UIKitTallyBorderedView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
 
-    func setOn(_ on: Bool) {
+    func setOn(_ on: Bool, animated: Bool = false) {
         leading.isActive = false
         trailing.isActive = false
         (on ? trailing : leading).isActive = true
-        backgroundColor = on ? UIKitChassis.bezelHi : UIKitChassis.screen
-        thumb.backgroundColor = on ? UIKitChassis.signal : UIKitChassis.signal3
-        tallyBorderColor = on ? UIKitChassis.signal2 : UIKitChassis.bezelHi
+        let apply = {
+            self.backgroundColor = on ? UIKitChassis.bezelHi : UIKitChassis.screen
+            self.thumb.backgroundColor = on ? UIKitChassis.signal : UIKitChassis.signal3
+            self.tallyBorderColor = on ? UIKitChassis.signal2 : UIKitChassis.bezelHi
+            // The swapped constraint only moves the thumb inside an animation
+            // transaction if the layout pass runs there too.
+            self.layoutIfNeeded()
+        }
+        guard animated, window != nil, !UIAccessibility.isReduceMotionEnabled else {
+            apply()
+            return
+        }
+        UIView.animate(
+            withDuration: CustomCommandChoiceMetrics.selectionAnimationDuration,
+            delay: 0,
+            options: [.curveEaseOut, .beginFromCurrentState],
+            animations: apply
+        )
     }
 }
 

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -1098,6 +1098,16 @@ enum CodePalette {
 
 // MARK: - Native content states
 
+private extension UIFont {
+    /// Only a semantic text style scales with Dynamic Type; the chassis's
+    /// fixed sizes already carry `Theme.typeScale` and must never compound
+    /// with it. The panels below take their body font from the caller, so
+    /// they opt in by what they were handed.
+    var followsDynamicType: Bool {
+        fontDescriptor.object(forKey: .textStyle) != nil
+    }
+}
+
 @MainActor
 final class FileViewerMessageView: UIView {
     private(set) var captionLabel: UIKitChassisLabel
@@ -1120,6 +1130,7 @@ final class FileViewerMessageView: UIView {
         backgroundColor = UIKitChassis.screen
         detailLabel.text = detail
         detailLabel.font = detailFont
+        detailLabel.adjustsFontForContentSizeCategory = detailFont.followsDynamicType
         detailLabel.textColor = caption == "LOADING"
             ? UIKitChassis.signal2 : UIKitChassis.signal3
         detailLabel.numberOfLines = caption == "LOADING" ? 2 : 0
@@ -1152,15 +1163,22 @@ final class FileViewerMessageView: UIView {
 
 @MainActor
 final class FileViewerTallyLampView: UIView {
+    private let dot = UIView()
+    private let color: UIColor
+
     init(caption: String, color: UIColor = TallyPalette.caution) {
+        self.color = color
         super.init(frame: .zero)
-        let dot = UIView()
         let diameter = 7 * Theme.typeScale
         dot.backgroundColor = color
         dot.layer.cornerRadius = diameter / 2
-        dot.layer.shadowColor = color.cgColor
         dot.layer.shadowOpacity = 0.7
         dot.layer.shadowRadius = 4
+        refreshLampGlow()
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+            (view: FileViewerTallyLampView, _: UITraitCollection) in
+            view.refreshLampGlow()
+        }
         dot.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             dot.widthAnchor.constraint(equalToConstant: diameter),
@@ -1193,6 +1211,14 @@ final class FileViewerTallyLampView: UIView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
+
+    /// The dot's fill and the caption follow the appearance on their own; a
+    /// CGColor does not — it flattens whatever traits were current when it
+    /// was taken, and these panels are built from an observation render
+    /// rather than a UIKit callback.
+    private func refreshLampGlow() {
+        dot.layer.shadowColor = color.resolvedColor(with: traitCollection).cgColor
+    }
 }
 
 @MainActor
@@ -1219,6 +1245,7 @@ final class FileViewerPanelView: UIKitTallyBorderedView {
             let label = UILabel()
             label.text = detail.text
             label.font = detail.font
+            label.adjustsFontForContentSizeCategory = detail.font.followsDynamicType
             label.textColor = detail.color
             label.numberOfLines = 0
             label.textAlignment = .center
@@ -1297,6 +1324,7 @@ final class FileViewerCodeContentView: UIView {
         let detail = UILabel()
         detail.text = "Showing the first \(FileViewerController.formatBytes(UInt64(FileViewerController.textByteLimit)))."
         detail.font = UIFont.preferredFont(forTextStyle: .footnote)
+        detail.adjustsFontForContentSizeCategory = true
         detail.textColor = UIKitChassis.signal3
         let row = UIStackView(arrangedSubviews: [caption, detail, UIView()])
         row.axis = .horizontal
@@ -1700,11 +1728,13 @@ final class FileViewerMarkdownTextView: UITextView, UITextViewDelegate {
     private var destinations: [URL: String] = [:]
     var openLink: (String) -> Void = { _ in }
     private var lastMeasuredWidth: CGFloat = -1
+    private let attributed: FileViewerMarkdownAttributedText
 
     init(
         attributed: FileViewerMarkdownAttributedText,
         openLink: @escaping (String) -> Void
     ) {
+        self.attributed = attributed
         super.init(frame: .zero, textContainer: nil)
         backgroundColor = .clear
         isEditable = false
@@ -1721,6 +1751,15 @@ final class FileViewerMarkdownTextView: UITextView, UITextViewDelegate {
         accessibilityLabel = attributed.text.string
         setContentHuggingPriority(.required, for: .vertical)
         setContentCompressionResistancePriority(.required, for: .vertical)
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+            (view: FileViewerMarkdownTextView, _: UITraitCollection) in
+            // TextKit resolves an attributed string's dynamic inks when the
+            // text is set, so an appearance flip only reaches a rendered
+            // block by re-feeding it. Blocks the reader has not scrolled to
+            // are not built yet and resolve against the new appearance when
+            // they mount.
+            view.attributedText = view.attributed.text
+        }
     }
 
     @available(*, unavailable)
@@ -1748,23 +1787,46 @@ final class FileViewerMarkdownTextView: UITextView, UITextViewDelegate {
         in characterRange: NSRange,
         interaction: UITextItemInteraction
     ) -> Bool {
+        // Only an actual activation opens the link. UIKit also asks with
+        // `.presentActions` and `.preview` while a long press is building its
+        // menu, and answering those would raise the confirmation sheet from a
+        // gesture that used to offer text selection instead. `false` keeps the
+        // system's own link menu (which would bypass the sheet) out of the way.
+        guard interaction == .invokeDefaultAction else { return false }
         openLink(destinations[URL] ?? URL.absoluteString)
         return false
     }
 }
 
 @MainActor
-final class FileViewerMarkdownContentView: UIView {
+final class FileViewerMarkdownContentView: UIView, UIScrollViewDelegate {
+    /// Blocks mount progressively — enough to fill the viewport plus
+    /// `mountAhead`, then more as the reader scrolls — because each one is a
+    /// full TextKit surface and a document may hold thousands of them
+    /// (`FileViewerController.textByteLimit` is 1.5 MB). This is the UIKit
+    /// spelling of the `LazyVStack` this screen replaced, and the smallest
+    /// design that bounds the work: appending in order keeps the geometry
+    /// above the reader exact, so no block ever needs an estimated height,
+    /// and mounted blocks are kept (never recycled) so scrolling back is
+    /// instant and a live text selection survives.
+    private static let mountAhead: CGFloat = 600
+    private static let mountBatch = 8
+    private static let maximumMountPasses = 24
+
     var openLink: (String) -> Void = { _ in }
     private(set) var scrollView = UIScrollView()
     private(set) var blockStack = UIStackView()
     private var blocks: [MarkdownBlock] = []
+    private var mountedCount = 0
+    private var mounting = false
+    private var pendingRestoreOffset: CGFloat?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = UIKitChassis.screen
         scrollView.backgroundColor = UIKitChassis.screen
         scrollView.alwaysBounceVertical = true
+        scrollView.delegate = self
         addSubview(scrollView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -1812,11 +1874,47 @@ final class FileViewerMarkdownContentView: UIView {
             blockStack.removeArrangedSubview(child)
             child.removeFromSuperview()
         }
-        for block in blocks { blockStack.addArrangedSubview(makeBlock(block)) }
-        setNeedsLayout()
-        layoutIfNeeded()
+        mountedCount = 0
+        // The QUIET watch swap keeps the reader where they were, so the fill
+        // has to reach the restored offset before it can be applied.
+        pendingRestoreOffset = oldOffset.y
+        mountBlocksIfNeeded()
+        pendingRestoreOffset = nil
         let maximum = max(0, scrollView.contentSize.height - scrollView.bounds.height)
         scrollView.contentOffset = CGPoint(x: 0, y: min(oldOffset.y, maximum))
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // A width or height change moves the fill line — the pane sizes this
+        // view only after `apply(blocks:)` has already run.
+        mountBlocksIfNeeded()
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        mountBlocksIfNeeded()
+    }
+
+    private func mountBlocksIfNeeded() {
+        guard !mounting, mountedCount < blocks.count else { return }
+        mounting = true
+        defer { mounting = false }
+        var passes = 0
+        while mountedCount < blocks.count, passes < Self.maximumMountPasses {
+            passes += 1
+            let reach = max(scrollView.contentOffset.y, pendingRestoreOffset ?? 0)
+                + max(scrollView.bounds.height, 1)
+                + Self.mountAhead
+            guard scrollView.contentSize.height < reach else { break }
+            let end = min(mountedCount + Self.mountBatch, blocks.count)
+            while mountedCount < end {
+                blockStack.addArrangedSubview(makeBlock(blocks[mountedCount]))
+                mountedCount += 1
+            }
+            // Resolve the new content height before deciding on another batch.
+            scrollView.setNeedsLayout()
+            scrollView.layoutIfNeeded()
+        }
     }
 
     private func makeBlock(_ block: MarkdownBlock) -> UIView {
@@ -1929,6 +2027,8 @@ final class FileViewerMarkdownContentView: UIView {
 @MainActor
 final class FileViewerMarkdownCodeFenceView: UIKitTallyBorderedView {
     private let fixedHeight: CGFloat
+    private let fenceText: NSAttributedString
+    private let textView = UITextView()
 
     init(language: CodeLanguage?, lines: [String]) {
         let highlighted = CodeHighlighter.highlight(
@@ -1962,15 +2062,21 @@ final class FileViewerMarkdownCodeFenceView: UIKitTallyBorderedView {
             if index < visualLines.count - 1 { text.append(NSAttributedString(string: "\n")) }
         }
         fixedHeight = ceil(font.lineHeight * CGFloat(visualLines.count)) + 20
+        fenceText = text
         super.init(frame: .zero)
         backgroundColor = UIKitChassis.chassis
         layer.cornerRadius = 6
         layer.cornerCurve = .continuous
         clipsToBounds = true
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+            (view: FileViewerMarkdownCodeFenceView, _: UITraitCollection) in
+            // Same rule as the prose blocks: TextKit caches the resolved
+            // token colors, so the fence has to be re-fed on a flip.
+            view.textView.attributedText = view.fenceText
+        }
 
         let scroll = UIScrollView()
         scroll.showsHorizontalScrollIndicator = false
-        let textView = UITextView()
         textView.backgroundColor = .clear
         textView.isEditable = false
         textView.isSelectable = true

--- a/Multiplex/Views/Terminal/FileViewerTreeColumn.swift
+++ b/Multiplex/Views/Terminal/FileViewerTreeColumn.swift
@@ -76,6 +76,9 @@ final class FileViewerTreeColumnView: UIView, UITableViewDataSource,
     private(set) var tableView = UITableView(frame: .zero, style: .plain)
 
     private let columnStack = UIStackView()
+    private var gitBlock: UIView?
+    private var gitDivider: UIView?
+    private var chromeRendered = false
     private var snapshot = FileViewerTreeColumnSnapshot(
         hostName: "",
         rootPath: "",
@@ -129,6 +132,7 @@ final class FileViewerTreeColumnView: UIView, UITableViewDataSource,
             forCellReuseIdentifier: FileViewerTreeMessageCell.reuseIdentifier
         )
         tableView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        buildChrome()
     }
 
     @available(*, unavailable)
@@ -154,14 +158,25 @@ final class FileViewerTreeColumnView: UIView, UITableViewDataSource,
         onChangedFilter: @escaping () -> Void = {},
         onSelect: @escaping (FileTree.Row) -> Void = { _ in }
     ) {
+        // The chrome is built once and mutated in place: `render` runs on every
+        // file selection and on every watch tick, and tearing the stack down
+        // would re-parent the table view under the reader's fingers (a
+        // decelerating flick stops dead, VoiceOver focus resets to the top).
+        let previous = chromeRendered ? self.snapshot : nil
+        let previousRows = displayRows
         self.snapshot = snapshot
         self.onUp = onUp
         self.onRepoDiff = onRepoDiff
         self.onChangedFilter = onChangedFilter
         self.onSelect = onSelect
-        rebuildChrome()
+        updateChrome(previous: previous)
+        chromeRendered = true
         rebuildDisplayRows()
-        tableView.reloadData()
+        if displayRows != previousRows {
+            tableView.reloadData()
+        } else if previous?.railPath != snapshot.railPath {
+            refreshCurrentRowHighlight()
+        }
     }
 
     func selectRow(at index: Int) {
@@ -238,12 +253,7 @@ final class FileViewerTreeColumnView: UIView, UITableViewDataSource,
         )
     }
 
-    private func rebuildChrome() {
-        for view in columnStack.arrangedSubviews {
-            columnStack.removeArrangedSubview(view)
-            view.removeFromSuperview()
-        }
-
+    private func buildChrome() {
         let location = UIKitChassisLabel(
             snapshot.locationLabel,
             size: 8,
@@ -253,22 +263,19 @@ final class FileViewerTreeColumnView: UIView, UITableViewDataSource,
         location.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         locationSourceLabel = location
 
+        let chip = UIKitChassisChip(
+            "UP",
+            accessibilityLabel: "Show the parent directory",
+            action: { [weak self] in self?.onUp() }
+        )
+        upChip = chip
+
         let headerStack = UIStackView(arrangedSubviews: [location])
         headerStack.axis = .horizontal
         headerStack.alignment = .center
         headerStack.spacing = 7
         headerStack.addArrangedSubview(makeFlexibleSpacer(minimumWidth: 4))
-        if snapshot.canHoistRoot {
-            let chip = UIKitChassisChip(
-                "UP",
-                accessibilityLabel: "Show the parent directory",
-                action: { [weak self] in self?.onUp() }
-            )
-            upChip = chip
-            headerStack.addArrangedSubview(chip)
-        } else {
-            upChip = nil
-        }
+        headerStack.addArrangedSubview(chip)
         columnStack.addArrangedSubview(inset(
             headerStack,
             horizontal: Self.headerHorizontalInset,
@@ -276,60 +283,99 @@ final class FileViewerTreeColumnView: UIView, UITableViewDataSource,
         ))
         columnStack.addArrangedSubview(makeDivider())
 
-        if snapshot.gitRoot != nil {
-            let branch = UILabel()
-            branch.text = "⎇ \(snapshot.branch ?? "—")"
-            branch.font = UIKitChassis.monoFont(10, weight: .semibold)
-            branch.textColor = UIKitChassis.signal
-            branch.lineBreakMode = .byTruncatingTail
-            branch.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-            branchLabel = branch
+        let branch = UILabel()
+        branch.font = UIKitChassis.monoFont(10, weight: .semibold)
+        branch.textColor = UIKitChassis.signal
+        branch.lineBreakMode = .byTruncatingTail
+        branch.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        branchLabel = branch
 
-            // The SwiftUI source used `.buttonStyle(.plain)`: the diff
-            // numbers are the complete visual treatment. A system button can
-            // acquire the platform's native button ground on newer releases,
-            // which turns this compact readout into an unrelated pill.
-            let counts = UIButton(type: .custom)
-            counts.backgroundColor = .clear
-            counts.contentEdgeInsets = .zero
-            counts.setAttributedTitle(Self.countsText(snapshot.shortStat), for: .normal)
-            counts.contentHorizontalAlignment = .leading
-            counts.accessibilityLabel = "Open the working tree's diff"
-            counts.hoverStyle = UIHoverStyle(
-                effect: .highlight,
-                shape: .rect(cornerRadius: 2)
-            )
-            counts.addAction(UIAction { [weak self] _ in self?.onRepoDiff() }, for: .touchUpInside)
-            countsButton = counts
+        // The SwiftUI source used `.buttonStyle(.plain)`: the diff
+        // numbers are the complete visual treatment. A system button can
+        // acquire the platform's native button ground on newer releases,
+        // which turns this compact readout into an unrelated pill.
+        let counts = UIButton(type: .custom)
+        counts.backgroundColor = .clear
+        counts.contentEdgeInsets = .zero
+        counts.contentHorizontalAlignment = .leading
+        counts.accessibilityLabel = "Open the working tree's diff"
+        counts.hoverStyle = UIHoverStyle(
+            effect: .highlight,
+            shape: .rect(cornerRadius: 2)
+        )
+        counts.addAction(UIAction { [weak self] _ in self?.onRepoDiff() }, for: .touchUpInside)
+        countsButton = counts
 
-            let changed = UIKitChassisChip(
-                "CHANGED",
-                prominent: snapshot.changedFilter,
-                accessibilityLabel: snapshot.changedFilter
-                    ? "Show the whole tree" : "Show only changed files",
-                action: { [weak self] in self?.onChangedFilter() }
-            )
-            changedChip = changed
+        let changed = UIKitChassisChip(
+            "CHANGED",
+            accessibilityLabel: "Show only changed files",
+            action: { [weak self] in self?.onChangedFilter() }
+        )
+        changedChip = changed
 
-            let gitStack = UIStackView(arrangedSubviews: [branch, counts])
-            gitStack.axis = .horizontal
-            gitStack.alignment = .center
-            gitStack.spacing = 8
-            gitStack.addArrangedSubview(makeFlexibleSpacer(minimumWidth: 4))
-            gitStack.addArrangedSubview(changed)
-            columnStack.addArrangedSubview(inset(
-                gitStack,
-                horizontal: Self.headerHorizontalInset,
-                vertical: Self.headerVerticalInset
-            ))
-            columnStack.addArrangedSubview(makeDivider())
-        } else {
-            branchLabel = nil
-            countsButton = nil
-            changedChip = nil
-        }
+        let gitStack = UIStackView(arrangedSubviews: [branch, counts])
+        gitStack.axis = .horizontal
+        gitStack.alignment = .center
+        gitStack.spacing = 8
+        gitStack.addArrangedSubview(makeFlexibleSpacer(minimumWidth: 4))
+        gitStack.addArrangedSubview(changed)
+        let gitRow = inset(
+            gitStack,
+            horizontal: Self.headerHorizontalInset,
+            vertical: Self.headerVerticalInset
+        )
+        let gitRule = makeDivider()
+        gitBlock = gitRow
+        gitDivider = gitRule
+        columnStack.addArrangedSubview(gitRow)
+        columnStack.addArrangedSubview(gitRule)
 
         columnStack.addArrangedSubview(tableView)
+        updateChrome(previous: nil)
+    }
+
+    /// Field-by-field, so an unchanged watch tick touches nothing. `previous`
+    /// is nil for the first pass, which then writes every value.
+    private func updateChrome(previous: FileViewerTreeColumnSnapshot?) {
+        let first = previous == nil
+        if first || previous?.locationLabel != snapshot.locationLabel {
+            locationSourceLabel?.setText(snapshot.locationLabel)
+        }
+        if first || previous?.canHoistRoot != snapshot.canHoistRoot {
+            upChip?.isHidden = !snapshot.canHoistRoot
+        }
+        let hasGit = snapshot.gitRoot != nil
+        if first || previous.map({ $0.gitRoot != nil }) != hasGit {
+            gitBlock?.isHidden = !hasGit
+            gitDivider?.isHidden = !hasGit
+        }
+        guard hasGit else { return }
+        if first || previous?.branch != snapshot.branch {
+            branchLabel?.text = "⎇ \(snapshot.branch ?? "—")"
+        }
+        if first || previous?.shortStat != snapshot.shortStat {
+            countsButton?.setAttributedTitle(
+                Self.countsText(snapshot.shortStat),
+                for: .normal
+            )
+        }
+        if first || previous?.changedFilter != snapshot.changedFilter {
+            changedChip?.isProminent = snapshot.changedFilter
+            changedChip?.accessibilityLabel = snapshot.changedFilter
+                ? "Show the whole tree" : "Show only changed files"
+        }
+    }
+
+    /// The current row's ground is snapshot state, not row state, so a rail
+    /// move repaints the cells on screen instead of reloading the table.
+    private func refreshCurrentRowHighlight() {
+        for indexPath in tableView.indexPathsForVisibleRows ?? [] {
+            guard displayRows.indices.contains(indexPath.row),
+                  case .tree(let row) = displayRows[indexPath.row],
+                  let cell = tableView.cellForRow(at: indexPath) as? FileViewerTreeRowCell
+            else { continue }
+            cell.apply(row, isCurrent: snapshot.railPath == row.entry.path)
+        }
     }
 
     private func rebuildDisplayRows() {
@@ -401,7 +447,7 @@ final class FileViewerTreeColumnView: UIView, UITableViewDataSource,
         return result
     }
 
-    private enum DisplayRow {
+    private enum DisplayRow: Equatable {
         case failure(String)
         case empty(String)
         case tree(FileTree.Row)
@@ -555,6 +601,10 @@ final class FileViewerTreeMessageCell: UITableViewCell {
     required init?(coder: NSCoder) { fatalError("unused") }
 
     func apply(_ text: String, color: UIColor, chassisCaps: Bool) {
+        // Body copy keeps Dynamic Type; the caps branch is chassis chrome at a
+        // fixed size (already scaled by `Theme.typeScale`) and must not
+        // compound with it.
+        messageLabel.adjustsFontForContentSizeCategory = !chassisCaps
         let inset: CGFloat = chassisCaps ? 12 : 10
         leadingConstraint.constant = inset
         trailingConstraint.constant = -inset

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -279,6 +279,10 @@ final class TerminalSurfaceView: UIView {
         }
         if coordinator.appliedTheme != configuration.theme {
             apply(configuration.theme, to: view)
+        } else if coordinator.appliedCaretVisible != (controller.status == .live) {
+            // The pane re-runs this update on every observed status change,
+            // which is where a connecting tab earns its caret back.
+            applyCaretColor(theme: configuration.theme, to: view)
         }
         #if !os(visionOS)
         coordinator.updateBottomChromeHeight(
@@ -304,7 +308,7 @@ final class TerminalSurfaceView: UIView {
     private func apply(_ theme: TerminalTheme, to view: TerminalView) {
         view.nativeBackgroundColor = UIColor(theme.background)
         view.nativeForegroundColor = UIColor(theme.foreground)
-        view.caretColor = UIColor(theme.cursor)
+        applyCaretColor(theme: theme, to: view)
         view.selectedTextBackgroundColor = UIColor(theme.cursor).withAlphaComponent(0.3)
         // SwiftTerm 1.15 adds an explicit selected-text foreground whose
         // upstream default is black. Preserve the theme's former text color,
@@ -328,6 +332,17 @@ final class TerminalSurfaceView: UIView {
         coordinator.appliedTheme = theme
     }
 
+    /// The caret carries the theme's cursor color — tally red in the house
+    /// themes — and SwiftTerm parks it at row 0 / column 0 while the screen is
+    /// still empty. Over the CONNECTING panel that lone red glyph reads as a
+    /// rendering fault, so the caret stays invisible until the tab's transport
+    /// is actually live.
+    private func applyCaretColor(theme: TerminalTheme, to view: TerminalView) {
+        let visible = controller.status == .live
+        view.caretColor = visible ? UIColor(theme.cursor) : .clear
+        coordinator.appliedCaretVisible = visible
+    }
+
     /// Forwards SwiftTerm delegate events to the session controller.
     /// SwiftTerm calls these on the main thread; `assumeIsolated` bridges
     /// into the controller's MainActor isolation.
@@ -340,6 +355,9 @@ final class TerminalSurfaceView: UIView {
         weak var linkHoverOverlay: TerminalLinkHoverOverlay?
         #endif
         var appliedTheme: TerminalTheme?
+        /// Whether the last applied caret color was the theme's cursor (live)
+        /// or clear. `nil` until the first application.
+        var appliedCaretVisible: Bool?
 
         init(controller: TerminalSessionController) {
             self.controller = controller

--- a/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
+++ b/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
@@ -200,12 +200,13 @@ enum TerminalFocusArbiter {
             }
             return
         }
-        // Foregrounding is not an ownership election. On iPadOS and
-        // visionOS several scenes activate together; allowing a nil owner to
-        // be claimed here makes notification order choose an arbitrary
-        // window. Fresh/live panes and explicit tab/window interactions use
-        // `claim` directly.
-        guard current === view else { return }
+        // An empty ownership IS re-elected here, on purpose: the two ways the
+        // app-wide owner goes nil have no other claim site. Releasing the app
+        // lock's `inputSuppressed` cleared it, and closing the focused window
+        // deallocated its TerminalView out of this weak reference — in both
+        // cases the terminal the user is looking at would otherwise sit there
+        // with no keyboard until they tap its grid.
+        guard current === view || current == nil else { return }
         claim(view)
     }
 

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -1188,6 +1188,22 @@ final class TerminalKeyClusterContext {
         #endif
     }
 
+    /// Block-based registrations outlive the object that installed them, and
+    /// `update(controller:)` only retires the previous terminal's — a context
+    /// that goes away with its window would otherwise strand every one it
+    /// still holds.
+    deinit {
+        let center = NotificationCenter.default
+        if let controlResetObserver {
+            center.removeObserver(controlResetObserver)
+        }
+        #if DEBUG
+        for observer in debugObservers {
+            center.removeObserver(observer)
+        }
+        #endif
+    }
+
     func update(controller: TerminalSessionController?) {
         let controllerChanged = self.controller !== controller
         self.controller = controller
@@ -1497,20 +1513,26 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
             : metric
         var x: CGFloat = 12
         let y: CGFloat = 9
+        // `layout(range:)` leaves the cursor on the last key's trailing edge
+        // with no spacing appended, so a group boundary advances by the whole
+        // `groupGap` — the pre-UIKit `HStack(spacing: groupGap)` gap, and what
+        // the reserved slab widths below already pay for. Subtracting
+        // `spacing` here packed the keys left and dumped the slack on the
+        // right edge.
         switch role {
         case .leading:
             layout(range: keys.indices, x: &x, y: y, spacing: activeMetric.spacing)
         case .trailing:
             layout(range: 0..<4, x: &x, y: y, spacing: activeMetric.spacing)
-            x += activeMetric.groupGap - activeMetric.spacing
+            x += activeMetric.groupGap
             layout(range: 4..<keys.count, x: &x, y: y, spacing: activeMetric.groupGap)
         case .standalone:
             layout(range: 0..<3, x: &x, y: y, spacing: activeMetric.spacing)
-            x += activeMetric.groupGap - activeMetric.spacing
+            x += activeMetric.groupGap
             let arrowCount = variant == .minimal ? 0 : 4
             if arrowCount > 0 {
                 layout(range: 3..<(3 + arrowCount), x: &x, y: y, spacing: activeMetric.spacing)
-                x += activeMetric.groupGap - activeMetric.spacing
+                x += activeMetric.groupGap
             }
             layout(
                 range: (3 + arrowCount)..<keys.count,

--- a/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
@@ -405,11 +405,13 @@ final class TerminalPaneViewController: UIViewController, UIDropInteractionDeleg
         }
     }
 
+    /// Deliberately unconditional in the transport's status: becoming the
+    /// visible tab must move the app-wide input session onto this pane even
+    /// when it is connecting or ended, or the tab that just went off screen
+    /// keeps the keyboard. The `.live` condition belongs only to the
+    /// status-change caller in `observeAndRender`.
     private func focusIfAppropriate() {
-        guard configuration.isActive,
-              configuration.focusAllowed,
-              configuration.controller?.status == .live
-        else { return }
+        guard configuration.isActive, configuration.focusAllowed else { return }
         configuration.controller?.focusTerminal()
     }
 
@@ -513,7 +515,10 @@ final class TerminalPaneViewController: UIViewController, UIDropInteractionDeleg
 
         let detail = UILabel()
         detail.text = "The tab can't reconnect because its host no longer exists in the deck."
-        detail.font = UIKitChassis.uiFont(13)
+        // Body copy, not chrome: a semantic style keeps Dynamic Type (fixed
+        // `uiFont` sizes ignore it, and the two mechanisms never compound).
+        detail.font = .preferredFont(forTextStyle: .subheadline)
+        detail.adjustsFontForContentSizeCategory = true
         detail.textColor = UIKitChassis.signal2
         detail.textAlignment = .center
         detail.numberOfLines = 0
@@ -590,7 +595,8 @@ final class TerminalPanePanelView: UIKitTallyBorderedView {
         if let reason {
             let label = UILabel()
             label.text = reason
-            label.font = UIKitChassis.uiFont(13)
+            label.font = .preferredFont(forTextStyle: .subheadline)
+            label.adjustsFontForContentSizeCategory = true
             label.textColor = UIKitChassis.signal2
             label.textAlignment = .center
             label.numberOfLines = 0
@@ -621,19 +627,22 @@ final class TerminalPanePanelView: UIKitTallyBorderedView {
 
 @MainActor
 final class TerminalTallyLampView: UIView {
+    private let dot = UIView()
+    private let color: UIColor
+
     init(caption: String, color: UIColor) {
+        self.color = color
         super.init(frame: .zero)
         isAccessibilityElement = true
         accessibilityLabel = caption.lowercased()
 
-        let dot = UIView()
         dot.backgroundColor = color
         let diameter = 7 * Theme.typeScale
         dot.layer.cornerRadius = diameter / 2
-        dot.layer.shadowColor = color.cgColor
         dot.layer.shadowOpacity = 0.7
         dot.layer.shadowRadius = 4
         dot.layer.shadowOffset = .zero
+        refreshLampGlow()
         dot.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             dot.widthAnchor.constraint(equalToConstant: diameter),
@@ -669,6 +678,22 @@ final class TerminalTallyLampView: UIView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        refreshLampGlow()
+    }
+
+    /// The dot's fill and the caption follow the appearance on their own; a
+    /// CGColor does not — it flattens whatever traits are current when it is
+    /// taken, and these lamps are built from observation renders rather than
+    /// a UIKit callback. Resolve the glow against this view's own traits and
+    /// re-resolve whenever the appearance flips.
+    private func refreshLampGlow() {
+        dot.layer.shadowColor = color.resolvedColor(with: traitCollection).cgColor
+    }
 }
 
 @MainActor
@@ -748,7 +773,8 @@ final class TerminalContextBarView: UIKitTallyBorderedView {
         case .failed(let message):
             let messageLabel = UILabel()
             messageLabel.text = message
-            messageLabel.font = UIKitChassis.uiFont(11)
+            messageLabel.font = .preferredFont(forTextStyle: .footnote)
+            messageLabel.adjustsFontForContentSizeCategory = true
             messageLabel.textColor = UIKitChassis.signal2
             messageLabel.numberOfLines = 2
             messageLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 320).isActive = true
@@ -856,6 +882,16 @@ final class TerminalKeyboardLockedView: UIKitTallyBorderedView {
         // behind the TALLY lock badge.
         let mic = UIButton(type: .custom)
         mic.setImage(UIImage(systemName: isDictating ? "mic.fill" : "mic"), for: .normal)
+        // Type-locked chrome glyph: authored point size, riding `typeScale`
+        // like the padlock beside it. Without a configuration UIKit draws it
+        // at the default body symbol size and never scales it on Mac.
+        mic.setPreferredSymbolConfiguration(
+            UIImage.SymbolConfiguration(
+                pointSize: 12 * Theme.typeScale,
+                weight: .semibold
+            ),
+            forImageIn: .normal
+        )
         mic.tintColor = isDictating ? UIKitChassis.chassis : UIKitChassis.signal2
         mic.backgroundColor = isDictating ? UIKitChassis.signal2 : .clear
         mic.accessibilityLabel = isDictating ? "Stop dictation" : "Dictate"

--- a/Multiplex/Views/Terminal/TerminalTabStrip.swift
+++ b/Multiplex/Views/Terminal/TerminalTabStrip.swift
@@ -224,8 +224,11 @@ final class TerminalTabStripView: UIView {
                     canSplit: key.cells[index].canSplit
                 )
             }
+            // Keep invalidation local. Each host already requests its own
+            // geometry pass after `apply`; walking the ancestor chain here can
+            // pull unrelated pending descendants into a shell animation.
             invalidateIntrinsicContentSize()
-            requestHostSizingPass()
+            setNeedsLayout()
             return
         }
 
@@ -250,21 +253,7 @@ final class TerminalTabStripView: UIView {
             return cell
         }
         invalidateIntrinsicContentSize()
-        requestHostSizingPass()
-    }
-
-    /// The host sizes this strip from `fittingContentSize()` during ITS OWN
-    /// layout pass (the window's `layoutNativeChrome`), and a tally-observed
-    /// render can change that size with no bounds change anywhere — nothing
-    /// else re-requests the pass, so a stale strip frame would stick until
-    /// rotation (user-reported). Dirty the whole ancestor chain so whichever
-    /// view the host actually lays out runs again.
-    private func requestHostSizingPass() {
-        var ancestor: UIView? = self
-        while let view = ancestor {
-            view.setNeedsLayout()
-            ancestor = view.superview
-        }
+        setNeedsLayout()
     }
 }
 
@@ -420,37 +409,28 @@ final class TerminalTabCell: UIControl {
             self.canSplit = canSplit
             accessibilityCustomActions = makeAccessibilityActions()
         }
+        let nextLabelText = Self.label(for: item)
+        if labelText != nextLabelText {
+            labelText = nextLabelText
+            sourceLabel.setText(nextLabelText)
+        }
         if isActive != item.isActive {
             isActive = item.isActive
             backgroundColor = Self.ground(isActive: item.isActive)
             accessibilityTraits = Self.traits(isActive: item.isActive)
-            // `UIKitChassisLabel` bakes its ink at init, so an active-ground
-            // change swaps the label. The cell — the control under the
-            // finger — is untouched.
-            labelText = Self.label(for: item)
-            replaceSourceLabel(color: Self.ink(isActive: item.isActive))
-        } else if labelText != Self.label(for: item) {
-            labelText = Self.label(for: item)
-            sourceLabel.setText(labelText)
+            // Keep the arranged-subview tree untouched while this control's
+            // own touch action is switching tabs. The host may measure the
+            // strip before that action has unwound.
+            sourceLabel.setInk(Self.ink(isActive: item.isActive))
         }
         accessibilityLabel = Self.accessibilityLabel(for: item)
-        guard self.tallyState != tallyState else { return }
-        self.tallyState = tallyState
-        dotView?.backgroundColor = tallyState.color
-        refreshLampShadow()
-    }
-
-    private func replaceSourceLabel(color: UIColor) {
-        let replacement = UIKitChassisLabel(labelText, size: 10, color: color)
-        replacement.isAccessibilityElement = false
-        if let index = contentStack.arrangedSubviews.firstIndex(of: sourceLabel) {
-            contentStack.insertArrangedSubview(replacement, at: index)
-        } else {
-            contentStack.addArrangedSubview(replacement)
+        if self.tallyState != tallyState {
+            self.tallyState = tallyState
+            dotView?.backgroundColor = tallyState.color
+            refreshLampShadow()
         }
-        contentStack.removeArrangedSubview(sourceLabel)
-        sourceLabel.removeFromSuperview()
-        sourceLabel = replacement
+        invalidateIntrinsicContentSize()
+        setNeedsLayout()
     }
 
     private static func label(for item: TerminalTabStrip.Item) -> String {

--- a/Multiplex/Views/Terminal/TerminalTabStrip.swift
+++ b/Multiplex/Views/Terminal/TerminalTabStrip.swift
@@ -20,7 +20,19 @@ final class TerminalTabStripView: UIView {
             var canSplit: Bool
         }
 
+        /// What a cell's *anatomy* depends on: its identity and whether it
+        /// carries a tally dot at all. Everything else a render can change is
+        /// mutable in place.
+        struct Structure: Equatable {
+            var id: UUID
+            var isAuxiliary: Bool
+        }
+
         var cells: [Cell]
+
+        var structure: [Structure] {
+            cells.map { Structure(id: $0.id, isAuxiliary: $0.isAuxiliary) }
+        }
     }
 
     private(set) var cells: [TerminalTabCell] = []
@@ -32,6 +44,9 @@ final class TerminalTabStripView: UIView {
     private var split: (UUID) -> Void = { _ in }
     private var close: (UUID) -> Void = { _ in }
     private var configurationGeneration = 0
+    /// The session controllers the live observation registration covers, in
+    /// item order. `nil` until the first arming.
+    private var observedControllers: [ObjectIdentifier]?
     private var renderedKey: RenderKey?
 
     override init(frame: CGRect) {
@@ -58,13 +73,25 @@ final class TerminalTabStripView: UIView {
     /// The SwiftUI source let the source-label cells determine the strip's
     /// height. Keep that intrinsic measurement explicit so every host (the
     /// iOS rail and the visionOS ornament) consumes the same geometry.
+    ///
+    /// Arithmetic on purpose, never a constraint solve: the stack is
+    /// required-pinned to this frame-managed view, and asking that live
+    /// subtree to fit a zero proposal from inside a layout pass can COMMIT
+    /// the degenerate solve instead of rolling it back — every authored
+    /// constant came out multiplied by one tiny factor and the rail drew
+    /// stacked glyphs over dead hit regions until a bounds change (device
+    /// rotation) forced a fresh pass (user-reported).
     func fittingContentSize() -> CGSize {
-        let fitted = stackView.systemLayoutSizeFitting(
-            UIView.layoutFittingCompressedSize,
-            withHorizontalFittingPriority: .fittingSizeLevel,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-        return CGSize(width: ceil(fitted.width), height: ceil(fitted.height))
+        guard !cells.isEmpty else { return .zero }
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+        for cell in cells {
+            let size = cell.intrinsicContentSize
+            width += size.width
+            height = max(height, size.height)
+        }
+        width += Self.cellSpacing * CGFloat(cells.count - 1)
+        return CGSize(width: ceil(width), height: ceil(height))
     }
 
     override var intrinsicContentSize: CGSize {
@@ -85,6 +112,20 @@ final class TerminalTabStripView: UIView {
         self.close = close
         accessibilityLabel = "\(items.count) tabs"
 
+        // The window re-renders this strip on every observed change of its
+        // own (a ~5 s host probe is enough), and an Observation registration
+        // can only be superseded, never cancelled — re-arming per render
+        // would strand one dead tracking per render against every tab's
+        // still-`.live` status. What the tracking actually covers is the tab
+        // controllers' identities, so re-arm only when that list changes and
+        // otherwise let the standing registration do its job, rendering from
+        // a plain (unregistered) read.
+        let tracked = trackedControllerIdentities()
+        guard tracked != observedControllers else {
+            render(states: items.map { TerminalTabTallyState(item: $0) })
+            return
+        }
+        observedControllers = tracked
         configurationGeneration &+= 1
         observeStatusesAndRender(generation: configurationGeneration)
     }
@@ -128,6 +169,15 @@ final class TerminalTabStripView: UIView {
         allowsSplit && items.count > 1 && items.contains(where: { $0.id == id })
     }
 
+    /// Everything `TerminalTabTallyState` reads observably is one session
+    /// controller's `status`, so this list is the whole tracked set.
+    private func trackedControllerIdentities() -> [ObjectIdentifier] {
+        items.compactMap { item in
+            guard !item.isAuxiliary, let controller = item.controller else { return nil }
+            return ObjectIdentifier(controller)
+        }
+    }
+
     /// Observation callbacks are one-shot. Each status change snapshots and
     /// re-arms the native strip, while a new item configuration invalidates
     /// callbacks registered for its predecessor.
@@ -156,7 +206,28 @@ final class TerminalTabStripView: UIView {
             )
         })
         guard renderedKey != key else { return }
+        let previousStructure = renderedKey?.structure
         renderedKey = key
+
+        // A cell is a UIControl a finger can already be tracking, and this
+        // strip re-renders on every observed status change (a ~5 s host probe
+        // is enough) and on every tab switch. Destroying and recreating the
+        // cells there cancels that in-flight touch, which is what makes a tab
+        // press read as dead. Nothing structural moved, so mutate in place.
+        if previousStructure == key.structure,
+           cells.count == key.cells.count,
+           items.count == key.cells.count {
+            for index in key.cells.indices {
+                cells[index].update(
+                    item: items[index],
+                    tallyState: states[index],
+                    canSplit: key.cells[index].canSplit
+                )
+            }
+            invalidateIntrinsicContentSize()
+            requestHostSizingPass()
+            return
+        }
 
         for arrangedSubview in stackView.arrangedSubviews {
             stackView.removeArrangedSubview(arrangedSubview)
@@ -179,6 +250,21 @@ final class TerminalTabStripView: UIView {
             return cell
         }
         invalidateIntrinsicContentSize()
+        requestHostSizingPass()
+    }
+
+    /// The host sizes this strip from `fittingContentSize()` during ITS OWN
+    /// layout pass (the window's `layoutNativeChrome`), and a tally-observed
+    /// render can change that size with no bounds change anywhere — nothing
+    /// else re-requests the pass, so a stale strip frame would stick until
+    /// rotation (user-reported). Dirty the whole ancestor chain so whichever
+    /// view the host actually lays out runs again.
+    private func requestHostSizingPass() {
+        var ancestor: UIView? = self
+        while let view = ancestor {
+            view.setNeedsLayout()
+            ancestor = view.superview
+        }
     }
 }
 
@@ -226,7 +312,7 @@ final class TerminalTabCell: UIControl {
     static let lampSize: CGFloat = 6
 
     let itemID: UUID
-    let tallyState: TerminalTabTallyState
+    private(set) var tallyState: TerminalTabTallyState
     private(set) var dotView: UIView?
     private(set) var sourceLabel: UIKitChassisLabel
 
@@ -234,7 +320,9 @@ final class TerminalTabCell: UIControl {
     private let makeMenu: () -> UIMenu
     private let split: () -> Void
     private let close: () -> Void
-    private let canSplit: Bool
+    private var canSplit: Bool
+    private var isActive: Bool
+    private var labelText: String
     private let contentStack = UIStackView()
 
     init(
@@ -253,22 +341,24 @@ final class TerminalTabCell: UIControl {
         self.split = split
         self.close = close
         self.canSplit = canSplit
+        isActive = item.isActive
+        labelText = Self.label(for: item)
         sourceLabel = UIKitChassisLabel(
-            item.hostName.map { "\(item.title) · \($0)" } ?? item.title,
+            labelText,
             size: 10,
-            color: item.isActive ? UIKitChassis.signal : UIKitChassis.signal2
+            color: Self.ink(isActive: item.isActive)
         )
         super.init(frame: .zero)
 
-        backgroundColor = item.isActive ? UIKitChassis.bezelHi : UIKitChassis.chassis
+        backgroundColor = Self.ground(isActive: item.isActive)
         layer.borderWidth = 1
         refreshBorderAndLamp()
         hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 3))
         isContextMenuInteractionEnabled = true
 
         isAccessibilityElement = true
-        accessibilityTraits = item.isActive ? [.button, .selected] : .button
-        accessibilityLabel = "\(item.title) tab\(item.isActive ? ", active" : "")"
+        accessibilityTraits = Self.traits(isActive: item.isActive)
+        accessibilityLabel = Self.accessibilityLabel(for: item)
         accessibilityCustomActions = makeAccessibilityActions()
 
         contentStack.axis = .horizontal
@@ -319,15 +409,82 @@ final class TerminalTabCell: UIControl {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
 
+    /// In-place refresh for a cell whose identity and anatomy are unchanged.
+    /// The control itself survives, so a press already tracking it does too.
+    func update(
+        item: TerminalTabStrip.Item,
+        tallyState: TerminalTabTallyState,
+        canSplit: Bool
+    ) {
+        if self.canSplit != canSplit {
+            self.canSplit = canSplit
+            accessibilityCustomActions = makeAccessibilityActions()
+        }
+        if isActive != item.isActive {
+            isActive = item.isActive
+            backgroundColor = Self.ground(isActive: item.isActive)
+            accessibilityTraits = Self.traits(isActive: item.isActive)
+            // `UIKitChassisLabel` bakes its ink at init, so an active-ground
+            // change swaps the label. The cell — the control under the
+            // finger — is untouched.
+            labelText = Self.label(for: item)
+            replaceSourceLabel(color: Self.ink(isActive: item.isActive))
+        } else if labelText != Self.label(for: item) {
+            labelText = Self.label(for: item)
+            sourceLabel.setText(labelText)
+        }
+        accessibilityLabel = Self.accessibilityLabel(for: item)
+        guard self.tallyState != tallyState else { return }
+        self.tallyState = tallyState
+        dotView?.backgroundColor = tallyState.color
+        refreshLampShadow()
+    }
+
+    private func replaceSourceLabel(color: UIColor) {
+        let replacement = UIKitChassisLabel(labelText, size: 10, color: color)
+        replacement.isAccessibilityElement = false
+        if let index = contentStack.arrangedSubviews.firstIndex(of: sourceLabel) {
+            contentStack.insertArrangedSubview(replacement, at: index)
+        } else {
+            contentStack.addArrangedSubview(replacement)
+        }
+        contentStack.removeArrangedSubview(sourceLabel)
+        sourceLabel.removeFromSuperview()
+        sourceLabel = replacement
+    }
+
+    private static func label(for item: TerminalTabStrip.Item) -> String {
+        item.hostName.map { "\(item.title) · \($0)" } ?? item.title
+    }
+
+    private static func accessibilityLabel(for item: TerminalTabStrip.Item) -> String {
+        "\(item.title) tab\(item.isActive ? ", active" : "")"
+    }
+
+    private static func ink(isActive: Bool) -> UIColor {
+        isActive ? UIKitChassis.signal : UIKitChassis.signal2
+    }
+
+    private static func ground(isActive: Bool) -> UIColor {
+        isActive ? UIKitChassis.bezelHi : UIKitChassis.chassis
+    }
+
+    private static func traits(isActive: Bool) -> UIAccessibilityTraits {
+        isActive ? [.button, .selected] : .button
+    }
+
     override var intrinsicContentSize: CGSize {
-        let content = contentStack.systemLayoutSizeFitting(
-            UIView.layoutFittingCompressedSize,
-            withHorizontalFittingPriority: .fittingSizeLevel,
-            verticalFittingPriority: .fittingSizeLevel
-        )
+        // Arithmetic from the label's text measurement and the authored
+        // constants — contentStack is required-pinned to the edges, so the
+        // cell's size is fully determined without asking the engine. A
+        // nested zero-proposal fit here, running while the strip's own
+        // measurement was in flight, is what collapsed the whole rail.
+        let label = sourceLabel.intrinsicContentSize
+        let lamp = dotView == nil ? 0 : Self.lampSize
+        let lampWidth = dotView == nil ? 0 : Self.lampSize + Self.contentSpacing
         return CGSize(
-            width: ceil(content.width + Self.horizontalInset * 2),
-            height: ceil(content.height + Self.verticalInset * 2)
+            width: ceil(label.width + lampWidth + Self.horizontalInset * 2),
+            height: ceil(max(label.height, lamp) + Self.verticalInset * 2)
         )
     }
 

--- a/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
+++ b/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
@@ -525,11 +525,10 @@ final class TerminalVisionTabOrnamentHostView: UIView {
     }
 
     private func tabStripSize() -> CGSize {
-        let measured = tabStrip.systemLayoutSizeFitting(
-            CGSize(width: UIView.layoutFittingCompressedSize.width, height: 30),
-            withHorizontalFittingPriority: .fittingSizeLevel,
-            verticalFittingPriority: .required
-        )
+        // `TerminalTabStripView` owns an arithmetic fitting contract. Do not
+        // feed its live, edge-pinned stack back through Auto Layout while a
+        // pinch action may be updating the selected cell in place.
+        let measured = tabStrip.fittingContentSize()
         return CGSize(width: max(1, ceil(measured.width)), height: 30)
     }
 }

--- a/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
+++ b/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
@@ -62,8 +62,17 @@ final class TerminalVisionOrnamentState {
     private(set) var activeTerminalController: TerminalSessionController?
     private(set) var umdController: UIViewController?
     private(set) var helperController: AgentHelperStripViewController?
+    /// The width the console row reserves for the mounted UMD. Held here
+    /// rather than measured inside the ornament body: the bar re-renders on
+    /// its own observations (a mosh contact loss swaps LIVE for the wider
+    /// NO LINK lamp) that the window's render pass never sees, and a stale
+    /// reservation squeezes the bar the UMD must never compress.
+    private(set) var umdContentSize: CGSize = .zero
 
     let topHostView: TerminalVisionTabOrnamentHostView
+    /// One key-cluster owner per ornament — the latch state and the DEBUG
+    /// proof hook stay single-owner across every fitting candidate.
+    let keyClusterContext = TerminalKeyClusterContext()
 
     init(tabStrip: TerminalTabStripView) {
         topHostView = TerminalVisionTabOrnamentHostView(tabStrip: tabStrip)
@@ -94,15 +103,27 @@ final class TerminalVisionOrnamentState {
         self.umdController = umdController
         self.helperController = nextHelper
         presentation = nextPresentation
+        refreshUMDContentSize()
         guard changed || forceRevision else { return }
         revision &+= 1
         topHostView.refreshFittingSize()
+    }
+
+    /// Re-derives the console row's reserved UMD geometry. Called on every
+    /// window render and whenever the mounted bar reports its own size change,
+    /// so the ornament never frames new status content at the old width.
+    func refreshUMDContentSize() {
+        let size = (umdController as? UMDBarViewController)?
+            .fittingContentSize(for: nil) ?? .zero
+        guard umdContentSize != size else { return }
+        umdContentSize = size
     }
 
     func clear() {
         activeTerminalController = nil
         umdController = nil
         helperController = nil
+        umdContentSize = .zero
         presentation = TerminalVisionOrnamentPresentation(
             showsTopSourceLabels: false,
             bottom: .hidden,
@@ -234,17 +255,27 @@ private struct TerminalVisionBottomOrnament: View {
                 TerminalVisionOrnamentWidthClamp(
                     maxWidth: state.presentation.maximumConsoleWidth
                 ) {
-                    let umdSize = (state.umdController as? UMDBarViewController)?
-                        .fittingContentSize(for: nil) ?? .zero
+                    // Observed, not measured here: the bar's own re-renders
+                    // move this width without a window render behind them.
                     TerminalKeyCluster(
                         controller: state.activeTerminalController,
-                        centerSize: umdSize
+                        centerSize: state.umdContentSize,
+                        context: state.keyClusterContext
                     ) {
                         if let umd = state.umdController {
                             TerminalVisionControllerMount(
                                 controller: umd,
                                 sizing: .terminalUMD,
-                                revision: state.revision
+                                revision: state.revision,
+                                onContentSizeChange: { [state] in
+                                    // The bar reports mid-layout; take the
+                                    // new reservation on the next turn so
+                                    // the ornament is never re-entered
+                                    // during its own update.
+                                    Task { @MainActor in
+                                        state.refreshUMDContentSize()
+                                    }
+                                }
                             )
                             .fixedSize()
                         }
@@ -339,15 +370,22 @@ struct TerminalKeyCluster<Center: View>: View {
     var controller: TerminalSessionController?
     private let center: Center?
     private let centerSize: CGSize
-    @State private var context = TerminalKeyClusterContext()
+    /// Supplied by the owner, never `@State`: the struct is rebuilt on every
+    /// ornament revision, and a default-expression context would mint (and
+    /// register) a throwaway owner each time. One instance per ornament keeps
+    /// the CTRL latch and the DEBUG proof hook single-owner, as the shell
+    /// layout's own long-lived context does.
+    private let context: TerminalKeyClusterContext
 
     init(
         controller: TerminalSessionController?,
         centerSize: CGSize,
+        context: TerminalKeyClusterContext? = nil,
         @ViewBuilder center: () -> Center
     ) {
         self.controller = controller
         self.centerSize = centerSize
+        self.context = context ?? TerminalKeyClusterContext()
         self.center = center()
     }
 
@@ -426,8 +464,12 @@ struct TerminalKeyCluster<Center: View>: View {
 }
 
 extension TerminalKeyCluster where Center == EmptyView {
-    init(controller: TerminalSessionController?) {
+    init(
+        controller: TerminalSessionController?,
+        context: TerminalKeyClusterContext? = nil
+    ) {
         self.controller = controller
+        self.context = context ?? TerminalKeyClusterContext()
         centerSize = .zero
         center = nil
     }
@@ -528,9 +570,11 @@ private struct TerminalVisionControllerMount: UIViewControllerRepresentable {
     let controller: UIViewController
     let sizing: TerminalVisionControllerSizing
     let revision: Int
+    var onContentSizeChange: (() -> Void)?
 
     func makeUIViewController(context: Context) -> TerminalVisionControllerHost {
         let host = TerminalVisionControllerHost()
+        host.onContentSizeChange = onContentSizeChange
         host.update(content: controller, sizing: sizing)
         return host
     }
@@ -540,6 +584,7 @@ private struct TerminalVisionControllerMount: UIViewControllerRepresentable {
         context: Context
     ) {
         _ = revision
+        host.onContentSizeChange = onContentSizeChange
         host.update(content: controller, sizing: sizing)
     }
 
@@ -547,6 +592,7 @@ private struct TerminalVisionControllerMount: UIViewControllerRepresentable {
         _ host: TerminalVisionControllerHost,
         coordinator: Void
     ) {
+        host.onContentSizeChange = nil
         host.update(content: nil, sizing: .terminalUMD)
     }
 
@@ -561,6 +607,10 @@ private struct TerminalVisionControllerMount: UIViewControllerRepresentable {
 
 @MainActor
 private final class TerminalVisionControllerHost: UIViewController {
+    /// The mounted child is the only witness to its own content changes; the
+    /// ornament reserves its geometry and has to hear about them.
+    var onContentSizeChange: (() -> Void)?
+
     private var content: UIViewController?
     private var sizing = TerminalVisionControllerSizing.terminalUMD
 
@@ -582,6 +632,7 @@ private final class TerminalVisionControllerHost: UIViewController {
         let size = fittingSize(proposedWidth: nil)
         if preferredContentSize != size { preferredContentSize = size }
         parent?.preferredContentSizeDidChange(forChildContentContainer: self)
+        onContentSizeChange?()
     }
 
     func update(

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -1621,23 +1621,9 @@ extension TerminalWindowViewController {
                     for: shell?.availableWidth ?? bounds.width
                 ).height
             }
-            // This view is frame-managed below, so its synthesized
-            // autoresizing constraints are *required* at whatever width it
-            // currently carries — a zero or stale one fights a required
-            // fitting width and the solve collapses the content onto the
-            // origin. Seed the proposal, then ask below required.
-            let umdView: UIView = umdController.view
-            if umdView.bounds.width != bounds.width {
-                umdView.frame = CGRect(
-                    x: umdView.frame.minX,
-                    y: umdView.frame.minY,
-                    width: bounds.width,
-                    height: umdView.frame.height
-                )
-            }
-            return umdView.systemLayoutSizeFitting(
+            return umdController.view.systemLayoutSizeFitting(
                 CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height),
-                withHorizontalFittingPriority: .defaultHigh,
+                withHorizontalFittingPriority: .required,
                 verticalFittingPriority: .fittingSizeLevel
             ).height
         }()

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -632,6 +632,7 @@ final class TerminalWindowViewController: UIViewController,
         rootView.setShellMode(shell != nil)
         layoutNativeChrome()
         presentPendingFeatureIfPossible()
+        applyAppearanceToPresentedFeature()
     }
 
     // MARK: Route reconciliation
@@ -881,13 +882,16 @@ final class TerminalWindowViewController: UIViewController,
 
     // MARK: Focus and probes
 
+    /// Keyboard focus follows the visible tab whatever its transport is
+    /// doing. Claiming is what resigns the tab that just went off screen, so
+    /// gating this on `.live` would leave a hidden live session first
+    /// responder while a connecting/ended pane is on screen — every keystroke
+    /// would land invisibly in the session behind it.
     private func claimActiveTerminalFocusIfAllowed() {
         guard terminalFocusAllowed,
               activeTab?.isAuxiliaryPane != true
         else { return }
-        if activeController?.status == .live {
-            activeController?.focusTerminal()
-        }
+        activeController?.focusTerminal()
     }
 
     /// Appearance and scene activation are not user focus requests. Several
@@ -1216,19 +1220,12 @@ extension TerminalWindowViewController {
             tabStrip.removeFromSuperview()
             rootView.tabScrollView.addSubview(tabStrip)
         }
-        let fitting = tabStrip.fittingContentSize()
-        let verticalInset = TerminalWindowUIKitRootView.tabRailVerticalInset
-        tabStrip.frame = CGRect(
-            x: TerminalWindowUIKitRootView.tabRailHorizontalInset,
-            y: verticalInset,
-            width: max(fitting.width, 1),
-            height: fitting.height
-        )
-        rootView.tabScrollView.contentSize = CGSize(
-            width: tabStrip.frame.maxX
-                + TerminalWindowUIKitRootView.tabRailHorizontalInset,
-            height: fitting.height + verticalInset * 2
-        )
+        // Geometry belongs to `layoutNativeChrome`, which measures the strip
+        // on every layout pass anyway: sizing it only here left a pass that
+        // changed the fitting size without a render with a stale strip width
+        // — cells compressed into each other, and the overflow past that
+        // width stopped hit-testing entirely.
+        rootView.setNeedsLayout()
     }
 
     private var tabItems: [TerminalTabStrip.Item] {
@@ -1612,8 +1609,9 @@ extension TerminalWindowViewController {
             reservesBottomSafeArea: shell == nil,
             safeAreaInsets: rootView.safeAreaInsets
         )
+        let tabsFitting = tabStrip.fittingContentSize()
         let tabsHeight: CGFloat = route.tabs.count > 1
-            ? tabStrip.fittingContentSize().height
+            ? tabsFitting.height
                 + TerminalWindowUIKitRootView.tabRailVerticalInset * 2
             : 0
         let umdHeight: CGFloat = {
@@ -1623,9 +1621,23 @@ extension TerminalWindowViewController {
                     for: shell?.availableWidth ?? bounds.width
                 ).height
             }
-            return umdController.view.systemLayoutSizeFitting(
+            // This view is frame-managed below, so its synthesized
+            // autoresizing constraints are *required* at whatever width it
+            // currently carries — a zero or stale one fights a required
+            // fitting width and the solve collapses the content onto the
+            // origin. Seed the proposal, then ask below required.
+            let umdView: UIView = umdController.view
+            if umdView.bounds.width != bounds.width {
+                umdView.frame = CGRect(
+                    x: umdView.frame.minX,
+                    y: umdView.frame.minY,
+                    width: bounds.width,
+                    height: umdView.frame.height
+                )
+            }
+            return umdView.systemLayoutSizeFitting(
                 CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height),
-                withHorizontalFittingPriority: .required,
+                withHorizontalFittingPriority: .defaultHigh,
                 verticalFittingPriority: .fittingSizeLevel
             ).height
         }()
@@ -1644,16 +1656,41 @@ extension TerminalWindowViewController {
                 height: max(0, contentBounds.height - umdHeight - tabsHeight)
             )
         } else {
+            // The classic window is the one plan hosted inside a
+            // UINavigationController, and a native child controller receives
+            // the navigation controller's FULL bounds — the translucent bar
+            // overlays the top band. Spend the top safe area here exactly
+            // like the bottom is spent below, or the tab rail lays out
+            // entirely under the bar (user-reported as "tab system gone")
+            // and the pane's first text row slides beneath it.
+            let topInset = rootView.safeAreaInsets.top
             rootView.tabScrollView.frame = CGRect(
-                x: 0, y: 0, width: contentBounds.width, height: tabsHeight
+                x: 0, y: topInset, width: contentBounds.width, height: tabsHeight
             )
             rootView.paneContainer.frame = CGRect(
                 x: 0,
-                y: tabsHeight,
+                y: topInset + tabsHeight,
                 width: contentBounds.width,
-                height: max(0, contentBounds.height - tabsHeight)
+                height: max(0, contentBounds.height - topInset - tabsHeight)
             )
             rootView.umdContainer.frame = .zero
+        }
+        // One measurement per pass owns the rail's height, the strip's frame,
+        // and the scroller's content size together, so they can never disagree
+        // about how wide the tabs are.
+        if tabStrip.superview === rootView.tabScrollView {
+            let verticalInset = TerminalWindowUIKitRootView.tabRailVerticalInset
+            tabStrip.frame = CGRect(
+                x: TerminalWindowUIKitRootView.tabRailHorizontalInset,
+                y: verticalInset,
+                width: max(tabsFitting.width, 1),
+                height: tabsFitting.height
+            )
+            rootView.tabScrollView.contentSize = CGSize(
+                width: tabStrip.frame.maxX
+                    + TerminalWindowUIKitRootView.tabRailHorizontalInset,
+                height: tabsFitting.height + verticalInset * 2
+            )
         }
         rootView.setBottomSafeAreaBackfill(
             frame: CGRect(
@@ -2174,8 +2211,20 @@ extension TerminalWindowViewController {
         UIKitChassis.configureSheetNavigationBar(navigation.navigationBar)
         navigation.presentationController?.delegate = self
         presentedFeatureController = navigation
+        applyAppearanceToPresentedFeature()
         present(navigation, animated: true)
         navigation.presentationController?.delegate = self
+    }
+
+    /// The link and path sheets carry no appearance property of their own, so
+    /// the stack they are hosted in wears the choice for them. `renderNow`
+    /// re-runs this on every appearance change (the observation reads
+    /// `themes.appearance`), which is what keeps an open sheet in step.
+    private func applyAppearanceToPresentedFeature() {
+        guard let presented = presentedFeatureController else { return }
+        let style = themes.appearance.interfaceStyle
+        guard presented.overrideUserInterfaceStyle != style else { return }
+        presented.overrideUserInterfaceStyle = style
     }
 
     private func dismissPresentedFeature() {
@@ -2202,7 +2251,7 @@ extension TerminalWindowViewController {
     private func presentPaywall() {
         guard !appLocked, presentedViewController == nil else { return }
         let paywall = ProPaywallViewController(entitlements: entitlements)
-        paywall.appAppearance = themes.appearance
+        paywall.followAppAppearance(themes)
         let navigation = UINavigationController(rootViewController: paywall)
         UIKitChassis.configureSheetNavigationBar(navigation.navigationBar)
         paywall.onDone = { [weak navigation] in navigation?.dismiss(animated: true) }
@@ -2220,7 +2269,7 @@ extension TerminalWindowViewController {
             host: host,
             sessionNames: notice.sessionNames
         )
-        guide.appAppearance = themes.appearance
+        guide.followAppAppearance(themes)
         let navigation = UINavigationController(rootViewController: guide)
         UIKitChassis.configureSheetNavigationBar(navigation.navigationBar)
         guide.onDone = { [weak navigation] in navigation?.dismiss(animated: true) }
@@ -2378,13 +2427,36 @@ extension TerminalWindowViewController {
 }
 #endif
 
+/// The tab rail's scroller. A `UIScrollView` delays content touches by 150 ms
+/// and discards them outright if the finger drifts during that window, so once
+/// the tabs overflow the rail a perfectly ordinary press never reached the
+/// cell — the "tabs feel dead" report. Track immediately instead, and let a
+/// genuine drag that starts on a cell still scroll the strip: UIKit's default
+/// `touchesShouldCancel` answers *false* for a `UIControl`, which with
+/// undelayed touches would pin the strip in place under any press.
+@MainActor
+final class TerminalTabScrollView: UIScrollView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        delaysContentTouches = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    override func touchesShouldCancel(in view: UIView) -> Bool {
+        if view is TerminalTabCell { return true }
+        return super.touchesShouldCancel(in: view)
+    }
+}
+
 @MainActor
 final class TerminalWindowUIKitRootView: UIView {
     static let tabRailHorizontalInset: CGFloat = 12
     static let tabRailVerticalInset: CGFloat = 6
 
     let paneContainer = UIView()
-    let tabScrollView = UIScrollView()
+    let tabScrollView = TerminalTabScrollView()
     let umdContainer = UIView()
     let helperContainer = UIView()
     private let bottomSafeAreaBackfill = UIView()

--- a/Multiplex/Views/Terminal/TmuxShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/TmuxShortcutPanel.swift
@@ -353,12 +353,22 @@ private final class TmuxShortcutPanelRootView: UIKitTallyBorderedView {
         fittingSize(for: width)
     }
 
+    /// The fitting width is a proposal, never a requirement: `contentStack` is
+    /// required-pinned to all four edges of this view, whose own width is set
+    /// by the popover (its autoresizing mask stays translated, so UIKit
+    /// synthesizes a REQUIRED width from the frame it currently has — zero
+    /// before the first layout, and the previous width for one pass after a
+    /// width change). Requiring a second, different width on top of those pins
+    /// is unsatisfiable, and Auto Layout resolves it by breaking the pins
+    /// instead: the grid solves to zero size and renders as empty bars until a
+    /// later clean pass heals it. A non-required proposal degrades the
+    /// measurement rather than the panel's layout.
     func fittingSize(for proposedWidth: CGFloat) -> CGSize {
         guard let contentStack else { return CGSize(width: proposedWidth, height: 28) }
         let contentWidth = max(0, proposedWidth - 28)
         let measured = contentStack.systemLayoutSizeFitting(
             CGSize(width: contentWidth, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .required,
+            withHorizontalFittingPriority: .defaultHigh,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: proposedWidth, height: ceil(measured.height + 28))

--- a/Multiplex/Views/Terminal/TmuxShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/TmuxShortcutPanel.swift
@@ -353,22 +353,12 @@ private final class TmuxShortcutPanelRootView: UIKitTallyBorderedView {
         fittingSize(for: width)
     }
 
-    /// The fitting width is a proposal, never a requirement: `contentStack` is
-    /// required-pinned to all four edges of this view, whose own width is set
-    /// by the popover (its autoresizing mask stays translated, so UIKit
-    /// synthesizes a REQUIRED width from the frame it currently has — zero
-    /// before the first layout, and the previous width for one pass after a
-    /// width change). Requiring a second, different width on top of those pins
-    /// is unsatisfiable, and Auto Layout resolves it by breaking the pins
-    /// instead: the grid solves to zero size and renders as empty bars until a
-    /// later clean pass heals it. A non-required proposal degrades the
-    /// measurement rather than the panel's layout.
     func fittingSize(for proposedWidth: CGFloat) -> CGSize {
         guard let contentStack else { return CGSize(width: proposedWidth, height: 28) }
         let contentWidth = max(0, proposedWidth - 28)
         let measured = contentStack.systemLayoutSizeFitting(
             CGSize(width: contentWidth, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .defaultHigh,
+            withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
         return CGSize(width: proposedWidth, height: ceil(measured.height + 28))

--- a/Multiplex/Views/Terminal/UMDBarUIKit.swift
+++ b/Multiplex/Views/Terminal/UMDBarUIKit.swift
@@ -992,8 +992,12 @@ final class UMDBarRootView: UIView {
         }
         let targetWidth = proposedWidth.map { max(0, $0 - horizontalInset) }
             ?? UIView.layoutFittingCompressedSize.width
+        // .defaultHigh, not .required: the content container is required-pinned
+        // to this bar's edges, and a required fitting width can only disagree
+        // with those pins by breaking one — degrading the measurement is safe,
+        // breaking the bar's internal layout draws its labels at the origin.
         let horizontalPriority: UILayoutPriority = proposedWidth == nil
-            ? .fittingSizeLevel : .required
+            ? .fittingSizeLevel : .defaultHigh
         let contentSize = contentView.systemLayoutSizeFitting(
             CGSize(
                 width: targetWidth,

--- a/Multiplex/Views/Terminal/UMDBarUIKit.swift
+++ b/Multiplex/Views/Terminal/UMDBarUIKit.swift
@@ -992,12 +992,8 @@ final class UMDBarRootView: UIView {
         }
         let targetWidth = proposedWidth.map { max(0, $0 - horizontalInset) }
             ?? UIView.layoutFittingCompressedSize.width
-        // .defaultHigh, not .required: the content container is required-pinned
-        // to this bar's edges, and a required fitting width can only disagree
-        // with those pins by breaking one — degrading the measurement is safe,
-        // breaking the bar's internal layout draws its labels at the origin.
         let horizontalPriority: UILayoutPriority = proposedWidth == nil
-            ? .fittingSizeLevel : .defaultHigh
+            ? .fittingSizeLevel : .required
         let contentSize = contentView.systemLayoutSizeFitting(
             CGSize(
                 width: targetWidth,

--- a/Multiplex/Views/Terminal/ViewportPane.swift
+++ b/Multiplex/Views/Terminal/ViewportPane.swift
@@ -647,6 +647,7 @@ final class ViewportFailureOverlayView: UIView {
         let messageLabel = UILabel()
         messageLabel.text = message
         messageLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        messageLabel.adjustsFontForContentSizeCategory = true
         messageLabel.textColor = UIKitChassis.signal2
         messageLabel.numberOfLines = 0
         messageLabel.textAlignment = .center
@@ -659,6 +660,7 @@ final class ViewportFailureOverlayView: UIView {
             let hintLabel = UILabel()
             hintLabel.text = hint
             hintLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+            hintLabel.adjustsFontForContentSizeCategory = true
             hintLabel.textColor = UIKitChassis.signal3
             hintLabel.numberOfLines = 0
             hintLabel.textAlignment = .center

--- a/MultiplexTests/SceneActivityCodecTests.swift
+++ b/MultiplexTests/SceneActivityCodecTests.swift
@@ -89,15 +89,47 @@ final class SceneActivityCodecTests: XCTestCase {
         ))
         XCTAssertEqual(SceneActivityCodec.payload(from: activity), expected)
 
-        // Saved-state files and live SwiftUI activation requests can carry
-        // either key depending on which lifecycle edge produced the activity.
+        // Saved-state archives can carry either value key depending on which
+        // lifecycle edge wrote them; the activity type is the same one every
+        // real archive uses.
         var savedOnly = activity.userInfo ?? [:]
         savedOnly.removeValue(forKey: SceneActivityCodec.legacyPresentedSceneValueKey)
         let savedActivity = NSUserActivity(
-            activityType: SceneActivityCodec.legacyOpenWindowActivityType
+            activityType: SceneActivityCodec.legacyStateRestorationActivityType
         )
         savedActivity.addUserInfoEntries(from: savedOnly)
         XCTAssertEqual(SceneActivityCodec.payload(from: savedActivity), expected)
+    }
+
+    func testLegacySessionUserInfoStandsInForADelayedRestorationActivity() throws {
+        let route = TerminalWindowRoute(tab: TerminalRoute(
+            hostID: UUID(),
+            mode: .attach(sessionName: "main")
+        ))
+        let userInfo: [String: Any] = [
+            SceneActivityCodec.legacySceneIDKey: "terminal",
+            SceneActivityCodec.legacySceneValueKey: try JSONEncoder().encode(route),
+            // A real session also carries keys this app knows nothing about.
+            "com.apple.SwiftUI.sceneTypeHash": 12_345,
+        ]
+        let activity = try XCTUnwrap(
+            SceneActivityCodec.legacySessionActivity(from: userInfo)
+        )
+        XCTAssertEqual(
+            activity.activityType,
+            SceneActivityCodec.legacyStateRestorationActivityType
+        )
+        XCTAssertEqual(SceneActivityCodec.payload(from: activity), .terminal(route))
+
+        // Nothing to decode is not a scene: an ID with no value, a session
+        // that never was SwiftUI's, and no userInfo at all all decline.
+        XCTAssertNil(SceneActivityCodec.legacySessionActivity(from: [
+            SceneActivityCodec.legacySceneIDKey: "terminal",
+        ]))
+        XCTAssertNil(SceneActivityCodec.legacySessionActivity(from: [
+            "unrelated": "value",
+        ]))
+        XCTAssertNil(SceneActivityCodec.legacySessionActivity(from: nil))
     }
 
     func testCapturedSwiftUIDeckValueMigrates() {

--- a/MultiplexTests/TerminalTabStripUIKitTests.swift
+++ b/MultiplexTests/TerminalTabStripUIKitTests.swift
@@ -77,6 +77,111 @@ final class TerminalTabStripUIKitTests: XCTestCase {
         XCTAssertEqual(view.intrinsicContentSize.height, expectedHeight)
     }
 
+    /// A real tab press synchronously updates both cells while the pressed
+    /// UIControl is still dispatching its action. The control, its labels, and
+    /// every hit region must survive that update; visionOS immediately asks
+    /// the ornament to fit this same live subtree.
+    func testTwoTabActivationKeepsIdentityAndGeometryStable() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = TerminalTabStripView()
+        var rerender: ((UUID) -> Void)!
+        rerender = { activeID in
+            view.apply(
+                items: [
+                    .init(
+                        id: firstID,
+                        title: "main",
+                        controller: nil,
+                        isActive: activeID == firstID
+                    ),
+                    .init(
+                        id: secondID,
+                        title: "scratch",
+                        controller: nil,
+                        isActive: activeID == secondID
+                    ),
+                ],
+                allowsSplit: true,
+                activate: { rerender($0) },
+                split: { _ in },
+                close: { _ in }
+            )
+        }
+        rerender(firstID)
+
+        let originalSize = view.fittingContentSize()
+        view.frame = CGRect(origin: .zero, size: originalSize)
+        view.layoutIfNeeded()
+        let originalCells = view.cells
+        let originalLabels = view.cells.map(\.sourceLabel)
+
+        view.cells[1].sendActions(for: .touchUpInside)
+        view.frame.size = view.fittingContentSize()
+        view.layoutIfNeeded()
+
+        XCTAssertEqual(view.fittingContentSize(), originalSize)
+        XCTAssertTrue(view.cells[0] === originalCells[0])
+        XCTAssertTrue(view.cells[1] === originalCells[1])
+        XCTAssertTrue(view.cells[0].sourceLabel === originalLabels[0])
+        XCTAssertTrue(view.cells[1].sourceLabel === originalLabels[1])
+        XCTAssertFalse(view.cells[0].accessibilityTraits.contains(.selected))
+        XCTAssertTrue(view.cells[1].accessibilityTraits.contains(.selected))
+        XCTAssertEqual(
+            view.cells[1].frame.minX - view.cells[0].frame.maxX,
+            TerminalTabStripView.cellSpacing,
+            accuracy: 0.5
+        )
+        for cell in view.cells {
+            XCTAssertGreaterThan(cell.frame.width, 0)
+            XCTAssertGreaterThan(cell.frame.height, 0)
+            let center = cell.convert(
+                CGPoint(x: cell.bounds.midX, y: cell.bounds.midY),
+                to: view
+            )
+            XCTAssertTrue(view.hitTest(center, with: nil) === cell)
+        }
+        rerender = nil
+    }
+
+    #if os(visionOS)
+    func testVisionTopOrnamentKeepsArithmeticTwoTabSizeAcrossActivation() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let strip = TerminalTabStripView()
+        let host = TerminalVisionTabOrnamentHostView(tabStrip: strip)
+        func render(activeID: UUID) {
+            strip.apply(
+                items: [
+                    .init(id: firstID, title: "main", controller: nil,
+                          isActive: activeID == firstID),
+                    .init(id: secondID, title: "scratch", controller: nil,
+                          isActive: activeID == secondID),
+                ],
+                allowsSplit: true,
+                activate: { render(activeID: $0) },
+                split: { _ in },
+                close: { _ in }
+            )
+            host.refreshFittingSize()
+        }
+        render(activeID: firstID)
+        let originalSize = host.fittingSize()
+        host.frame = CGRect(origin: .zero, size: originalSize)
+        host.layoutIfNeeded()
+
+        strip.cells[1].sendActions(for: .touchUpInside)
+        host.frame.size = host.fittingSize()
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(host.fittingSize(), originalSize)
+        XCTAssertEqual(strip.frame.width, strip.fittingContentSize().width, accuracy: 0.5)
+        XCTAssertEqual(strip.frame.height, 30, accuracy: 0.5)
+        XCTAssertEqual(strip.cells.count, 2)
+        XCTAssertTrue(strip.cells.allSatisfy { !$0.frame.isEmpty })
+    }
+    #endif
+
     func testAuxiliaryTabHasNoTallyLamp() {
         let id = UUID()
         let view = configuredView(items: [
@@ -176,6 +281,7 @@ final class TerminalTabStripUIKitTests: XCTestCase {
             .init(id: id, title: "agent", controller: controller, isActive: true),
         ])
         XCTAssertTrue(view.cells[0] === cell)
+        XCTAssertTrue(cell.sourceLabel === label)
         XCTAssertTrue(cell.accessibilityTraits.contains(.selected))
         XCTAssertEqual(cell.accessibilityLabel, "agent tab, active")
         XCTAssertEqual(cell.sourceLabel.accessibilityLabel, "agent")

--- a/MultiplexTests/TerminalTabStripUIKitTests.swift
+++ b/MultiplexTests/TerminalTabStripUIKitTests.swift
@@ -139,6 +139,54 @@ final class TerminalTabStripUIKitTests: XCTestCase {
         XCTAssertEqual(replacementActivations, [id])
     }
 
+    /// Status churn and tab switches must not cancel a press already tracking
+    /// one of these controls, so a render that changes only what a cell wears
+    /// mutates it instead of rebuilding the row.
+    func testStatusAndActiveChurnMutateCellsInPlace() throws {
+        let host = Host(name: "devbox", hostname: "127.0.0.1", username: "dev")
+        let controller = TerminalSessionController(
+            route: TerminalRoute(hostID: host.id, mode: .attach(sessionName: "main")),
+            host: host
+        )
+        let id = UUID()
+        let view = TerminalTabStripView()
+        apply(to: view, items: [
+            .init(id: id, title: "main", controller: nil, isActive: false),
+        ])
+        let cell = try XCTUnwrap(view.cells.first)
+        let dot = try XCTUnwrap(cell.dotView)
+        let label = cell.sourceLabel
+        XCTAssertEqual(cell.tallyState, .ended)
+
+        apply(to: view, items: [
+            .init(id: id, title: "main", controller: controller, isActive: false),
+        ])
+        XCTAssertTrue(view.cells[0] === cell)
+        XCTAssertTrue(cell.dotView === dot)
+        XCTAssertEqual(cell.tallyState, .connecting)
+
+        apply(to: view, items: [
+            .init(id: id, title: "agent", controller: controller, isActive: false),
+        ])
+        XCTAssertTrue(view.cells[0] === cell)
+        XCTAssertTrue(cell.sourceLabel === label)
+        XCTAssertEqual(cell.sourceLabel.accessibilityLabel, "agent")
+
+        apply(to: view, items: [
+            .init(id: id, title: "agent", controller: controller, isActive: true),
+        ])
+        XCTAssertTrue(view.cells[0] === cell)
+        XCTAssertTrue(cell.accessibilityTraits.contains(.selected))
+        XCTAssertEqual(cell.accessibilityLabel, "agent tab, active")
+        XCTAssertEqual(cell.sourceLabel.accessibilityLabel, "agent")
+
+        // Only a changed identity list is allowed to rebuild the row.
+        apply(to: view, items: [
+            .init(id: UUID(), title: "agent", controller: controller, isActive: true),
+        ])
+        XCTAssertFalse(view.cells[0] === cell)
+    }
+
     func testCellsEnableTouchContextMenuInteraction() throws {
         let id = UUID()
         let view = configuredView(items: [
@@ -219,6 +267,14 @@ final class TerminalTabStripUIKitTests: XCTestCase {
         items: [TerminalTabStrip.Item]
     ) -> TerminalTabStripView {
         let view = TerminalTabStripView()
+        apply(to: view, items: items)
+        return view
+    }
+
+    private func apply(
+        to view: TerminalTabStripView,
+        items: [TerminalTabStrip.Item]
+    ) {
         view.apply(
             items: items,
             allowsSplit: true,
@@ -226,7 +282,6 @@ final class TerminalTabStripUIKitTests: XCTestCase {
             split: { _ in },
             close: { _ in }
         )
-        return view
     }
 
     private func menuTitles(_ menu: UIMenu) -> [String] {

--- a/MultiplexTests/TerminalWindowUIKitTests.swift
+++ b/MultiplexTests/TerminalWindowUIKitTests.swift
@@ -46,9 +46,9 @@ final class TerminalWindowUIKitTests: XCTestCase {
             second,
             allowed: true
         )
-        XCTAssertNil(
-            TerminalFocusArbiter.current,
-            "Foreground notification order must not elect a terminal when ownership is empty"
+        XCTAssertTrue(
+            TerminalFocusArbiter.current === contender,
+            "An empty ownership is re-elected on restore: app-unlock clears the owner via inputSuppressed and a closed focused window deallocates it, and neither has another claim site"
         )
     }
 
@@ -212,6 +212,56 @@ final class TerminalWindowUIKitTests: XCTestCase {
             accuracy: 0.5
         )
         XCTAssertEqual(panes.frame.minY, rail.frame.maxY, accuracy: 0.5)
+    }
+
+    func testTabRailScrollerTracksPressesAtOnceAndSizesWithItsLayoutPass() throws {
+        let first = TerminalRoute(hostID: UUID(), mode: .attach(sessionName: "main"))
+        let second = TerminalRoute(hostID: UUID(), mode: .attach(sessionName: "scratch"))
+        // The rail only exists on the shell stage: a classic visionOS window
+        // hands its strip to the ornament instead.
+        let shell = TerminalWindowShellConfiguration(
+            deckControlLabel: "DECK",
+            availableWidth: 420,
+            showDeck: {},
+            openTerminalRoute: { _ in },
+            revealTab: { _ in },
+            tabsEmptied: {},
+            terminalFocusAllowed: false
+        )
+        let fixture = makeFixture(
+            route: TerminalWindowRoute(tabs: [first, second]),
+            shell: shell
+        )
+        fixture.controller.loadViewIfNeeded()
+        fixture.controller.view.frame = CGRect(x: 0, y: 0, width: 420, height: 620)
+        fixture.controller.view.setNeedsLayout()
+        fixture.controller.view.layoutIfNeeded()
+
+        let rail = try XCTUnwrap(
+            view("terminalWindow.tabs", in: fixture.controller.view)
+                as? TerminalTabScrollView
+        )
+        let strip = try XCTUnwrap(descendant(
+            of: TerminalTabStripView.self,
+            in: fixture.controller.view
+        ))
+        let cell = try XCTUnwrap(strip.cells.first)
+
+        XCTAssertFalse(
+            rail.delaysContentTouches,
+            "A delayed content touch is the press a drifting finger loses"
+        )
+        XCTAssertTrue(
+            rail.touchesShouldCancel(in: cell),
+            "A real drag starting on a cell must still scroll the strip"
+        )
+        XCTAssertEqual(
+            rail.contentSize.width,
+            strip.frame.maxX + TerminalWindowUIKitRootView.tabRailHorizontalInset,
+            accuracy: 0.5,
+            "Strip frame and content size are one measurement per layout pass"
+        )
+        XCTAssertGreaterThanOrEqual(strip.frame.width, strip.fittingContentSize().width)
     }
 
     func testRestoredAuxiliaryWithoutLiveControllerIsStrippedBeforeRendering() {

--- a/MultiplexTests/UIKitScenePresentationPlanTests.swift
+++ b/MultiplexTests/UIKitScenePresentationPlanTests.swift
@@ -110,7 +110,7 @@ final class UIKitScenePresentationPlanTests: XCTestCase {
             mode: .attach(sessionName: "main")
         ))
         let terminal = NSUserActivity(
-            activityType: SceneActivityCodec.legacyOpenWindowActivityType
+            activityType: SceneActivityCodec.legacyStateRestorationActivityType
         )
         terminal.addUserInfoEntries(from: [
             SceneActivityCodec.legacySceneIDKey: "terminal",
@@ -202,39 +202,55 @@ final class UIKitScenePresentationPlanTests: XCTestCase {
         XCTAssertEqual(buffer.accept([live], phase: .activation), [live])
     }
 
-    func testPersistedSwiftUISessionAdoptionIsNarrow() {
-        let legacy = NSUserActivity(
-            activityType: SceneActivityCodec.legacyStateRestorationActivityType
-        )
-        legacy.addUserInfoEntries(from: [
-            SceneActivityCodec.legacySceneIDKey: "deck",
-            SceneActivityCodec.legacyPresentedSceneValueKey: Data("\"main\"".utf8),
-        ])
+    func testSceneAdoptionFollowsDelegateOwnershipNotLegacyFingerprints() {
+        let native = "Multiplex.MultiplexSceneDelegate"
 
+        // The persisted SwiftUI delegate, resolvable because SwiftUI happens
+        // to be loaded. Either slot naming it is the scene UIKit would
+        // otherwise connect to a lifecycle this executable no longer runs.
         XCTAssertTrue(UIKitLegacySceneMigrationPolicy.requiresAdoption(
-            configuredDelegateClassName: "SwiftUI.AppSceneDelegate",
-            liveDelegateClassName: nil,
-            restorationActivity: legacy
+            nativeDelegateClassName: native,
+            configuredDelegateClassName:
+                UIKitLegacySceneMigrationPolicy.swiftUIDelegateClassName,
+            liveDelegateClassName: nil
         ))
         XCTAssertTrue(UIKitLegacySceneMigrationPolicy.requiresAdoption(
+            nativeDelegateClassName: native,
             configuredDelegateClassName: nil,
-            liveDelegateClassName: "SwiftUI.AppSceneDelegate",
-            restorationActivity: nil
+            liveDelegateClassName:
+                UIKitLegacySceneMigrationPolicy.swiftUIDelegateClassName
         ))
+
+        // The safety net that used to erase itself: without SwiftUI in the
+        // process the persisted class name resolves to nothing in BOTH slots,
+        // and after the first adoption the session's restoration activity is
+        // this app's own type, so no legacy fingerprint remains to match. A
+        // scene in this state has no delegate at all and must still be
+        // adopted — the alternative is a blank window on every later launch.
         XCTAssertTrue(UIKitLegacySceneMigrationPolicy.requiresAdoption(
+            nativeDelegateClassName: native,
             configuredDelegateClassName: nil,
-            liveDelegateClassName: nil,
-            restorationActivity: legacy
+            liveDelegateClassName: nil
+        ))
+
+        // A scene UIKit owns natively is never taken: already connected, and
+        // configured-but-not-yet-instantiated (where stealing it would orphan
+        // the connection options UIKit is about to deliver).
+        XCTAssertFalse(UIKitLegacySceneMigrationPolicy.requiresAdoption(
+            nativeDelegateClassName: native,
+            configuredDelegateClassName: native,
+            liveDelegateClassName: native
         ))
         XCTAssertFalse(UIKitLegacySceneMigrationPolicy.requiresAdoption(
-            configuredDelegateClassName: "Multiplex.MultiplexSceneDelegate",
-            liveDelegateClassName: "Multiplex.MultiplexSceneDelegate",
-            restorationActivity: legacy
+            nativeDelegateClassName: native,
+            configuredDelegateClassName: native,
+            liveDelegateClassName: nil
         ))
         XCTAssertFalse(UIKitLegacySceneMigrationPolicy.requiresAdoption(
-            configuredDelegateClassName: nil,
-            liveDelegateClassName: nil,
-            restorationActivity: nil
+            nativeDelegateClassName: native,
+            configuredDelegateClassName:
+                UIKitLegacySceneMigrationPolicy.swiftUIDelegateClassName,
+            liveDelegateClassName: native
         ))
     }
 
@@ -256,6 +272,71 @@ final class UIKitScenePresentationPlanTests: XCTestCase {
         XCTAssertNil(UIKitSceneGeometryPolicy.parseSize("0x700"))
         XCTAssertNil(UIKitSceneGeometryPolicy.parseSize("1120"))
         XCTAssertNil(UIKitSceneGeometryPolicy.parseSize("wideX700"))
+    }
+
+    func testRememberedWindowSizeStandsInForTheAuthoredDefault() throws {
+        let suiteName = "SceneWindowSizeStoreTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = SceneWindowSizeStore(defaults: defaults)
+        let terminalDefault = UIKitSceneGeometryPolicy.terminalDefault
+
+        // Nothing remembered: the authored default, exactly as `.defaultSize`.
+        XCTAssertNil(store.lastSize(for: .terminal))
+        XCTAssertEqual(
+            SceneGeometryPolicy.chooseInitialSize(
+                environmentOverride: nil,
+                remembered: store.lastSize(for: .terminal),
+                default: terminalDefault
+            ),
+            terminalDefault
+        )
+
+        // A window the user resized is what the next window of that kind
+        // opens at, and it says nothing about the other kind.
+        let resized = CGSize(width: 1_600, height: 1_000)
+        store.record(resized, for: .terminal)
+        XCTAssertNil(store.lastSize(for: .deck))
+        XCTAssertEqual(
+            SceneGeometryPolicy.chooseInitialSize(
+                environmentOverride: nil,
+                remembered: store.lastSize(for: .terminal),
+                default: terminalDefault
+            ),
+            resized
+        )
+
+        // A DEBUG screenshot override still wins outright.
+        XCTAssertEqual(
+            SceneGeometryPolicy.chooseInitialSize(
+                environmentOverride: CGSize(width: 860, height: 540),
+                remembered: store.lastSize(for: .terminal),
+                default: terminalDefault
+            ),
+            CGSize(width: 860, height: 540)
+        )
+
+        // A scene sampled mid-teardown reports nothing worth remembering.
+        store.record(.zero, for: .terminal)
+        store.record(CGSize(width: 1_600, height: CGFloat.nan), for: .terminal)
+        XCTAssertEqual(store.lastSize(for: .terminal), resized)
+    }
+
+    func testGeometryOverrideKeysStayInStepWithTheGeometryPolicy() {
+        for kind in SceneGeometryKind.allCases {
+            let payload: ScenePayload = switch kind {
+            case .deck: .deck(.main)
+            case .terminal: .terminal(TerminalWindowRoute(tabs: []))
+            }
+            XCTAssertEqual(SceneGeometryKind(payload), kind)
+            XCTAssertEqual(
+                UIKitSceneGeometryPolicy.preferredSize(
+                    for: payload,
+                    environment: [kind.debugSizeEnvironmentKey: "900x600"]
+                ),
+                CGSize(width: 900, height: 600)
+            )
+        }
     }
 
     func testConnectionPhaseWaitsForDelayedRestorationAndPreservesActivation() throws {

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -181,3 +181,12 @@ find.
 - New Session (and Add Host, agent prompt, theme editor): content scrolls
   under the home indicator again, and typing in any field keeps it above
   the keyboard.
+
+TWO-TAB RAIL + NEW DECK TILES — labels stay in their frames
+
+- On iPhone, add a second tab and switch between the two repeatedly. Both
+  cells must keep their full width, spacing, and hit regions — no labels
+  piling up at the rail's origin. Repeat in the Vision Pro top ornament.
+- Return to the deck while new sessions appear: every new tile must lay out
+  its miniature, title, tally, and telemetry normally instead of stacking
+  them in its top-left corner.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -142,3 +142,42 @@ each ask is a slow round trip. It is now asked once per launch.
 - The App lock row still names your device's real method ("Require Face
   ID" on a Face ID phone, "Require device passcode" without biometry), and
   the lock itself still prompts correctly when you turn it on.
+
+UIKIT REBUILD — the whole chrome, same TALLY
+
+Every surface — deck, terminal windows, the iPhone shell, Settings, Add
+Host and Bind, the paywall, file viewer, and viewport — now runs on UIKit
+instead of SwiftUI. Layout and behavior are meant to be IDENTICAL to the
+July 31 beta; anything that looks or feels different from that build is a
+find.
+
+- Sweep your usual flows on iPhone, iPad, and Vision Pro: attach, tabs,
+  merge/split, the key rail, agent chips, file drops, link presses,
+  Settings, Add Host.
+- Update in place over the previous beta with windows open: the same
+  decks and terminals must come back after the update, not a fresh
+  launch.
+- Settings opens at the top, and keeps your place when you scroll and
+  return.
+- Native confirmation actions (Done, Create & Attach) use system Liquid
+  Glass.
+- Long-press a link or path: the prompt shows the complete target,
+  hyphenated URLs included.
+- Flip SYSTEM / LIGHT / DARK while sheets and terminals are open: every
+  surface follows, including sheets that were already up.
+- Vision Pro: a terminal window is still the rounded monitor silhouette
+  against the room — no square glass corners; a new terminal opens at
+  the size you last used, not a fixed default.
+
+- Tabs press reliably: near the left edge (drifting taps used to start a
+  back-swipe instead), with many tabs open (the strip used to cancel the
+  press), and while a session's status is changing under your finger.
+- Attach on iPhone: the window must lay out cleanly during CONNECTING —
+  no piled-up title text, no key rail at the top, no text spilling out of
+  the connecting panel, no red mark in the corner.
+- First presentation renders complete: Add Host ▸ BIND section titles and
+  the paste control, and a deck tile appearing for a session created
+  while you watch — nothing stacked in a corner, no empty grey bars.
+- New Session (and Add Host, agent prompt, theme editor): content scrolls
+  under the home indicator again, and typing in any field keeps it above
+  the keyboard.


### PR DESCRIPTION
## Summary

Fix pass on top of #23 from a multi-agent deep review (37 adversarially verified findings) plus live device reports.

- Terminal: tab-rail touch stealing (edge-swipe exemption, scroller cancellation, in-place cell updates), tab-strip measurement collapse (constraint solves replaced with arithmetic), connecting-state first-layout scramble, caret hidden until live, tab-switch focus claims restored, UMD stale width
- iPad classic: terminal window now spends the top safe area (tab rail rendered under the navigation bar, pane offset)
- Deck: feed identity back on FleetFeedID, tile content-equality gate, reorder outline/animation, safe-area double-spend, ACQUIRING SIGNAL bezel, fresh-tile layout seeding
- Sheets: bottom safe-area clipping in New Session / Add Host / agent prompt / theme editor (shared keyboard-inset helper), TEST CONNECTION re-enable, bind paywall drain, keyboard avoidance
- Appearance: presented sheets follow SYSTEM/LIGHT/DARK live (AppAppearanceFollowing), guide sheets no longer clobber the window override, trait-refresh sweep (lamps, markdown ink, dashed borders, paste control)
- visionOS: plain terminal window silhouette restored (preferredContainerBackgroundStyle), new windows open at the remembered per-kind size instead of a forced default
- Scene lifecycle: legacy SwiftUI scene adoption hardened (ownership-invariant policy, buffered connection options, saved-state wipe window closed), Reduce Motion reaches classic decks
- External actions: shell coordinator wired for app lock + presenter availability
- Memory/perf: observation re-arming keyed, notification observer teardown, lifecycle task growth, lazy markdown block mounting, incremental tree-column updates
- Docs/tests: stale AGENTS.md bullets rewritten, TestFlight changelog entry, new regression tests (both platforms green: iPad 911, visionOS 910 + 36 Swift Testing each)

## Known open issue

A two-tab tab-strip collapse on device is suspected to be introduced by this fix pass and is under investigation — do not merge until resolved.

## Validation

- ./Tools/build.sh test ipad / test vos — green
- Release-configuration builds green on both platforms
- ./Tools/build.sh verify vos / verify ipad — live attach verified with screenshots
- Simulator verification of each reported bug against the fixed build (A/B vs the PR commit for the caret fix)