### PR TITLE
Take an attention banner's press to the session that pinged you

### DIFF
--- a/Multiplex/Models/AgentAttention.swift
+++ b/Multiplex/Models/AgentAttention.swift
@@ -59,6 +59,78 @@ struct AttentionAlert {
     /// What the blocking dialog asks (`AgentAttention.dialogSummary`),
     /// when the event is needs-input and the tail yielded readable copy.
     var dialogSummary: String?
+
+    /// What this alert's banner should get back to when pressed.
+    var tapTarget: AttentionTapTarget {
+        AttentionTapTarget(
+            hostID: host.id,
+            sessionName: sessionName,
+            backend: host.sessionBackend,
+            tabID: tabID
+        )
+    }
+}
+
+/// The identity a posted banner carries into its own press, encoded into
+/// the notification's `userInfo` as strings only — a pressed banner may
+/// outlive the process that posted it, so nothing here can be a live
+/// reference. Backend is part of the identity for the same reason it is in
+/// `TerminalWorkspace.focusTab`: both namespaces may legally contain `main`.
+struct AttentionTapTarget: Equatable {
+    var hostID: UUID
+    var sessionName: String
+    var backend: Host.SessionBackend
+    /// The exact open tab for tab-scoped alerts (plain shells, in-band
+    /// bells); nil for session-scoped probe alerts.
+    var tabID: UUID?
+
+    /// Only a session-scoped probe alert names a real multiplexer session
+    /// that could be attached fresh. A tab-scoped alert's session name is
+    /// display copy ("shell") — pressing its banner after the tab closed
+    /// must never mint an attach to a namesake.
+    var sessionIsAttachable: Bool { tabID == nil }
+
+    private enum Key {
+        static let host = "attentionHostID"
+        static let session = "attentionSession"
+        static let backend = "attentionBackend"
+        static let tab = "attentionTabID"
+    }
+
+    init(
+        hostID: UUID, sessionName: String,
+        backend: Host.SessionBackend, tabID: UUID? = nil
+    ) {
+        self.hostID = hostID
+        self.sessionName = sessionName
+        self.backend = backend
+        self.tabID = tabID
+    }
+
+    var userInfo: [String: String] {
+        var info = [
+            Key.host: hostID.uuidString,
+            Key.session: sessionName,
+            Key.backend: backend.rawValue,
+        ]
+        if let tabID { info[Key.tab] = tabID.uuidString }
+        return info
+    }
+
+    /// Fail-soft: a banner from a build with a different payload shape
+    /// decodes to nil and the press just foregrounds the app.
+    init?(userInfo: [AnyHashable: Any]) {
+        guard let hostString = userInfo[Key.host] as? String,
+              let hostID = UUID(uuidString: hostString),
+              let sessionName = userInfo[Key.session] as? String,
+              let backendRaw = userInfo[Key.backend] as? String,
+              let backend = Host.SessionBackend(rawValue: backendRaw)
+        else { return nil }
+        self.hostID = hostID
+        self.sessionName = sessionName
+        self.backend = backend
+        tabID = (userInfo[Key.tab] as? String).flatMap(UUID.init(uuidString:))
+    }
 }
 
 /// The state classifier. Everything here matches *structure*, not prose —

--- a/Multiplex/Services/AttentionCenter.swift
+++ b/Multiplex/Services/AttentionCenter.swift
@@ -53,6 +53,7 @@ final class AttentionCenter {
         // Banners must show while the app is frontmost — the whole point is
         // pinging the user about a window they're not looking at.
         UNUserNotificationCenter.current().delegate = banner
+        banner.onTap = { [weak self] target in self?.handleTap(target) }
     }
 
     // MARK: Events
@@ -136,6 +137,37 @@ final class AttentionCenter {
         }
     }
 
+    // MARK: Tap
+
+    /// The fallback's seam, overridable by tests. Live wiring submits to
+    /// the process-wide router — the same queue widget taps ride, which
+    /// waits behind the app lock and raises the deck scene when the press
+    /// launched a fresh process with no context mounted yet.
+    @ObservationIgnored var performExternalAction: (ExternalAction) -> Void = {
+        ExternalActionRouter.shared.submit($0)
+    }
+
+    /// A banner's press gets the user back to the session that pinged them.
+    /// An already-open tab reveals directly — tab-scoped alerts by tab id,
+    /// session alerts through the same (host, session, backend) identity a
+    /// deck tile press uses; tmux and herdr tabs match alike. A session
+    /// alert with no open window rides the external-action seam instead:
+    /// the widget's status-guarded reveal-or-attach, so the tap still lands
+    /// after the window was closed or the process died. Not Pro-gated —
+    /// the banner only existed because Pro was active when it posted, and
+    /// attach itself is a free surface.
+    func handleTap(_ target: AttentionTapTarget) {
+        if let tabID = target.tabID, workspace?.focusTab(id: tabID) == true { return }
+        if workspace?.focusTab(
+            hostID: target.hostID,
+            sessionName: target.sessionName,
+            backend: target.backend
+        ) == true { return }
+        guard target.sessionIsAttachable else { return }
+        performExternalAction(
+            .openShell(host: .id(target.hostID), sessionName: target.sessionName))
+    }
+
     // MARK: Delivery
 
     private func post(_ alert: AttentionAlert) {
@@ -149,6 +181,9 @@ final class AttentionCenter {
         if let subtitle = copy.subtitle { content.subtitle = subtitle }
         content.body = copy.body
         content.sound = .default
+        // The press decodes this to focus the alert's window (or attach it
+        // afresh) — see `handleTap`.
+        content.userInfo = alert.tapTarget.userInfo
         let sourceID = alert.tabID?.uuidString ?? alert.sessionName
         content.threadIdentifier = "\(alert.host.id)-\(sourceID)"
         // One live banner per tmux session or plain-shell tab: a newer event
@@ -214,13 +249,33 @@ final class AttentionCenter {
     }
 }
 
-/// Presents banners while the app is foreground (the default is silence).
+/// Presents banners while the app is foreground (the default is silence)
+/// and routes a banner's press back into the center.
 private final class ForegroundBanner: NSObject, UNUserNotificationCenterDelegate {
+    /// Set once at composition. Delegate callbacks arrive on system queues,
+    /// so the hop onto the main actor happens here.
+    var onTap: (@MainActor (AttentionTapTarget) -> Void)?
+
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         completionHandler([.banner, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        // Only the default press is intent — a dismissed banner is not.
+        if response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+           let target = AttentionTapTarget(
+               userInfo: response.notification.request.content.userInfo) {
+            let onTap = onTap
+            Task { @MainActor in onTap?(target) }
+        }
+        completionHandler()
     }
 }

--- a/Multiplex/Services/TerminalWorkspace.swift
+++ b/Multiplex/Services/TerminalWorkspace.swift
@@ -220,6 +220,19 @@ final class TerminalWorkspace {
         return true
     }
 
+    /// Bring the window holding this exact tab forward and make it active —
+    /// a notification tap's route back to a tab-scoped alert (a plain shell
+    /// has no session identity for `focusTab(hostID:sessionName:backend:)`
+    /// to match).
+    @discardableResult
+    func focusTab(id tabID: UUID) -> Bool {
+        guard let entry = windows.first(where: { entry in
+            entry.tabs.contains { $0.id == tabID }
+        }) else { return false }
+        entry.reveal(tabID)
+        return true
+    }
+
     /// First-registered window holding a tab for this session — attach and
     /// create tabs alike; plain shells have no session name/backend and never
     /// match.

--- a/MultiplexTests/AgentAttentionTests.swift
+++ b/MultiplexTests/AgentAttentionTests.swift
@@ -479,6 +479,115 @@ final class AgentAttentionTests: XCTestCase {
         XCTAssertEqual(sessions.first?.activeAgent, .claudeCode)
     }
 
+    // MARK: Notification tap
+
+    func testTapTargetUserInfoRoundTrip() {
+        let session = AttentionTapTarget(
+            hostID: UUID(), sessionName: "main", backend: .herdr)
+        XCTAssertEqual(AttentionTapTarget(userInfo: session.userInfo), session)
+        XCTAssertTrue(session.sessionIsAttachable)
+
+        let tab = AttentionTapTarget(
+            hostID: UUID(), sessionName: "shell", backend: .tmux, tabID: UUID())
+        XCTAssertEqual(AttentionTapTarget(userInfo: tab.userInfo), tab)
+        // A tab-scoped alert's session name is display copy — pressing its
+        // banner must never mint an attach to a namesake session.
+        XCTAssertFalse(tab.sessionIsAttachable)
+
+        // A banner from another payload shape decodes to nil (the press
+        // just foregrounds the app), and so does a corrupted backend.
+        XCTAssertNil(AttentionTapTarget(userInfo: [:]))
+        var corrupted = session.userInfo
+        corrupted["attentionBackend"] = "screen"
+        XCTAssertNil(AttentionTapTarget(userInfo: corrupted))
+    }
+
+    func testAlertBuildsTapTargetFromHostIdentity() {
+        var host = Host(name: "devbox", hostname: "127.0.0.1", username: "dev")
+        host.sessionBackend = .herdr
+        let target = AttentionAlert(
+            host: host,
+            sessionName: "deploy",
+            agent: .pi,
+            event: .turnEnded,
+            paneTitle: ""
+        ).tapTarget
+        XCTAssertEqual(target.hostID, host.id)
+        XCTAssertEqual(target.sessionName, "deploy")
+        XCTAssertEqual(target.backend, .herdr)
+        XCTAssertNil(target.tabID)
+    }
+
+    @MainActor
+    func testTapRevealsOpenTabBySessionIdentity() {
+        let center = AttentionCenter()
+        let workspace = TerminalWorkspace()
+        center.workspace = workspace
+        let host = Host(name: "devbox", hostname: "127.0.0.1", username: "dev")
+        let tmuxTab = TerminalRoute(hostID: host.id, mode: .attach(sessionName: "main"))
+        let herdrTab = TerminalRoute(hostID: host.id, mode: .herdrAttach(sessionName: "main"))
+        var revealed: [UUID] = []
+        workspace.registerWindow(TerminalWorkspace.WindowEntry(
+            id: UUID(),
+            tabs: [tmuxTab, herdrTab],
+            label: "terminal",
+            reveal: { revealed.append($0) },
+            surrender: { [] },
+            adopt: { _ in }
+        ))
+        var submitted: [ExternalAction] = []
+        center.performExternalAction = { submitted.append($0) }
+
+        // Backend is identity: both namespaces hold "main", and each press
+        // must reveal its own backend's tab.
+        center.handleTap(AttentionTapTarget(
+            hostID: host.id, sessionName: "main", backend: .herdr))
+        XCTAssertEqual(revealed, [herdrTab.id])
+        center.handleTap(AttentionTapTarget(
+            hostID: host.id, sessionName: "main", backend: .tmux))
+        XCTAssertEqual(revealed, [herdrTab.id, tmuxTab.id])
+
+        // A tab-scoped alert reveals its exact tab even though a plain
+        // shell has no session identity to match.
+        let shellTab = TerminalRoute(hostID: host.id, mode: .shell)
+        workspace.registerWindow(TerminalWorkspace.WindowEntry(
+            id: UUID(),
+            tabs: [shellTab],
+            label: "shell",
+            reveal: { revealed.append($0) },
+            surrender: { [] },
+            adopt: { _ in }
+        ))
+        center.handleTap(AttentionTapTarget(
+            hostID: host.id, sessionName: "shell", backend: .tmux, tabID: shellTab.id))
+        XCTAssertEqual(revealed.last, shellTab.id)
+
+        // Every press above found its window — none may fall through to
+        // the external-action seam.
+        XCTAssertTrue(submitted.isEmpty)
+    }
+
+    @MainActor
+    func testTapWithoutOpenWindowAttachesViaExternalSeam() {
+        let center = AttentionCenter()
+        center.workspace = TerminalWorkspace()
+        var submitted: [ExternalAction] = []
+        center.performExternalAction = { submitted.append($0) }
+        let hostID = UUID()
+
+        // A session-scoped alert re-attaches through the widget seam (the
+        // router queues behind the app lock and raises the deck itself).
+        center.handleTap(AttentionTapTarget(
+            hostID: hostID, sessionName: "deploy", backend: .herdr))
+        XCTAssertEqual(submitted, [.openShell(host: .id(hostID), sessionName: "deploy")])
+
+        // A tab-scoped alert whose tab died stops at the reveal attempt:
+        // its "shell" display name is not an attachable session.
+        center.handleTap(AttentionTapTarget(
+            hostID: hostID, sessionName: "shell", backend: .tmux, tabID: UUID()))
+        XCTAssertEqual(submitted.count, 1)
+    }
+
     // MARK: Pro gate
 
     @MainActor

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -370,3 +370,22 @@ install commands sit behind a TMUX | HERDR bar you switch in place.
   holds that exact line.
 - A dead tile's own INSTALL GUIDE is unchanged — it still shows only the
   backend that host is set to.
+
+NOTIFICATION TAPS LAND — the banner press goes to the session
+
+Pressing an agent alert banner (Pro: finished / wants permission / has a
+question, tmux and herdr alike) now takes you to that session instead of
+just foregrounding the app: the window already holding it comes forward
+with that tab active, and a session with no open window attaches in a new
+one, connecting first like a widget tap would.
+
+- Let an agent finish in an unfocused window, press the banner: that
+  window comes forward with the right tab active — no duplicate window.
+- Close the session's window, let the next alert arrive, press it: the
+  app connects and attaches that exact session afresh, herdr sessions
+  included.
+- Press a banner for a host you have since deleted or disabled: a clear
+  deck alert says so instead of silently doing nothing.
+- With the app lock on, press a banner: the veil asks first; the session
+  opens only after unlock.
+- Swiping a banner away (not pressing it) must not open anything.


### PR DESCRIPTION
## What

Pressing an agent alert banner (finished / wants permission / has a question — tmux and herdr alike) now takes you to that session instead of just foregrounding the app. Until now the notification delegate only presented banners; the press was dead.

## How

- **`AttentionTapTarget`** (`Models/AgentAttention.swift`, pure + tested): the identity a banner carries into its own press — host id, session name, backend, optional tab id — encoded into `userInfo` as strings only, so a press survives the posting process dying. Backend is part of the identity for the same reason it is in `TerminalWorkspace.focusTab`: both namespaces may legally contain `main`. `AttentionAlert.tapTarget` derives it; `post()` attaches it to every request.
- **`AttentionCenter.handleTap`**: an already-open tab reveals directly — tab-scoped alerts (plain shells, in-band bells) by exact tab id via the new `TerminalWorkspace.focusTab(id:)`, session alerts through the same `(host, session, backend)` identity a deck tile press uses. A session alert with no open window rides the external-action seam instead: the widget's status-guarded `openShell`, which queues behind the app lock, raises the deck when the press launched a fresh process, refuses deleted/disabled hosts with the existing alert copy, and resolves tmux vs herdr attach through `Mode.attach(host:sessionName:)`.
- **`ForegroundBanner`** gains `didReceive`: only the default press acts (a swiped-away banner is not intent), decoding is fail-soft (a banner from another payload shape just foregrounds the app), and the hop onto the main actor happens at the delegate boundary.

Deliberate boundaries:
- A tab-scoped alert whose tab died stops at the reveal attempt — its "shell" display name must never mint an attach to a namesake session.
- The tap path is not Pro-gated: the banner only existed because Pro was active when it posted, and attach itself is a free surface.
- The external fallback is injected as a closure so tests exercise it without the process-wide router singleton.

## Verification

- Four new tests in `AgentAttentionTests`: userInfo round-trip incl. corrupted-payload rejection, alert → target mapping, backend-disambiguated reveal against a real `TerminalWorkspace`, and the attach-vs-stop fallback split.
- `./Tools/build.sh test vos` green; `build vos` + `build ipad` succeed; SwiftLint strict at zero violations.
- TestFlight changelog entry staged.
- The one unautomatable piece is the system's real banner press (simulator notifications aren't drivable — on record); worth one manual device check before release.