### PR TITLE
Give popover panels breathing room on visionOS's rounded platter

### DIFF
--- a/Multiplex/Design/Chassis.swift
+++ b/Multiplex/Design/Chassis.swift
@@ -31,6 +31,18 @@ enum UIKitChassis {
         GlassPrototype.enabled ? GlassPrototype.signal3 : TallyPalette.signal3
     }
 
+    /// Edge clearance between a popover-hosted panel's frame and its content
+    /// (tmux shortcuts, Command Setup, agent HISTORY). iPad popovers wear the
+    /// square TALLY frame, so the tight chassis inset reads correct; visionOS
+    /// hosts the same panels on the system's rounded glass platter, whose
+    /// corner mask crowds content sitting at 14 pt. Panels widen their
+    /// preferred width by the same delta so content never narrows.
+    #if os(visionOS)
+    nonisolated static let popoverPanelInset: CGFloat = 22
+    #else
+    nonisolated static let popoverPanelInset: CGFloat = 14
+    #endif
+
     static func uiFont(_ size: CGFloat, weight: UIFont.Weight = .regular) -> UIFont {
         .systemFont(ofSize: size * Theme.typeScale, weight: weight)
     }

--- a/Multiplex/Views/Terminal/AgentHistoryPanel.swift
+++ b/Multiplex/Views/Terminal/AgentHistoryPanel.swift
@@ -6,7 +6,8 @@ import UIKit
 /// where supported, JUMP scrolls the live Claude transcript to that message.
 @MainActor
 final class AgentHistoryPanelViewController: UIViewController {
-    nonisolated static let preferredWidth: CGFloat = 380
+    nonisolated static let preferredWidth: CGFloat =
+        352 + 2 * UIKitChassis.popoverPanelInset
     nonisolated static let maximumListHeight: CGFloat = 420
 
     typealias HistoryStatus = TerminalSessionController.AgentHistoryStatus
@@ -164,9 +165,10 @@ final class AgentHistoryPanelViewController: UIViewController {
         let container = UIView()
         container.addSubview(row)
         row.translatesAutoresizingMaskIntoConstraints = false
+        let inset = UIKitChassis.popoverPanelInset
         NSLayoutConstraint.activate([
-            row.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
-            row.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -14),
+            row.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: inset),
+            row.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -inset),
             row.topAnchor.constraint(equalTo: container.topAnchor, constant: 10),
             row.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -10),
         ])
@@ -277,7 +279,7 @@ final class AgentHistoryPanelViewController: UIViewController {
             let row = AgentHistoryMessageRowView(
                 message: message,
                 expanded: expandedOrdinal == message.ordinal,
-                availableWidth: panelWidth - 28,
+                availableWidth: panelWidth - 2 * UIKitChassis.popoverPanelInset,
                 showsJump: jumpAvailable && message.reachable,
                 toggle: { [weak self] ordinal in
                     self?.toggleMessage(ordinal)
@@ -372,6 +374,14 @@ final class AgentHistoryPanelViewController: UIViewController {
 
 @MainActor
 private final class AgentHistoryPanelRootView: UIView {
+    /// visionOS's rounded platter mask crowds the last row, so the list gets
+    /// a footer clearance there; iPad's square frame keeps the flush bottom.
+    #if os(visionOS)
+    private static let footerClearance: CGFloat = 10
+    #else
+    private static let footerClearance: CGFloat = 0
+    #endif
+
     private var width: CGFloat
     private weak var rootStack: UIStackView?
 
@@ -391,7 +401,10 @@ private final class AgentHistoryPanelRootView: UIView {
             rootStack.leadingAnchor.constraint(equalTo: leadingAnchor),
             rootStack.trailingAnchor.constraint(equalTo: trailingAnchor),
             rootStack.topAnchor.constraint(equalTo: topAnchor),
-            rootStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            rootStack.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -Self.footerClearance
+            ),
         ])
     }
 
@@ -406,7 +419,10 @@ private final class AgentHistoryPanelRootView: UIView {
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
-        return CGSize(width: proposedWidth, height: ceil(measured.height))
+        return CGSize(
+            width: proposedWidth,
+            height: ceil(measured.height) + Self.footerClearance
+        )
     }
 }
 
@@ -477,9 +493,10 @@ private final class AgentHistoryMessageRowView: UIView {
         row.spacing = 10
         addSubview(row)
         row.translatesAutoresizingMaskIntoConstraints = false
+        let inset = UIKitChassis.popoverPanelInset
         NSLayoutConstraint.activate([
-            row.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-            row.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            row.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            row.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
             row.topAnchor.constraint(equalTo: topAnchor, constant: 9),
             row.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -9),
         ])

--- a/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
+++ b/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
@@ -51,8 +51,12 @@ final class CustomAgentCommandDrafts {
 /// once before handing the result to the host configuration.
 @MainActor
 final class CustomAgentCommandPanelViewController: UIViewController {
-    nonisolated static let preferredWidth: CGFloat = 500
+    nonisolated static let preferredWidth: CGFloat =
+        472 + 2 * UIKitChassis.popoverPanelInset
     nonisolated static let maximumEditorHeight: CGFloat = 430
+    /// The list viewport keeps its rows 2 pt inside the header/footer text
+    /// edge at every panel inset.
+    nonisolated static let listInset: CGFloat = UIKitChassis.popoverPanelInset - 2
     /// Below the footer legend's own resistance (see `legendRow`), so a
     /// shortened popover spends the scroll viewport before any chrome.
     private static let listHeightPriority = UILayoutPriority(650)
@@ -281,9 +285,9 @@ final class CustomAgentCommandPanelViewController: UIViewController {
         stack.isLayoutMarginsRelativeArrangement = true
         stack.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 20,
-            leading: 14,
+            leading: UIKitChassis.popoverPanelInset,
             bottom: 14,
-            trailing: 14
+            trailing: UIKitChassis.popoverPanelInset
         )
         return stack
     }
@@ -304,11 +308,11 @@ final class CustomAgentCommandPanelViewController: UIViewController {
         NSLayoutConstraint.activate([
             listStack.leadingAnchor.constraint(
                 equalTo: listScrollView.contentLayoutGuide.leadingAnchor,
-                constant: 12
+                constant: Self.listInset
             ),
             listStack.trailingAnchor.constraint(
                 equalTo: listScrollView.contentLayoutGuide.trailingAnchor,
-                constant: -12
+                constant: -Self.listInset
             ),
             listStack.topAnchor.constraint(
                 equalTo: listScrollView.contentLayoutGuide.topAnchor,
@@ -320,7 +324,7 @@ final class CustomAgentCommandPanelViewController: UIViewController {
             ),
             listStack.widthAnchor.constraint(
                 equalTo: listScrollView.frameLayoutGuide.widthAnchor,
-                constant: -24
+                constant: -2 * Self.listInset
             ),
         ])
         // The viewport's height is a ceiling that must hold and a resting
@@ -402,9 +406,9 @@ final class CustomAgentCommandPanelViewController: UIViewController {
         stack.isLayoutMarginsRelativeArrangement = true
         stack.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 14,
-            leading: 14,
-            bottom: 14,
-            trailing: 14
+            leading: UIKitChassis.popoverPanelInset,
+            bottom: UIKitChassis.popoverPanelInset,
+            trailing: UIKitChassis.popoverPanelInset
         )
         return stack
     }
@@ -559,7 +563,7 @@ final class CustomAgentCommandPanelViewController: UIViewController {
     }
 
     private func builtInColumnCount(for width: CGFloat) -> Int {
-        max(0, width - 24) >= 421 ? 2 : 1
+        max(0, width - 2 * Self.listInset) >= 421 ? 2 : 1
     }
 
     private func usesCompactControls(for width: CGFloat) -> Bool {
@@ -571,7 +575,7 @@ final class CustomAgentCommandPanelViewController: UIViewController {
         notifiesParent: Bool
     ) {
         guard isViewLoaded else { return }
-        let contentWidth = max(1, width - 24)
+        let contentWidth = max(1, width - 2 * Self.listInset)
         listStack.setNeedsLayout()
         listStack.layoutIfNeeded()
         let measured = listStack.systemLayoutSizeFitting(

--- a/Multiplex/Views/Terminal/TmuxShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/TmuxShortcutPanel.swift
@@ -6,7 +6,8 @@ import UIKit
 /// is deliberately not involved.
 @MainActor
 final class TmuxShortcutPanelViewController: UIViewController {
-    nonisolated static let preferredWidth: CGFloat = 430
+    nonisolated static let preferredWidth: CGFloat =
+        402 + 2 * UIKitChassis.popoverPanelInset
     nonisolated static let confirmationWindow: UInt64 = 2_000_000_000
 
     private var panelWidth: CGFloat
@@ -314,11 +315,12 @@ private final class TmuxShortcutPanelRootView: UIKitTallyBorderedView {
         self.contentStack = contentStack
         addSubview(contentStack)
         contentStack.translatesAutoresizingMaskIntoConstraints = false
+        let inset = UIKitChassis.popoverPanelInset
         NSLayoutConstraint.activate([
-            contentStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-            contentStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
-            contentStack.topAnchor.constraint(equalTo: topAnchor, constant: 14),
-            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -14),
+            contentStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            contentStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
+            contentStack.topAnchor.constraint(equalTo: topAnchor, constant: inset),
+            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -inset),
         ])
     }
 
@@ -327,14 +329,15 @@ private final class TmuxShortcutPanelRootView: UIKitTallyBorderedView {
     }
 
     func fittingSize(for proposedWidth: CGFloat) -> CGSize {
-        guard let contentStack else { return CGSize(width: proposedWidth, height: 28) }
-        let contentWidth = max(0, proposedWidth - 28)
+        let insets = 2 * UIKitChassis.popoverPanelInset
+        guard let contentStack else { return CGSize(width: proposedWidth, height: insets) }
+        let contentWidth = max(0, proposedWidth - insets)
         let measured = contentStack.systemLayoutSizeFitting(
             CGSize(width: contentWidth, height: UIView.layoutFittingCompressedSize.height),
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
-        return CGSize(width: proposedWidth, height: ceil(measured.height + 28))
+        return CGSize(width: proposedWidth, height: ceil(measured.height + insets))
     }
 }
 

--- a/Multiplex/Views/Terminal/UMDBarUIKit.swift
+++ b/Multiplex/Views/Terminal/UMDBarUIKit.swift
@@ -1,5 +1,8 @@
 import Observation
 import UIKit
+#if DEBUG
+import notify
+#endif
 
 enum UMDBarStyle: Equatable {
     /// The visionOS classic window's title row. The terminal key cluster
@@ -106,7 +109,11 @@ final class UMDBarViewController: UIViewController,
     private let rootView = UMDBarRootView()
     private(set) var fileAttachController: FileAttachMenuViewController
     private weak var tmuxPopoverController: TmuxShortcutPanelViewController?
+    private weak var tmuxButtonView: UMDBarButton?
     private var resumesFocusAfterTmuxShortcuts = false
+    #if DEBUG && os(visionOS)
+    private var debugObservers: [NSObjectProtocol] = []
+    #endif
     private var observationGeneration = 0
     private var renderedKey: UMDBarRenderKey?
     private var currentObservedState = UMDBarObservedState(
@@ -132,6 +139,9 @@ final class UMDBarViewController: UIViewController,
         addChild(fileAttachController)
         rootView.parkFileAttachView(fileAttachController.view)
         fileAttachController.didMove(toParent: self)
+        #if DEBUG && os(visionOS)
+        installDebugObservers()
+        #endif
         renderAndObserve()
     }
 
@@ -158,6 +168,12 @@ final class UMDBarViewController: UIViewController,
         tmuxPopoverController?.dismiss(animated: false)
         tmuxPopoverController = nil
         resumeFocusAfterTmuxPresentationIfNeeded()
+        #if DEBUG && os(visionOS)
+        for observer in debugObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        debugObservers.removeAll()
+        #endif
     }
 
     /// One action router backs direct controls and every UIMenu item, making
@@ -523,6 +539,7 @@ final class UMDBarViewController: UIViewController,
             guard let self, let button else { return }
             self.showTmuxShortcuts(from: button)
         }, for: .touchUpInside)
+        tmuxButtonView = button
         return button
     }
 
@@ -874,7 +891,57 @@ final class UMDBarViewController: UIViewController,
         resumesFocusAfterTmuxShortcuts = false
         configuration.controller?.resumeFocusAfterPresentation()
     }
+
+    #if DEBUG && os(visionOS)
+    /// visionOS spelling of `debug.tmuxshortcuts` (the iPad key rail's hook
+    /// registers the same Darwin name there): opens the focused window's UMD
+    /// tmux popover for layout capture.
+    private func installDebugObservers() {
+        UMDTmuxShortcutsDebugHook.install()
+        debugObservers.append(NotificationCenter.default.addObserver(
+            forName: .multiplexDebugUMDTmuxShortcuts,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      let terminalView = self.configuration.controller?.terminalView,
+                      TerminalFocusArbiter.current === terminalView,
+                      let button = self.tmuxButtonView
+                else { return }
+                self.showTmuxShortcuts(from: button)
+            }
+        })
+    }
+    #endif
 }
+
+#if DEBUG && os(visionOS)
+extension Notification.Name {
+    static let multiplexDebugUMDTmuxShortcuts = Notification.Name(
+        "MultiplexDebugUMDTmuxShortcuts"
+    )
+}
+
+@MainActor
+private enum UMDTmuxShortcutsDebugHook {
+    private static var installed = false
+
+    static func install() {
+        guard !installed else { return }
+        installed = true
+        var token: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.tmuxshortcuts", &token, .main
+        ) { _ in
+            NotificationCenter.default.post(
+                name: .multiplexDebugUMDTmuxShortcuts,
+                object: nil
+            )
+        }
+    }
+}
+#endif
 
 @MainActor
 final class UMDBarRootView: UIView {


### PR DESCRIPTION
## Summary
- visionOS hosts the tmux shortcuts popover, Command Setup editor, and agent HISTORY panel on the system's rounded glass platter, but all three kept the iPad-tuned 14 pt chassis inset — content crowded the corner mask.
- One shared constant, `UIKitChassis.popoverPanelInset` (22 pt visionOS / 14 pt elsewhere), now carries the clearance. Each panel's `preferredWidth` is spelled `content + 2 * inset`, so on visionOS the panels widen by 16 pt instead of narrowing their content; iPad is unchanged by construction (existing UIKit tests assert sizes against `preferredWidth` on both platforms).
- Panel specifics: the HISTORY list gains a visionOS-only 10 pt bottom clearance so its last row clears the platter's bottom corners (iPad stays flush); Command Setup's list keeps its rows 2 pt inside the header text edge at every inset (`listInset`), with the column-count and editor-height math updated in lockstep.
- `debug.tmuxshortcuts` now answers on visionOS: the UMD registers the same Darwin name (DEBUG-only, focus-guarded, presents from the ⌘ TMUX chip). The existing hook lived in the iPad key rail's `#if !os(visionOS)` block, leaving no headless way to capture that popover on visionOS.

## Verification
- `./Tools/build.sh build vos` and `build ipad` both succeed; `lint` at zero violations.
- `./Tools/build.sh test vos`: 1064 tests, 0 failures (includes the three panels' UIKit sizing suites).
- Captured all three popovers on the visionOS simulator via the debug hooks: headers, corner chips (CLOSE / DONE / ADD COMMAND), and last rows all clear the rounded mask.