### PR TITLE
Give herdr tabs their own shortcut panel (HRDR)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -753,9 +753,11 @@ logic belongs — keep parsing/command-building out of views.
   target name falls back to the fresh-session mint; a failed in-session
   create is a visible failure, never a fallback mint. herdr reports no client count or creation time.
   The shortcut panel has a herdr variant (`HerdrShortcut`, pure + tested;
-  the rail key face reads HRDR): non-destructive rows send herdr's stock
+  the rail key face reads HRDR; deliberately curated small — zoom,
+  scrollback, rename-tab, picker, and sidebar rows were trimmed
+  2026-08-02): non-destructive rows send herdr's stock
   ⌃B defaults through SwiftTerm (read from `herdr --default-config`,
-  split/zoom exercised against a real 0.7.5 TUI attach 2026-08-02 —
+  splits exercised against a real 0.7.5 TUI attach 2026-08-02 —
   `split_vertical` ⌃B V is left/right, `split_horizontal` ⌃B − is
   top/bottom; a same-burst prefix+key registers), while the confirmed
   closes resolve the focused pane/tab/workspace from ONE snapshot exec

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,8 +189,8 @@ app.multiplexterm.multiplex.<name>`:
   host-side: `herdr --session <name> api snapshot` gains a tab in the
   focused workspace and no session is minted).
 - `debug.tmuxshortcuts` / `debug.customcommands` / `debug.msghistory` — open
-  the tmux-shortcut popover / Command Setup editor / agent HISTORY panel for
-  layout capture.
+  the focused tab's shortcut popover (TMUX content, or HRDR on a herdr
+  tab) / Command Setup editor / agent HISTORY panel for layout capture.
 - `debug.link` — activate the first visible link through the resolve →
   policy → confirmation path (URL → link sheet, path → file-viewer sheet;
   text both resolvers decline must present nothing). `debug.linkopen` runs
@@ -454,7 +454,12 @@ logic belongs — keep parsing/command-building out of views.
   390/420 pt cutoffs must stay in lockstep with the measured `KeyBarRow`
   tiers (375 pt locked floor keeps RET; narrow locked phones move TMUX to
   a top-right button, and the overflow deliberately has no duplicate tmux
-  entry). The top popover opens downward; while presented, the arbiter
+  entry). "TMUX" names the shortcut-key SLOT: a herdr tab fills it with
+  HRDR — four mono characters, so every tier and cutoff holds unchanged —
+  and both open the shared `ShortcutPanelViewController`, whose content
+  (`ShortcutPanelContent.tmux`/`.herdr`) is the ONE place a backend's
+  shortcut set lives. The panel root scrolls when a phone popover clamps
+  its height — never clip rows. The top popover opens downward; while presented, the arbiter
   resigns the terminal (a docked keyboard would clip the grid) and
   restores only if that tab still owns focus. Every key sends through
   `TerminalView.send` → delegate → ordered pump — never a side channel;
@@ -747,6 +752,18 @@ logic belongs — keep parsing/command-building out of views.
   session's world: tmux active-pane cwd / herdr server default). A dead
   target name falls back to the fresh-session mint; a failed in-session
   create is a visible failure, never a fallback mint. herdr reports no client count or creation time.
+  The shortcut panel has a herdr variant (`HerdrShortcut`, pure + tested;
+  the rail key face reads HRDR): non-destructive rows send herdr's stock
+  ⌃B defaults through SwiftTerm (read from `herdr --default-config`,
+  split/zoom exercised against a real 0.7.5 TUI attach 2026-08-02 —
+  `split_vertical` ⌃B V is left/right, `split_horizontal` ⌃B − is
+  top/bottom; a same-burst prefix+key registers), while the confirmed
+  closes resolve the focused pane/tab/workspace from ONE snapshot exec
+  and close by id (`HerdrProbe.parseFocusedCloseTarget` — strictly what
+  the server names focused, never a guess) so a rebound key can't
+  misfire them. The panel's Switch Workspace section rides
+  `workspace list` → `workspace focus <id>` on the control connection;
+  response-derived ids pass the bake vet before splicing.
   Keep the Agent Gallery withdrawn until transcript support exists.
   A terminal window's `+ TAB` session press changes shape the same way
   (`TerminalRoute.newTabTarget` — the one place the entry's name, the

--- a/Multiplex/Models/HerdrShortcut.swift
+++ b/Multiplex/Models/HerdrShortcut.swift
@@ -1,9 +1,13 @@
 /// Familiar herdr commands exposed by the terminal chrome — the herdr-backend
 /// sibling of `TmuxShortcut`. herdr's default prefix is Control-B like tmux's,
 /// and non-destructive rows send the stock prefix binding through SwiftTerm.
-/// Defaults were read from `herdr --default-config` and the split/zoom/detach
+/// Defaults were read from `herdr --default-config` and the split/detach
 /// bindings exercised against a real 0.7.5 TUI attach (2026-08-02); a
 /// same-burst prefix+key registers once the client is interactive.
+/// Deliberately curated small (user-trimmed 2026-08-02): zoom, scrollback,
+/// rename-tab, the workspace picker, and the sidebar toggle are herdr UI the
+/// TUI already surfaces — the panel carries only the commands touch actually
+/// needs.
 /// Destructive commands are confirmed by our UI, then resolved and executed
 /// over the SSH control connection (`HerdrProbe.closeShortcutCommand`), so
 /// they follow herdr's server truth instead of a rebindable key and never
@@ -25,31 +29,24 @@ enum HerdrShortcut: String, CaseIterable, Identifiable, Sendable {
     case splitLeftRight
     case splitTopBottom
     case nextPane
-    case togglePaneZoom
-    case editScrollback
     case closePane
     case newTab
     case nextTab
     case previousTab
-    case renameTab
     case closeTab
     case newWorkspace
-    case workspacePicker
     case renameWorkspace
-    case toggleSidebar
     case closeWorkspace
 
     var id: Self { self }
 
     var group: Group {
         switch self {
-        case .splitLeftRight, .splitTopBottom, .nextPane, .togglePaneZoom,
-             .editScrollback, .closePane:
+        case .splitLeftRight, .splitTopBottom, .nextPane, .closePane:
             .panes
-        case .newTab, .nextTab, .previousTab, .renameTab, .closeTab:
+        case .newTab, .nextTab, .previousTab, .closeTab:
             .tabs
-        case .newWorkspace, .workspacePicker, .renameWorkspace, .toggleSidebar,
-             .closeWorkspace:
+        case .newWorkspace, .renameWorkspace, .closeWorkspace:
             .workspaces
         }
     }
@@ -59,18 +56,13 @@ enum HerdrShortcut: String, CaseIterable, Identifiable, Sendable {
         case .splitLeftRight: "Split Left / Right"
         case .splitTopBottom: "Split Top / Bottom"
         case .nextPane: "Next Pane"
-        case .togglePaneZoom: "Toggle Pane Zoom"
-        case .editScrollback: "Edit Scrollback"
         case .closePane: "Close Pane"
         case .newTab: "New Tab"
         case .nextTab: "Next Tab"
         case .previousTab: "Previous Tab"
-        case .renameTab: "Rename Tab"
         case .closeTab: "Close Tab"
         case .newWorkspace: "New Workspace"
-        case .workspacePicker: "Workspace Picker"
         case .renameWorkspace: "Rename Workspace"
-        case .toggleSidebar: "Toggle Sidebar"
         case .closeWorkspace: "Close Workspace"
         }
     }
@@ -83,18 +75,13 @@ enum HerdrShortcut: String, CaseIterable, Identifiable, Sendable {
         case .splitLeftRight: "split_vertical"
         case .splitTopBottom: "split_horizontal"
         case .nextPane: "cycle_pane_next"
-        case .togglePaneZoom: "zoom"
-        case .editScrollback: "edit_scrollback"
         case .closePane: "close_pane"
         case .newTab: "new_tab"
         case .nextTab: "next_tab"
         case .previousTab: "previous_tab"
-        case .renameTab: "rename_tab"
         case .closeTab: "close_tab"
         case .newWorkspace: "new_workspace"
-        case .workspacePicker: "workspace_picker"
         case .renameWorkspace: "rename_workspace"
-        case .toggleSidebar: "toggle_sidebar"
         case .closeWorkspace: "close_workspace"
         }
     }
@@ -107,16 +94,11 @@ enum HerdrShortcut: String, CaseIterable, Identifiable, Sendable {
         case .splitLeftRight: "v"
         case .splitTopBottom: "-"
         case .nextPane: "\t"
-        case .togglePaneZoom: "z"
-        case .editScrollback: "e"
         case .newTab: "c"
         case .nextTab: "n"
         case .previousTab: "p"
-        case .renameTab: "T"
         case .newWorkspace: "N"
-        case .workspacePicker: "w"
         case .renameWorkspace: "W"
-        case .toggleSidebar: "b"
         case .closePane, .closeTab, .closeWorkspace: nil
         }
     }
@@ -136,7 +118,6 @@ enum HerdrShortcut: String, CaseIterable, Identifiable, Sendable {
         guard !requiresDoubleActivation else { return "2×" }
         switch self {
         case .nextPane: return "⌃B ⇥"
-        case .renameTab: return "⌃B ⇧T"
         case .newWorkspace: return "⌃B ⇧N"
         case .renameWorkspace: return "⌃B ⇧W"
         default: return "⌃B \(binding.map { String($0).uppercased() } ?? "")"

--- a/Multiplex/Models/HerdrShortcut.swift
+++ b/Multiplex/Models/HerdrShortcut.swift
@@ -1,0 +1,158 @@
+/// Familiar herdr commands exposed by the terminal chrome — the herdr-backend
+/// sibling of `TmuxShortcut`. herdr's default prefix is Control-B like tmux's,
+/// and non-destructive rows send the stock prefix binding through SwiftTerm.
+/// Defaults were read from `herdr --default-config` and the split/zoom/detach
+/// bindings exercised against a real 0.7.5 TUI attach (2026-08-02); a
+/// same-burst prefix+key registers once the client is interactive.
+/// Destructive commands are confirmed by our UI, then resolved and executed
+/// over the SSH control connection (`HerdrProbe.closeShortcutCommand`), so
+/// they follow herdr's server truth instead of a rebindable key and never
+/// meet herdr's own confirmation dialog twice.
+enum HerdrShortcut: String, CaseIterable, Identifiable, Sendable {
+    enum Group: String, CaseIterable, Sendable {
+        case panes = "Panes"
+        case tabs = "Tabs"
+        case workspaces = "Workspaces"
+    }
+
+    /// What a confirmed destructive row closes. The raw value is herdr's own
+    /// CLI noun (`herdr pane|tab|workspace close <id>`), spliced verbatim by
+    /// `HerdrProbe.closeShortcutCommand`.
+    enum CloseScope: String, Sendable {
+        case pane, tab, workspace
+    }
+
+    case splitLeftRight
+    case splitTopBottom
+    case nextPane
+    case togglePaneZoom
+    case editScrollback
+    case closePane
+    case newTab
+    case nextTab
+    case previousTab
+    case renameTab
+    case closeTab
+    case newWorkspace
+    case workspacePicker
+    case renameWorkspace
+    case toggleSidebar
+    case closeWorkspace
+
+    var id: Self { self }
+
+    var group: Group {
+        switch self {
+        case .splitLeftRight, .splitTopBottom, .nextPane, .togglePaneZoom,
+             .editScrollback, .closePane:
+            .panes
+        case .newTab, .nextTab, .previousTab, .renameTab, .closeTab:
+            .tabs
+        case .newWorkspace, .workspacePicker, .renameWorkspace, .toggleSidebar,
+             .closeWorkspace:
+            .workspaces
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .splitLeftRight: "Split Left / Right"
+        case .splitTopBottom: "Split Top / Bottom"
+        case .nextPane: "Next Pane"
+        case .togglePaneZoom: "Toggle Pane Zoom"
+        case .editScrollback: "Edit Scrollback"
+        case .closePane: "Close Pane"
+        case .newTab: "New Tab"
+        case .nextTab: "Next Tab"
+        case .previousTab: "Previous Tab"
+        case .renameTab: "Rename Tab"
+        case .closeTab: "Close Tab"
+        case .newWorkspace: "New Workspace"
+        case .workspacePicker: "Workspace Picker"
+        case .renameWorkspace: "Rename Workspace"
+        case .toggleSidebar: "Toggle Sidebar"
+        case .closeWorkspace: "Close Workspace"
+        }
+    }
+
+    /// herdr's config action name (`[keys]` in config.toml), shown as
+    /// supporting text: it names the action for both execution paths and is
+    /// exactly the key a user would rebind.
+    var command: String {
+        switch self {
+        case .splitLeftRight: "split_vertical"
+        case .splitTopBottom: "split_horizontal"
+        case .nextPane: "cycle_pane_next"
+        case .togglePaneZoom: "zoom"
+        case .editScrollback: "edit_scrollback"
+        case .closePane: "close_pane"
+        case .newTab: "new_tab"
+        case .nextTab: "next_tab"
+        case .previousTab: "previous_tab"
+        case .renameTab: "rename_tab"
+        case .closeTab: "close_tab"
+        case .newWorkspace: "new_workspace"
+        case .workspacePicker: "workspace_picker"
+        case .renameWorkspace: "rename_workspace"
+        case .toggleSidebar: "toggle_sidebar"
+        case .closeWorkspace: "close_workspace"
+        }
+    }
+
+    /// The key pressed after the prefix. Uppercase letters are herdr's
+    /// `prefix+shift+…` defaults — the terminal byte for Shift+letter IS the
+    /// uppercase letter; `\t` is `prefix+tab`.
+    var binding: Character? {
+        switch self {
+        case .splitLeftRight: "v"
+        case .splitTopBottom: "-"
+        case .nextPane: "\t"
+        case .togglePaneZoom: "z"
+        case .editScrollback: "e"
+        case .newTab: "c"
+        case .nextTab: "n"
+        case .previousTab: "p"
+        case .renameTab: "T"
+        case .newWorkspace: "N"
+        case .workspacePicker: "w"
+        case .renameWorkspace: "W"
+        case .toggleSidebar: "b"
+        case .closePane, .closeTab, .closeWorkspace: nil
+        }
+    }
+
+    var closeScope: CloseScope? {
+        switch self {
+        case .closePane: .pane
+        case .closeTab: .tab
+        case .closeWorkspace: .workspace
+        default: nil
+        }
+    }
+
+    var requiresDoubleActivation: Bool { closeScope != nil }
+
+    var bindingLabel: String {
+        guard !requiresDoubleActivation else { return "2×" }
+        switch self {
+        case .nextPane: return "⌃B ⇥"
+        case .renameTab: return "⌃B ⇧T"
+        case .newWorkspace: return "⌃B ⇧N"
+        case .renameWorkspace: return "⌃B ⇧W"
+        default: return "⌃B \(binding.map { String($0).uppercased() } ?? "")"
+        }
+    }
+
+    /// Non-destructive actions ride the stock binding through SwiftTerm's
+    /// ordered input path. The confirmed closes deliberately have none: after
+    /// the panel's second press they resolve the focused target and close it
+    /// through `HerdrProbe`, never a keybinding.
+    var bindingInput: [UInt8]? {
+        guard closeScope == nil, let binding else { return nil }
+        return [0x02, binding.asciiValue!]
+    }
+
+    static func shortcuts(in group: Group) -> [Self] {
+        allCases.filter { $0.group == group }
+    }
+}

--- a/Multiplex/Models/ShortcutPanelContent.swift
+++ b/Multiplex/Models/ShortcutPanelContent.swift
@@ -1,0 +1,104 @@
+/// Pure presentation records for the shared multiplexer-shortcut panel: one
+/// UIKit dropdown renders both the tmux and the herdr shortcut sets. Derived
+/// entirely from `TmuxShortcut`/`HerdrShortcut` so the enums stay the single
+/// source of bindings and the panel view never learns a backend.
+struct ShortcutPanelItem: Equatable, Sendable, Identifiable {
+    /// The backend action a row performs, carried typed so selection
+    /// dispatches without string lookups. A payload mismatched to the tab's
+    /// backend fails closed on the controller's own route guards.
+    enum Payload: Equatable, Sendable {
+        case tmux(TmuxShortcut)
+        case herdr(HerdrShortcut)
+    }
+
+    var payload: Payload
+    var title: String
+    var command: String
+    var bindingLabel: String
+    var requiresDoubleActivation: Bool
+    var accessibilityIdentifier: String
+
+    var id: String { accessibilityIdentifier }
+
+    init(_ shortcut: TmuxShortcut) {
+        payload = .tmux(shortcut)
+        title = shortcut.title
+        command = shortcut.command
+        bindingLabel = shortcut.bindingLabel
+        requiresDoubleActivation = shortcut.requiresDoubleActivation
+        accessibilityIdentifier = "tmuxShortcut.\(shortcut.rawValue)"
+    }
+
+    init(_ shortcut: HerdrShortcut) {
+        payload = .herdr(shortcut)
+        title = shortcut.title
+        command = shortcut.command
+        bindingLabel = shortcut.bindingLabel
+        requiresDoubleActivation = shortcut.requiresDoubleActivation
+        accessibilityIdentifier = "herdrShortcut.\(shortcut.rawValue)"
+    }
+}
+
+struct ShortcutPanelSection: Equatable, Sendable {
+    var title: String
+    var accessibilityIdentifier: String
+    var items: [ShortcutPanelItem]
+}
+
+/// Everything one backend's panel shows. The switch section is the live list
+/// loaded after presentation: tmux windows or herdr workspaces, both carried
+/// as `TmuxWindowChoice` rows the way the probe reuses the tmux records.
+struct ShortcutPanelContent: Equatable, Sendable {
+    var headerTitle: String
+    var prefixLabel: String
+    var sections: [ShortcutPanelSection]
+    var switchSectionTitle: String
+    var switchSectionAccessibilityIdentifier: String
+    var switchChoiceAccessibilityPrefix: String
+    /// Spoken row noun ("window"/"workspace") for the switch rows.
+    var switchNoun: String
+
+    static let tmux = ShortcutPanelContent(
+        headerTitle: "TMUX SHORTCUTS",
+        prefixLabel: "DEFAULT PREFIX  ⌃B",
+        sections: TmuxShortcut.Group.allCases.map { group in
+            ShortcutPanelSection(
+                title: group.rawValue,
+                accessibilityIdentifier: "tmuxGroup.\(group.rawValue)",
+                items: TmuxShortcut.shortcuts(in: group).map(ShortcutPanelItem.init)
+            )
+        },
+        switchSectionTitle: "Switch Window",
+        switchSectionAccessibilityIdentifier: "tmuxWindowSection",
+        switchChoiceAccessibilityPrefix: "tmuxWindow.",
+        switchNoun: "window"
+    )
+
+    /// herdr's default prefix is also Control-B (`herdr --default-config`,
+    /// 0.7.5) — the header states the same truth for both backends.
+    static let herdr = ShortcutPanelContent(
+        headerTitle: "HERDR SHORTCUTS",
+        prefixLabel: "DEFAULT PREFIX  ⌃B",
+        sections: HerdrShortcut.Group.allCases.map { group in
+            ShortcutPanelSection(
+                title: group.rawValue,
+                accessibilityIdentifier: "herdrGroup.\(group.rawValue)",
+                items: HerdrShortcut.shortcuts(in: group).map(ShortcutPanelItem.init)
+            )
+        },
+        switchSectionTitle: "Switch Workspace",
+        switchSectionAccessibilityIdentifier: "herdrWorkspaceSection",
+        switchChoiceAccessibilityPrefix: "herdrWorkspace.",
+        switchNoun: "workspace"
+    )
+
+    /// The panel for one terminal tab's backend; nil hides the chrome
+    /// entirely (plain shells, viewports, the file viewer).
+    static func content(for backend: Host.SessionBackend?) -> ShortcutPanelContent? {
+        switch backend {
+        case .tmux: .tmux
+        case .herdr: .herdr
+        case nil: nil
+        }
+    }
+}

--- a/Multiplex/Models/SingleWindowShellPolicy.swift
+++ b/Multiplex/Models/SingleWindowShellPolicy.swift
@@ -43,6 +43,8 @@ enum SingleWindowShellLayout {
     /// An unlocked compact key rail retains TMUX at 390 points. Keyboard lock
     /// adds RET on iPhone; its slightly tighter Air tier keeps both controls at
     /// 420 points, while narrower locked phones move TMUX to the top bar.
+    /// "TMUX" names the shortcut-key slot — herdr tabs fill it with HRDR at
+    /// the same four-character width, so both cutoffs hold for both backends.
     static let keyBarTmuxMinimumWidth: CGFloat = 390
     static let keyBarTmuxWithReturnMinimumWidth: CGFloat = 420
 

--- a/Multiplex/Services/HerdrProbe.swift
+++ b/Multiplex/Services/HerdrProbe.swift
@@ -318,6 +318,7 @@ enum HerdrProbe {
         var layouts: [Layout]
         /// The session's ONE focus — what every attached client shows.
         var focusedWorkspaceID: String?
+        var focusedTabID: String?
         var focusedPaneID: String?
 
         enum CodingKeys: String, CodingKey {
@@ -325,6 +326,7 @@ enum HerdrProbe {
             case protocolVersion = "protocol"
             case workspaces, panes, layouts
             case focusedWorkspaceID = "focused_workspace_id"
+            case focusedTabID = "focused_tab_id"
             case focusedPaneID = "focused_pane_id"
         }
     }
@@ -334,11 +336,15 @@ enum HerdrProbe {
         var number: Int
         var label: String
         var activeTabID: String
+        /// Present in `workspace list` entries (and snapshots); the snapshot
+        /// path keeps deciding focus by `focusedWorkspaceID`.
+        var focused: Bool?
 
         enum CodingKeys: String, CodingKey {
             case workspaceID = "workspace_id"
             case number, label
             case activeTabID = "active_tab_id"
+            case focused
         }
     }
 
@@ -739,6 +745,91 @@ enum HerdrProbe {
         (try? JSONDecoder().decode(
             Envelope<CreatedResult>.self, from: Data(text.utf8)))?
             .result.rootPane.paneID
+    }
+
+    // MARK: - Shortcut panel (HRDR)
+
+    /// The shortcut panel's workspace list for one session — the herdr
+    /// analog of `TmuxProbe.windowListCommand`, one envelope exec.
+    static func workspaceListCommand(sessionName: String) -> String {
+        pathPrefix
+            + "herdr --session \(sessionName.shellQuoted) workspace list"
+            + " 2>/dev/null || true"
+    }
+
+    /// Workspaces as the panel's switch rows, reusing the tmux choice record
+    /// the way the probe reuses `TmuxSession` — `tmuxID` carries herdr's
+    /// workspace id. nil when nothing decodes; the panel then simply shows
+    /// no switch section.
+    static func parseWorkspaceChoices(_ output: String) -> [TmuxWindowChoice]? {
+        guard let list = firstDecodedLine(in: output, decodeWorkspaceList)
+        else { return nil }
+        return list.workspaces
+            .sorted { $0.number < $1.number }
+            .map { workspace in
+                TmuxWindowChoice(
+                    tmuxID: workspace.workspaceID,
+                    index: workspace.number,
+                    isActive: workspace.focused ?? false,
+                    name: displayLabel(workspace)
+                )
+            }
+    }
+
+    private struct WorkspaceListResult: Decodable {
+        var workspaces: [Workspace]
+    }
+
+    private static func decodeWorkspaceList(_ text: String) -> WorkspaceListResult? {
+        (try? JSONDecoder().decode(
+            Envelope<WorkspaceListResult>.self, from: Data(text.utf8)))?.result
+    }
+
+    /// Switch the session's ONE global focus to a workspace — every attached
+    /// client follows, exactly like the panel's tmux `select-window`. The id
+    /// is response-derived, so it passes the same framing vet as pane ids;
+    /// nil means the row is not actionable.
+    static func focusWorkspaceCommand(
+        sessionName: String, workspaceID: String
+    ) -> String? {
+        guard bakeablePaneID(workspaceID) else { return nil }
+        return pathPrefix
+            + "herdr --session \(sessionName.shellQuoted)"
+            + " workspace focus \(workspaceID.shellQuoted) 2>/dev/null || true"
+    }
+
+    /// The target a confirmed destructive close aims at, resolved from one
+    /// snapshot exec: strictly what the server names focused — a close must
+    /// never guess. The focused tab falls back to the focused workspace's
+    /// active tab (the same tab by definition, stated two ways).
+    static func parseFocusedCloseTarget(
+        _ output: String, scope: HerdrShortcut.CloseScope
+    ) -> String? {
+        guard let snapshot = firstDecodedLine(in: output, decodeSnapshot)
+        else { return nil }
+        let target: String? = switch scope {
+        case .pane:
+            snapshot.focusedPaneID
+        case .tab:
+            snapshot.focusedTabID ?? snapshot.workspaces.first {
+                $0.workspaceID == snapshot.focusedWorkspaceID
+            }?.activeTabID
+        case .workspace:
+            snapshot.focusedWorkspaceID
+        }
+        return target.flatMap { bakeablePaneID($0) ? $0 : nil }
+    }
+
+    /// Close one resolved target. The UI has already required the second
+    /// press, and the CLI verbs close without their own confirmation.
+    static func closeShortcutCommand(
+        sessionName: String, scope: HerdrShortcut.CloseScope, targetID: String
+    ) -> String? {
+        guard bakeablePaneID(targetID) else { return nil }
+        return pathPrefix
+            + "herdr --session \(sessionName.shellQuoted)"
+            + " \(scope.rawValue) close \(targetID.shellQuoted)"
+            + " 2>/dev/null || true"
     }
 
     /// A user-entered name reduced to what a herdr session (a directory

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -810,6 +810,16 @@ final class TerminalSessionController {
         }
     }
 
+    /// One entry point for the shared shortcut panel: dispatch by the row's
+    /// own payload. A payload mismatched to this tab's backend fails closed
+    /// on the per-backend route guards below.
+    func performPanelShortcut(_ item: ShortcutPanelItem) {
+        switch item.payload {
+        case .tmux(let shortcut): performTmuxShortcut(shortcut)
+        case .herdr(let shortcut): performHerdrShortcut(shortcut)
+        }
+    }
+
     /// Run one command from the shared tmux panel. Ordinary shortcuts enter
     /// through SwiftTerm exactly like keyboard input. Destructive shortcuts
     /// were already confirmed by the panel's second press and use an SSH exec
@@ -837,7 +847,61 @@ final class TerminalSessionController {
         guard let command = TmuxProbe.directShortcutCommand(
             shortcut, sessionName: sessionName
         ) else { return }
-        Task { await executeTmuxControlCommand(command) }
+        Task { await executeControlCommand(command) }
+    }
+
+    /// Run one command from the herdr panel (HRDR) — `performTmuxShortcut`'s
+    /// herdr-backend sibling. Non-destructive rows send herdr's stock ⌃B
+    /// binding through SwiftTerm; the confirmed closes resolve the focused
+    /// target from one snapshot exec and close it by id, so they follow the
+    /// server's truth rather than a rebindable key.
+    func performHerdrShortcut(_ shortcut: HerdrShortcut) {
+        guard status == .live, route.sessionBackend == .herdr,
+              let sessionName = route.sessionName
+        else { return }
+        if case .finding = historyJump { return }
+        if let input = shortcut.bindingInput {
+            terminalView?.send(input)
+            return
+        }
+        guard let scope = shortcut.closeScope else { return }
+        Task { await closeHerdrFocusedTarget(scope, sessionName: sessionName) }
+    }
+
+    /// Snapshot → focused id → close, two control execs. An unreadable
+    /// snapshot or an unnamed focus declines silently — the tmux closes'
+    /// `[ -n "$target" ]` posture: a close must never guess its target.
+    private func closeHerdrFocusedTarget(
+        _ scope: HerdrShortcut.CloseScope, sessionName: String
+    ) async {
+        let snapshot = HerdrProbe.snapshotCommand(sessionName: sessionName)
+        guard let output = try? await withControlConnection({
+            try await $0.exec(snapshot)
+        }),
+            let target = HerdrProbe.parseFocusedCloseTarget(output, scope: scope),
+            let close = HerdrProbe.closeShortcutCommand(
+                sessionName: sessionName, scope: scope, targetID: target
+            )
+        else { return }
+        await executeControlCommand(close)
+    }
+
+    /// The shortcut panel's switch list — tmux windows or herdr workspaces,
+    /// decided by this tab's backend so the panel never learns one.
+    func loadShortcutSwitchChoices() async -> [TmuxWindowChoice]? {
+        switch route.sessionBackend {
+        case .tmux: await loadTmuxWindowList()
+        case .herdr: await loadHerdrWorkspaceList()
+        case nil: nil
+        }
+    }
+
+    func selectShortcutSwitchChoice(_ choice: TmuxWindowChoice) {
+        switch route.sessionBackend {
+        case .tmux: selectTmuxWindow(choice)
+        case .herdr: selectHerdrWorkspace(choice)
+        case nil: break
+        }
     }
 
     /// The shortcut panel's window list, read through the control path so
@@ -861,7 +925,32 @@ final class TerminalSessionController {
         guard status == .live, route.usesTmux else { return }
         if case .finding = historyJump { return }
         let command = TmuxProbe.selectWindowCommand(windowID: window.tmuxID)
-        Task { await executeTmuxControlCommand(command) }
+        Task { await executeControlCommand(command) }
+    }
+
+    /// The herdr panel's workspace rows, through the same control path.
+    func loadHerdrWorkspaceList() async -> [TmuxWindowChoice]? {
+        guard status == .live, route.sessionBackend == .herdr,
+              let sessionName = route.sessionName
+        else { return nil }
+        let command = HerdrProbe.workspaceListCommand(sessionName: sessionName)
+        guard let output = try? await withControlConnection({
+            try await $0.exec(command)
+        }) else { return nil }
+        return HerdrProbe.parseWorkspaceChoices(output)
+    }
+
+    /// Focus one workspace of the attached herdr session — the session's ONE
+    /// global focus moves, and the attached client follows on its own.
+    func selectHerdrWorkspace(_ choice: TmuxWindowChoice) {
+        guard status == .live, route.sessionBackend == .herdr,
+              let sessionName = route.sessionName
+        else { return }
+        if case .finding = historyJump { return }
+        guard let command = HerdrProbe.focusWorkspaceCommand(
+            sessionName: sessionName, workspaceID: choice.tmuxID
+        ) else { return }
+        Task { await executeControlCommand(command) }
     }
 
     /// Leave the contextual copy UI and tmux copy mode together. Escape is
@@ -987,7 +1076,7 @@ final class TerminalSessionController {
     /// SSH tabs already own an exec-capable connection next to their PTY.
     /// Mosh tabs deliberately do not, so a destructive user action opens a
     /// short-lived SSH control connection and closes it after the command.
-    private func executeTmuxControlCommand(_ command: String) async {
+    private func executeControlCommand(_ command: String) async {
         if let connection {
             _ = try? await connection.exec(command)
             return

--- a/Multiplex/Views/Terminal/ShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/ShortcutPanel.swift
@@ -1,39 +1,43 @@
 import UIKit
 
 /// UIKit implementation of the custom TALLY dropdown shared by the iPad key
-/// rail and the visionOS UMD. Commands live in a compact square grid with the
-/// human label, tmux command, and stock binding; the system Menu row treatment
+/// rail and the visionOS UMD, rendering one backend's `ShortcutPanelContent`
+/// (TMUX or HRDR). Commands live in a compact square grid with the human
+/// label, command reference, and stock binding; the system Menu row treatment
 /// is deliberately not involved.
 @MainActor
-final class TmuxShortcutPanelViewController: UIViewController {
+final class ShortcutPanelViewController: UIViewController {
     nonisolated static let preferredWidth: CGFloat = 430
     nonisolated static let confirmationWindow: UInt64 = 2_000_000_000
 
+    private let content: ShortcutPanelContent
     private var panelWidth: CGFloat
-    private var select: (TmuxShortcut) -> Void
-    private var loadWindows: (() async -> [TmuxWindowChoice]?)?
-    private var selectWindow: ((TmuxWindowChoice) -> Void)?
+    private var select: (ShortcutPanelItem) -> Void
+    private var loadChoices: (() async -> [TmuxWindowChoice]?)?
+    private var selectChoice: ((TmuxWindowChoice) -> Void)?
 
-    private let panelView: TmuxShortcutPanelRootView
+    private let panelView: ShortcutPanelRootView
     private let contentStack = UIStackView()
-    private let windowSection = UIStackView()
-    private var shortcutButtons: [TmuxShortcut: TmuxShortcutButton] = [:]
-    private var windowLoadTask: Task<Void, Never>?
+    private let switchSection = UIStackView()
+    private var itemButtons: [String: ShortcutItemButton] = [:]
+    private var choiceLoadTask: Task<Void, Never>?
     private var disarmTask: Task<Void, Never>?
-    private var armedShortcut: TmuxShortcut?
-    private var didRequestWindows = false
+    private var armedItemID: String?
+    private var didRequestChoices = false
 
     init(
-        width: CGFloat = TmuxShortcutPanelViewController.preferredWidth,
-        select: @escaping (TmuxShortcut) -> Void,
-        loadWindows: (() async -> [TmuxWindowChoice]?)? = nil,
-        selectWindow: ((TmuxWindowChoice) -> Void)? = nil
+        content: ShortcutPanelContent,
+        width: CGFloat = ShortcutPanelViewController.preferredWidth,
+        select: @escaping (ShortcutPanelItem) -> Void,
+        loadChoices: (() async -> [TmuxWindowChoice]?)? = nil,
+        selectChoice: ((TmuxWindowChoice) -> Void)? = nil
     ) {
+        self.content = content
         panelWidth = width
         self.select = select
-        self.loadWindows = loadWindows
-        self.selectWindow = selectWindow
-        panelView = TmuxShortcutPanelRootView(width: width)
+        self.loadChoices = loadChoices
+        self.selectChoice = selectChoice
+        panelView = ShortcutPanelRootView(width: width)
         super.init(nibName: nil, bundle: nil)
         preferredContentSize = panelView.intrinsicContentSize
     }
@@ -49,14 +53,14 @@ final class TmuxShortcutPanelViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        requestWindowsIfNeeded()
+        requestChoicesIfNeeded()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         disarm()
-        windowLoadTask?.cancel()
-        windowLoadTask = nil
+        choiceLoadTask?.cancel()
+        choiceLoadTask = nil
     }
 
     /// The view controller owns an intrinsic height so UIKit popovers follow
@@ -67,36 +71,38 @@ final class TmuxShortcutPanelViewController: UIViewController {
     }
 
     /// Internal by design: it is the single render path used by the async
-    /// loader and by UIKit-focused tests. A single window has no useful switch
-    /// action and therefore earns no section.
-    func applyWindows(_ windows: [TmuxWindowChoice]) {
-        windowSection.arrangedSubviews.forEach {
-            windowSection.removeArrangedSubview($0)
+    /// loader and by UIKit-focused tests. A single window/workspace has no
+    /// useful switch action and therefore earns no section.
+    func applyChoices(_ choices: [TmuxWindowChoice]) {
+        switchSection.arrangedSubviews.forEach {
+            switchSection.removeArrangedSubview($0)
             $0.removeFromSuperview()
         }
 
-        guard windows.count > 1 else {
-            windowSection.isHidden = true
+        guard choices.count > 1 else {
+            switchSection.isHidden = true
             refreshPreferredContentSize()
             return
         }
 
         let title = UIKitChassisLabel(
-            "Switch Window",
+            content.switchSectionTitle,
             size: 9,
             color: UIKitChassis.signal2
         )
         title.accessibilityTraits.insert(.header)
-        title.accessibilityIdentifier = "tmuxWindowSection.title"
-        windowSection.addArrangedSubview(title)
+        title.accessibilityIdentifier =
+            "\(content.switchSectionAccessibilityIdentifier).title"
+        switchSection.addArrangedSubview(title)
 
-        let grid = makeWindowGrid(windows)
-        if windows.count > 8 {
+        let grid = makeChoiceGrid(choices)
+        if choices.count > 8 {
             let scrollView = UIScrollView()
             scrollView.backgroundColor = UIKitChassis.bezelHi
             scrollView.showsVerticalScrollIndicator = true
             scrollView.alwaysBounceVertical = false
-            scrollView.accessibilityIdentifier = "tmuxWindowSection.scroll"
+            scrollView.accessibilityIdentifier =
+                "\(content.switchSectionAccessibilityIdentifier).scroll"
             scrollView.addSubview(grid)
             grid.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
@@ -107,12 +113,12 @@ final class TmuxShortcutPanelViewController: UIViewController {
                 grid.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
                 scrollView.heightAnchor.constraint(equalToConstant: 200),
             ])
-            windowSection.addArrangedSubview(scrollView)
+            switchSection.addArrangedSubview(scrollView)
         } else {
-            windowSection.addArrangedSubview(grid)
+            switchSection.addArrangedSubview(grid)
         }
 
-        windowSection.isHidden = false
+        switchSection.isHidden = false
         refreshPreferredContentSize()
     }
 
@@ -128,23 +134,24 @@ final class TmuxShortcutPanelViewController: UIViewController {
         panelView.install(contentStack: contentStack)
 
         contentStack.addArrangedSubview(makeHeader())
-        for group in TmuxShortcut.Group.allCases {
-            contentStack.addArrangedSubview(makeShortcutSection(group))
+        for section in content.sections {
+            contentStack.addArrangedSubview(makeShortcutSection(section))
         }
 
-        windowSection.axis = .vertical
-        windowSection.alignment = .fill
-        windowSection.spacing = 6
-        windowSection.isHidden = true
-        windowSection.accessibilityIdentifier = "tmuxWindowSection"
-        contentStack.addArrangedSubview(windowSection)
+        switchSection.axis = .vertical
+        switchSection.alignment = .fill
+        switchSection.spacing = 6
+        switchSection.isHidden = true
+        switchSection.accessibilityIdentifier =
+            content.switchSectionAccessibilityIdentifier
+        contentStack.addArrangedSubview(switchSection)
     }
 
     private func makeHeader() -> UIView {
-        let title = UIKitChassisLabel("TMUX SHORTCUTS", size: 13)
+        let title = UIKitChassisLabel(content.headerTitle, size: 13)
         title.accessibilityTraits.insert(.header)
-        let prefix = TmuxPanelLabel(
-            "DEFAULT PREFIX  ⌃B",
+        let prefix = ShortcutPanelLabel(
+            content.prefixLabel,
             font: UIKitChassis.monoFont(9, weight: .semibold),
             color: UIKitChassis.signal2,
             kern: 0.8
@@ -172,34 +179,37 @@ final class TmuxShortcutPanelViewController: UIViewController {
         return container
     }
 
-    private func makeShortcutSection(_ group: TmuxShortcut.Group) -> UIView {
+    private func makeShortcutSection(_ section: ShortcutPanelSection) -> UIView {
         let title = UIKitChassisLabel(
-            group.rawValue,
+            section.title,
             size: 9,
             color: UIKitChassis.signal2
         )
         title.accessibilityTraits.insert(.header)
-        title.accessibilityIdentifier = "tmuxGroup.\(group.rawValue)"
+        title.accessibilityIdentifier = section.accessibilityIdentifier
 
-        let shortcuts = TmuxShortcut.shortcuts(in: group)
-        let grid = makeTwoColumnGrid(shortcuts.map { shortcut in
-            let button = TmuxShortcutButton(shortcut: shortcut)
-            button.addTarget(self, action: #selector(shortcutPressed(_:)), for: .touchUpInside)
-            shortcutButtons[shortcut] = button
+        let grid = makeTwoColumnGrid(section.items.map { item in
+            let button = ShortcutItemButton(item: item)
+            button.addTarget(self, action: #selector(itemPressed(_:)), for: .touchUpInside)
+            itemButtons[item.id] = button
             return button
         })
 
-        let section = UIStackView(arrangedSubviews: [title, grid])
-        section.axis = .vertical
-        section.alignment = .fill
-        section.spacing = 6
-        return section
+        let stack = UIStackView(arrangedSubviews: [title, grid])
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 6
+        return stack
     }
 
-    private func makeWindowGrid(_ windows: [TmuxWindowChoice]) -> UIView {
-        makeTwoColumnGrid(windows.map { window in
-            let button = TmuxWindowButton(window: window)
-            button.addTarget(self, action: #selector(windowPressed(_:)), for: .touchUpInside)
+    private func makeChoiceGrid(_ choices: [TmuxWindowChoice]) -> UIView {
+        makeTwoColumnGrid(choices.map { choice in
+            let button = ShortcutChoiceButton(
+                choice: choice,
+                noun: content.switchNoun,
+                accessibilityPrefix: content.switchChoiceAccessibilityPrefix
+            )
+            button.addTarget(self, action: #selector(choicePressed(_:)), for: .touchUpInside)
             return button
         })
     }
@@ -232,34 +242,34 @@ final class TmuxShortcutPanelViewController: UIViewController {
         return grid
     }
 
-    @objc private func shortcutPressed(_ sender: TmuxShortcutButton) {
-        activate(sender.shortcut)
+    @objc private func itemPressed(_ sender: ShortcutItemButton) {
+        activate(sender.item)
     }
 
-    @objc private func windowPressed(_ sender: TmuxWindowButton) {
+    @objc private func choicePressed(_ sender: ShortcutChoiceButton) {
         disarm()
-        selectWindow?(sender.windowChoice)
+        selectChoice?(sender.choice)
     }
 
-    private func activate(_ shortcut: TmuxShortcut) {
-        guard shortcut.requiresDoubleActivation else {
+    private func activate(_ item: ShortcutPanelItem) {
+        guard item.requiresDoubleActivation else {
             disarm()
-            select(shortcut)
+            select(item)
             return
         }
 
-        if armedShortcut == shortcut {
+        if armedItemID == item.id {
             disarm()
-            select(shortcut)
+            select(item)
             return
         }
 
         disarmTask?.cancel()
-        setArmedShortcut(shortcut)
+        setArmedItemID(item.id)
         disarmTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: Self.confirmationWindow)
-            guard !Task.isCancelled, self?.armedShortcut == shortcut else { return }
-            self?.setArmedShortcut(nil)
+            guard !Task.isCancelled, self?.armedItemID == item.id else { return }
+            self?.setArmedItemID(nil)
             self?.disarmTask = nil
         }
     }
@@ -267,24 +277,24 @@ final class TmuxShortcutPanelViewController: UIViewController {
     private func disarm() {
         disarmTask?.cancel()
         disarmTask = nil
-        setArmedShortcut(nil)
+        setArmedItemID(nil)
     }
 
-    private func setArmedShortcut(_ shortcut: TmuxShortcut?) {
-        armedShortcut = shortcut
-        for (candidate, button) in shortcutButtons {
-            button.setArmed(candidate == shortcut)
+    private func setArmedItemID(_ id: String?) {
+        armedItemID = id
+        for (candidate, button) in itemButtons {
+            button.setArmed(candidate == id)
         }
     }
 
-    private func requestWindowsIfNeeded() {
-        guard !didRequestWindows, let loadWindows else { return }
-        didRequestWindows = true
-        windowLoadTask = Task { @MainActor [weak self] in
-            let windows = await loadWindows() ?? []
+    private func requestChoicesIfNeeded() {
+        guard !didRequestChoices, let loadChoices else { return }
+        didRequestChoices = true
+        choiceLoadTask = Task { @MainActor [weak self] in
+            let choices = await loadChoices() ?? []
             guard !Task.isCancelled else { return }
-            self?.applyWindows(windows)
-            self?.windowLoadTask = nil
+            self?.applyChoices(choices)
+            self?.choiceLoadTask = nil
         }
     }
 
@@ -301,8 +311,9 @@ final class TmuxShortcutPanelViewController: UIViewController {
 }
 
 @MainActor
-private final class TmuxShortcutPanelRootView: UIKitTallyBorderedView {
+private final class ShortcutPanelRootView: UIKitTallyBorderedView {
     private var width: CGFloat
+    private let scrollView = UIScrollView()
     private weak var contentStack: UIStackView?
 
     init(width: CGFloat) {
@@ -310,15 +321,33 @@ private final class TmuxShortcutPanelRootView: UIKitTallyBorderedView {
         super.init(frame: .zero)
     }
 
+    /// The content lives in a scroll view: `preferredContentSize` asks for
+    /// the full grid, but an iPhone popover clamps tall content to the
+    /// screen (the herdr set plus a workspace grid overflows one), and a
+    /// clamped panel must scroll — never clip rows mid-face.
     func install(contentStack: UIStackView) {
         self.contentStack = contentStack
-        addSubview(contentStack)
+        scrollView.alwaysBounceVertical = false
+        scrollView.showsVerticalScrollIndicator = true
+        addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            contentStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-            contentStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
-            contentStack.topAnchor.constraint(equalTo: topAnchor, constant: 14),
-            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -14),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            contentStack.leadingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 14),
+            contentStack.trailingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -14),
+            contentStack.topAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 14),
+            contentStack.bottomAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -14),
+            contentStack.widthAnchor.constraint(
+                equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -28),
         ])
     }
 
@@ -339,32 +368,32 @@ private final class TmuxShortcutPanelRootView: UIKitTallyBorderedView {
 }
 
 @MainActor
-private final class TmuxShortcutButton: UIControl {
-    let shortcut: TmuxShortcut
+private final class ShortcutItemButton: UIControl {
+    let item: ShortcutPanelItem
 
-    private let titleLabel = TmuxPanelLabel()
-    private let commandLabel = TmuxPanelLabel()
-    private let bindingLabel = TmuxPanelLabel()
+    private let titleLabel = ShortcutPanelLabel()
+    private let commandLabel = ShortcutPanelLabel()
+    private let bindingLabel = ShortcutPanelLabel()
     private let bindingBorder = UIKitTallyBorderedView()
     private var isArmed = false
 
-    init(shortcut: TmuxShortcut) {
-        self.shortcut = shortcut
+    init(item: ShortcutPanelItem) {
+        self.item = item
         super.init(frame: .zero)
         minimumHeight(48)
-        accessibilityIdentifier = "tmuxShortcut.\(shortcut.rawValue)"
+        accessibilityIdentifier = item.accessibilityIdentifier
         isAccessibilityElement = true
         accessibilityTraits = .button
         hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
 
         titleLabel.configure(
-            shortcut.title.uppercased(),
+            item.title.uppercased(),
             font: UIKitChassis.compressedLabelFont(10),
             color: UIKitChassis.signal,
             kern: 0.8
         )
         commandLabel.configure(
-            shortcut.command,
+            item.command,
             font: UIKitChassis.monoFont(8),
             color: UIKitChassis.signal2
         )
@@ -423,15 +452,15 @@ private final class TmuxShortcutButton: UIControl {
 
     func setArmed(_ armed: Bool) {
         isArmed = armed
-        commandLabel.setText(armed ? "press again to close" : shortcut.command)
+        commandLabel.setText(armed ? "press again to close" : item.command)
         bindingLabel.configure(
-            armed ? "AGAIN" : shortcut.bindingLabel,
+            armed ? "AGAIN" : item.bindingLabel,
             font: UIKitChassis.monoFont(9, weight: .semibold),
             color: UIKitChassis.signal2
         )
         layer.borderWidth = armed ? 1 : 0
         refreshBorder()
-        accessibilityLabel = Self.accessibilityLabel(for: shortcut, isArmed: armed)
+        accessibilityLabel = Self.accessibilityLabel(for: item, isArmed: armed)
         refreshBackground()
     }
 
@@ -452,16 +481,16 @@ private final class TmuxShortcutButton: UIControl {
     }
 
     private static func accessibilityLabel(
-        for shortcut: TmuxShortcut,
+        for item: ShortcutPanelItem,
         isArmed: Bool
     ) -> String {
         if isArmed {
-            return "\(shortcut.title), press again to close"
+            return "\(item.title), press again to close"
         }
-        if shortcut.requiresDoubleActivation {
-            return "\(shortcut.title), \(shortcut.command), press twice to confirm"
+        if item.requiresDoubleActivation {
+            return "\(item.title), \(item.command), press twice to confirm"
         }
-        return "\(shortcut.title), \(shortcut.command), \(shortcut.bindingLabel)"
+        return "\(item.title), \(item.command), \(item.bindingLabel)"
     }
 
     @objc private func beginPress() {
@@ -486,29 +515,29 @@ private final class TmuxShortcutButton: UIControl {
 }
 
 @MainActor
-private final class TmuxWindowButton: UIControl {
-    let windowChoice: TmuxWindowChoice
+private final class ShortcutChoiceButton: UIControl {
+    let choice: TmuxWindowChoice
 
-    init(window: TmuxWindowChoice) {
-        windowChoice = window
+    init(choice: TmuxWindowChoice, noun: String, accessibilityPrefix: String) {
+        self.choice = choice
         super.init(frame: .zero)
         minimumHeight(40)
-        accessibilityIdentifier = "tmuxWindow.\(window.tmuxID)"
+        accessibilityIdentifier = accessibilityPrefix + choice.tmuxID
         isAccessibilityElement = true
         accessibilityTraits = .button
         hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
-        accessibilityLabel = window.isActive
-            ? "Window \(window.index), \(window.name), current window"
-            : "Switch to window \(window.index), \(window.name)"
+        accessibilityLabel = choice.isActive
+            ? "\(noun.capitalized) \(choice.index), \(choice.name), current \(noun)"
+            : "Switch to \(noun) \(choice.index), \(choice.name)"
 
-        let index = TmuxPanelLabel(
-            "\(window.index)",
+        let index = ShortcutPanelLabel(
+            "\(choice.index)",
             font: UIKitChassis.monoFont(9, weight: .semibold),
             color: UIKitChassis.signal2
         )
         index.setContentHuggingPriority(.required, for: .horizontal)
-        let name = TmuxPanelLabel(
-            window.name.uppercased(),
+        let name = ShortcutPanelLabel(
+            choice.name.uppercased(),
             font: UIKitChassis.compressedLabelFont(10),
             color: UIKitChassis.signal,
             kern: 0.8
@@ -519,8 +548,8 @@ private final class TmuxWindowButton: UIControl {
         spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
         spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         var content: [UIView] = [index, name, spacer]
-        if window.isActive {
-            let active = TmuxPanelLabel(
+        if choice.isActive {
+            let active = ShortcutPanelLabel(
                 "ACTIVE",
                 font: UIKitChassis.monoFont(9, weight: .semibold),
                 color: UIKitChassis.signal2
@@ -585,7 +614,7 @@ private final class TmuxWindowButton: UIControl {
 }
 
 @MainActor
-private final class TmuxPanelLabel: UILabel {
+private final class ShortcutPanelLabel: UILabel {
     private var sourceText = ""
     private var sourceFont = UIFont.systemFont(ofSize: 10)
     private var sourceColor = UIKitChassis.signal

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -17,7 +17,9 @@ final class TerminalSurfaceView: UIView {
         var contentSafeArea: UIEdgeInsets = .zero
         var railOwnsBottomSafeArea = false
         var isActive = true
-        var showsTmuxShortcuts = true
+        /// Which multiplexer owns the rail's shortcut key (TMUX/HRDR); nil
+        /// drops the key — plain shells and auxiliary panes have no panel.
+        var shortcutBackend: Host.SessionBackend?
     }
 
     private static let focusTapName = "multiplex.focus-tap"
@@ -181,13 +183,13 @@ final class TerminalSurfaceView: UIView {
         let keyBar = TerminalKeyBar(
             terminal: view,
             controller: controller,
-            performTmuxShortcut: { [weak controller] shortcut in
-                controller?.performTmuxShortcut(shortcut)
+            performShortcut: { [weak controller] item in
+                controller?.performPanelShortcut(item)
             },
             finishTmuxCopyMode: { [weak controller] in
                 controller?.finishTmuxCopyMode()
             },
-            showsTmuxShortcuts: configuration.showsTmuxShortcuts
+            shortcutBackend: configuration.shortcutBackend
         )
         keyBar.contentSafeArea = configuration.contentSafeArea
         coordinator.keyBar = keyBar

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -365,6 +365,8 @@ final class TerminalCtrlComboViewController: UIViewController {
 /// Pure layout ladder for the native rail. Its last two exact floors are
 /// load-bearing: 420 points keeps RET + TMUX on iPhone Air, while 375 points
 /// keeps every essential terminal key when TMUX moves to the shell bar.
+/// "tmux" here names the shortcut-key SLOT — a herdr tab fills it with HRDR,
+/// four mono characters like TMUX, so every tier holds for both backends.
 enum TerminalKeyBarLayout {
     enum Tier: Equatable {
         case full
@@ -534,9 +536,12 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
 
     private weak var terminal: TerminalView?
     private weak var controller: TerminalSessionController?
-    private let performTmuxShortcut: (TmuxShortcut) -> Void
+    private let performShortcut: (ShortcutPanelItem) -> Void
     private let finishTmuxCopyMode: () -> Void
-    private let showsTmuxShortcuts: Bool
+    /// Which multiplexer owns this tab's shortcut key: TMUX, HRDR, or none.
+    /// Both faces are four mono characters, so every layout tier below is
+    /// backend-independent by construction.
+    private let shortcutBackend: Host.SessionBackend?
     private let showsReturnKey: Bool
     private let topBorder = UIView()
     private var ctrlLatched = false
@@ -545,7 +550,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     private var renderedSignature: RenderSignature?
     private(set) var renderedKeys: [TerminalTallyKeyControl] = []
     private weak var ctrlKeyControl: TerminalTallyKeyControl?
-    private weak var tmuxPopoverController: UIViewController?
+    private weak var shortcutPopoverController: UIViewController?
     private var ctrlComboView: TerminalCtrlComboView?
 
     private struct RenderSignature: Equatable {
@@ -556,15 +561,15 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     init(
         terminal: TerminalView,
         controller: TerminalSessionController?,
-        performTmuxShortcut: @escaping (TmuxShortcut) -> Void,
+        performShortcut: @escaping (ShortcutPanelItem) -> Void,
         finishTmuxCopyMode: @escaping () -> Void,
-        showsTmuxShortcuts: Bool
+        shortcutBackend: Host.SessionBackend?
     ) {
         self.terminal = terminal
         self.controller = controller
-        self.performTmuxShortcut = performTmuxShortcut
+        self.performShortcut = performShortcut
         self.finishTmuxCopyMode = finishTmuxCopyMode
-        self.showsTmuxShortcuts = showsTmuxShortcuts
+        self.shortcutBackend = shortcutBackend
         showsReturnKey = UIDevice.current.userInterfaceIdiom == .pad
         ctrlLatched = terminal.controlModifier
         super.init(frame: .zero)
@@ -606,7 +611,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         let specification = TerminalKeyBarLayout.specification(
             width: bounds.width,
             contentSafeArea: contentSafeArea,
-            showsTmux: showsTmuxShortcuts,
+            showsTmux: shortcutBackend != nil,
             includesReturn: includesReturn
         )
         let signature = RenderSignature(tier: specification.tier, state: state)
@@ -724,15 +729,19 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
                 longPressKey: state.keyboardLocked ? nil : .lockKeyboard
             ))
         }
-        if specification.tmux {
+        if specification.tmux, let backend = shortcutBackend {
+            // The identifier names the slot, not the occupant — debug hooks
+            // and tests address "tmux" for either backend's key.
             right.append(RailKey(
-                key: .showTmuxShortcuts,
+                key: .showShortcutPanel,
                 face: .text(
-                    "TMUX",
+                    backend == .herdr ? "HRDR" : "TMUX",
                     font: UIKitChassis.monoFont(9, weight: .semibold),
                     kerning: 0.7
                 ),
-                accessibility: "Show tmux shortcuts",
+                accessibility: backend == .herdr
+                    ? "Show herdr shortcuts"
+                    : "Show tmux shortcuts",
                 identifier: "tmux"
             ))
         }
@@ -846,39 +855,41 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
             TerminalFocusArbiter.lock(terminal)
         case .dictation:
             controller?.toggleDictation()
-        case .showTmuxShortcuts:
-            showTmuxShortcuts()
-        case .tmux(let shortcut):
+        case .showShortcutPanel:
+            showShortcutPanel()
+        case .shortcut(let item):
             click()
-            performTmuxShortcut(shortcut)
+            performShortcut(item)
         }
     }
 
-    private func showTmuxShortcuts() {
-        guard tmuxPopoverController == nil,
+    private func showShortcutPanel() {
+        guard shortcutPopoverController == nil,
+              let content = ShortcutPanelContent.content(for: shortcutBackend),
               let presenter = presentingViewController
         else { return }
         let sceneWidth = window?.bounds.width ?? presenter.view.bounds.width
         let panelWidth = min(
-            TmuxShortcutPanelViewController.preferredWidth,
+            ShortcutPanelViewController.preferredWidth,
             max(280, sceneWidth - 24)
         )
-        let controller = TmuxShortcutPanelViewController(
+        let controller = ShortcutPanelViewController(
+            content: content,
             width: panelWidth,
-            select: { [weak self] shortcut in
-                self?.tmuxPopoverController?.dismiss(animated: true)
-                self?.press(.tmux(shortcut))
+            select: { [weak self] item in
+                self?.shortcutPopoverController?.dismiss(animated: true)
+                self?.press(.shortcut(item))
             },
-            loadWindows: { [weak self] in
-                await self?.controller?.loadTmuxWindowList()
+            loadChoices: { [weak self] in
+                await self?.controller?.loadShortcutSwitchChoices()
             },
-            selectWindow: { [weak self] window in
-                self?.tmuxPopoverController?.dismiss(animated: true)
+            selectChoice: { [weak self] choice in
+                self?.shortcutPopoverController?.dismiss(animated: true)
                 self?.click()
-                self?.controller?.selectTmuxWindow(window)
+                self?.controller?.selectShortcutSwitchChoice(choice)
             }
         )
-        tmuxPopoverController = controller
+        shortcutPopoverController = controller
         controller.modalPresentationStyle = .popover
         controller.loadViewIfNeeded()
         controller.view.backgroundColor = UIKitChassis.bezel
@@ -1001,12 +1012,12 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     #if DEBUG
     func debugShowTmuxShortcuts() {
         guard let terminal, TerminalFocusArbiter.current === terminal else { return }
-        showTmuxShortcuts()
+        showShortcutPanel()
     }
 
     func debugSendTmuxCopyMode() {
         guard let terminal, TerminalFocusArbiter.current === terminal else { return }
-        press(.tmux(.copyMode))
+        press(.shortcut(ShortcutPanelItem(TmuxShortcut.copyMode)))
     }
 
     func debugFinishTmuxCopyMode() {
@@ -1019,7 +1030,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
               TerminalFocusArbiter.current === terminal,
               shortcut.requiresDoubleActivation
         else { return }
-        press(.tmux(shortcut))
+        press(.shortcut(ShortcutPanelItem(shortcut)))
     }
 
     func debugToggleDictation() {
@@ -1061,8 +1072,8 @@ private enum TerminalKey {
     case keyboard
     case lockKeyboard
     case dictation
-    case showTmuxShortcuts
-    case tmux(TmuxShortcut)
+    case showShortcutPanel
+    case shortcut(ShortcutPanelItem)
 }
 
 extension TerminalKeyBar: UIPopoverPresentationControllerDelegate {

--- a/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
@@ -208,7 +208,7 @@ final class TerminalPaneViewController: UIViewController, UIDropInteractionDeleg
             contentSafeArea: configuration.contentSafeArea,
             railOwnsBottomSafeArea: configuration.railOwnsBottomSafeArea,
             isActive: configuration.isActive && configuration.focusAllowed,
-            showsTmuxShortcuts: configuration.controller?.route.usesTmux == true
+            shortcutBackend: configuration.controller?.route.sessionBackend
         )
     }
 

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -1422,7 +1422,7 @@ extension TerminalWindowViewController {
             keychainTip: activeTabKeychainNotice != nil
                 ? { [weak self] in self?.presentKeychainTip() } : nil,
             newTabTarget: newTabTarget,
-            showsTmuxShortcuts: activeTab?.usesTmux == true,
+            shortcutBackend: activeTab?.sessionBackend,
             style: shell == nil ? .regular : .shell,
             deckControlLabel: shell?.deckControlLabel ?? "DECK",
             availableWidth: shell?.availableWidth,

--- a/Multiplex/Views/Terminal/UMDBarUIKit.swift
+++ b/Multiplex/Views/Terminal/UMDBarUIKit.swift
@@ -26,7 +26,8 @@ struct UMDBarConfiguration {
     /// What `newSession` actually mints — a herdr tab renames the entry
     /// and relabels the control (see `TerminalRoute.NewTabTarget`).
     var newTabTarget: TerminalRoute.NewTabTarget
-    var showsTmuxShortcuts: Bool
+    /// Which multiplexer owns the shortcut chip (TMUX/HRDR); nil hides it.
+    var shortcutBackend: Host.SessionBackend?
     var style: UMDBarStyle
     var deckControlLabel: String
     var availableWidth: CGFloat?
@@ -52,7 +53,7 @@ private struct UMDBarPresentationKey: Equatable {
     var hasCloseSession: Bool
     var hasKeychainTip: Bool
     var newTabTarget: TerminalRoute.NewTabTarget
-    var showsTmuxShortcuts: Bool
+    var shortcutBackend: Host.SessionBackend?
     var style: UMDBarStyle
     var deckControlLabel: String
     var availableWidth: CGFloat?
@@ -68,7 +69,7 @@ private struct UMDBarPresentationKey: Equatable {
         hasCloseSession = configuration.closeSession != nil
         hasKeychainTip = configuration.keychainTip != nil
         newTabTarget = configuration.newTabTarget
-        showsTmuxShortcuts = configuration.showsTmuxShortcuts
+        shortcutBackend = configuration.shortcutBackend
         style = configuration.style
         deckControlLabel = configuration.deckControlLabel
         availableWidth = configuration.availableWidth
@@ -105,8 +106,8 @@ final class UMDBarViewController: UIViewController,
     private var configuration: UMDBarConfiguration
     private let rootView = UMDBarRootView()
     private(set) var fileAttachController: FileAttachMenuViewController
-    private weak var tmuxPopoverController: TmuxShortcutPanelViewController?
-    private var resumesFocusAfterTmuxShortcuts = false
+    private weak var shortcutPopoverController: ShortcutPanelViewController?
+    private var resumesFocusAfterShortcutPanel = false
     private var observationGeneration = 0
     private var renderedKey: UMDBarRenderKey?
     private var currentObservedState = UMDBarObservedState(
@@ -155,9 +156,9 @@ final class UMDBarViewController: UIViewController,
 
     func prepareForRemoval() {
         observationGeneration &+= 1
-        tmuxPopoverController?.dismiss(animated: false)
-        tmuxPopoverController = nil
-        resumeFocusAfterTmuxPresentationIfNeeded()
+        shortcutPopoverController?.dismiss(animated: false)
+        shortcutPopoverController = nil
+        resumeFocusAfterShortcutPresentationIfNeeded()
     }
 
     /// One action router backs direct controls and every UIMenu item, making
@@ -286,8 +287,8 @@ final class UMDBarViewController: UIViewController,
         ]
 
         views.append(fileAttachController.takeAttachButton())
-        if configuration.showsTmuxShortcuts {
-            views.append(tmuxButton())
+        if let backend = configuration.shortcutBackend {
+            views.append(shortcutButton(backend))
         }
         if !configuration.mergeSources.isEmpty {
             views.append(mergeButton())
@@ -363,8 +364,8 @@ final class UMDBarViewController: UIViewController,
             ))
             views.append(newTabButton())
             views.append(fileAttachController.takeAttachButton())
-            if configuration.showsTmuxShortcuts {
-                views.append(tmuxButton())
+            if let backend = configuration.shortcutBackend {
+                views.append(shortcutButton(backend))
             }
             if showsChipCompanionMenu {
                 views.append(overflowButton(displacesDirectActions: false))
@@ -372,8 +373,9 @@ final class UMDBarViewController: UIViewController,
             views.append(detachButton())
         } else {
             views.append(overflowButton(displacesDirectActions: true))
-            if showsCompactTopBarTmuxShortcut(state: state) {
-                views.append(tmuxButton())
+            if let backend = configuration.shortcutBackend,
+               showsCompactTopBarShortcut(state: state) {
+                views.append(shortcutButton(backend))
             }
         }
 
@@ -392,13 +394,13 @@ final class UMDBarViewController: UIViewController,
         #endif
     }
 
-    private func showsCompactTopBarTmuxShortcut(
+    private func showsCompactTopBarShortcut(
         state: UMDBarObservedState
     ) -> Bool {
         guard let availableWidth = configuration.availableWidth else { return false }
         return SingleWindowShellLayout.showsTopBarTmuxShortcut(
             availableWidth: availableWidth,
-            supportsTmuxShortcuts: configuration.showsTmuxShortcuts,
+            supportsTmuxShortcuts: configuration.shortcutBackend != nil,
             keyBarIncludesReturnKey: state.keyboardLocked
         )
     }
@@ -510,18 +512,22 @@ final class UMDBarViewController: UIViewController,
         )
     }
 
-    private func tmuxButton() -> UMDBarButton {
+    /// The identifier names the chip's slot, not its occupant — tests and
+    /// hooks address "umd.tmux" for either backend's shortcut chip.
+    private func shortcutButton(_ backend: Host.SessionBackend) -> UMDBarButton {
         let button = UMDBarButton(
-            caption: "TMUX",
+            caption: backend == .herdr ? "HRDR" : "TMUX",
             systemImage: "command",
             prominent: false,
-            accessibilityLabel: "Show tmux shortcuts"
+            accessibilityLabel: backend == .herdr
+                ? "Show herdr shortcuts"
+                : "Show tmux shortcuts"
         )
         button.accessibilityIdentifier = "umd.tmux"
         button.isEnabled = currentObservedState.status == .live
         button.addAction(UIAction { [weak self, weak button] _ in
             guard let self, let button else { return }
-            self.showTmuxShortcuts(from: button)
+            self.showShortcutPanel(from: button)
         }, for: .touchUpInside)
         return button
     }
@@ -777,45 +783,49 @@ final class UMDBarViewController: UIViewController,
         }
     }
 
-    private func showTmuxShortcuts(from source: UIView) {
-        guard tmuxPopoverController == nil,
+    private func showShortcutPanel(from source: UIView) {
+        guard shortcutPopoverController == nil,
+              let content = ShortcutPanelContent.content(
+                for: configuration.shortcutBackend
+              ),
               configuration.controller?.status == .live
         else { return }
 
         if configuration.style == .shell {
-            resumesFocusAfterTmuxShortcuts =
+            resumesFocusAfterShortcutPanel =
                 configuration.controller?.suspendFocusForPresentation() == true
         }
 
         let panelWidth = min(
-            TmuxShortcutPanelViewController.preferredWidth,
+            ShortcutPanelViewController.preferredWidth,
             max(
                 280,
                 (configuration.availableWidth
-                    ?? TmuxShortcutPanelViewController.preferredWidth + 24) - 24
+                    ?? ShortcutPanelViewController.preferredWidth + 24) - 24
             )
         )
-        let panel = TmuxShortcutPanelViewController(
+        let panel = ShortcutPanelViewController(
+            content: content,
             width: panelWidth,
-            select: { [weak self] shortcut in
+            select: { [weak self] item in
                 guard let self else { return }
-                self.tmuxPopoverController?.dismiss(animated: true) {
-                    self.resumeFocusAfterTmuxPresentationIfNeeded()
+                self.shortcutPopoverController?.dismiss(animated: true) {
+                    self.resumeFocusAfterShortcutPresentationIfNeeded()
                 }
-                self.configuration.controller?.performTmuxShortcut(shortcut)
+                self.configuration.controller?.performPanelShortcut(item)
             },
-            loadWindows: { [weak controller = configuration.controller] in
-                await controller?.loadTmuxWindowList()
+            loadChoices: { [weak controller = configuration.controller] in
+                await controller?.loadShortcutSwitchChoices()
             },
-            selectWindow: { [weak self] window in
+            selectChoice: { [weak self] choice in
                 guard let self else { return }
-                self.tmuxPopoverController?.dismiss(animated: true) {
-                    self.resumeFocusAfterTmuxPresentationIfNeeded()
+                self.shortcutPopoverController?.dismiss(animated: true) {
+                    self.resumeFocusAfterShortcutPresentationIfNeeded()
                 }
-                self.configuration.controller?.selectTmuxWindow(window)
+                self.configuration.controller?.selectShortcutSwitchChoice(choice)
             }
         )
-        tmuxPopoverController = panel
+        shortcutPopoverController = panel
         panel.modalPresentationStyle = .popover
         // visionOS hosts this popover in a window of its own; carry the
         // ornament mount's appearance override across or a pinned LIGHT
@@ -852,8 +862,8 @@ final class UMDBarViewController: UIViewController,
     func presentationControllerDidDismiss(
         _ presentationController: UIPresentationController
     ) {
-        tmuxPopoverController = nil
-        resumeFocusAfterTmuxPresentationIfNeeded()
+        shortcutPopoverController = nil
+        resumeFocusAfterShortcutPresentationIfNeeded()
     }
 
     func adaptivePresentationStyle(
@@ -869,9 +879,9 @@ final class UMDBarViewController: UIViewController,
         .none
     }
 
-    private func resumeFocusAfterTmuxPresentationIfNeeded() {
-        guard resumesFocusAfterTmuxShortcuts else { return }
-        resumesFocusAfterTmuxShortcuts = false
+    private func resumeFocusAfterShortcutPresentationIfNeeded() {
+        guard resumesFocusAfterShortcutPanel else { return }
+        resumesFocusAfterShortcutPanel = false
         configuration.controller?.resumeFocusAfterPresentation()
     }
 }

--- a/MultiplexTests/HerdrProbeTests.swift
+++ b/MultiplexTests/HerdrProbeTests.swift
@@ -673,6 +673,94 @@ final class HerdrProbeTests: XCTestCase {
         XCTAssertTrue(suffixed.hasSuffix("-2"),
                       "the uniqueness suffix must stay inside herdr's 64-byte limit")
     }
+
+    // MARK: Shortcut panel (HRDR)
+
+    /// Captured `herdr workspace list` envelope shape (0.7.5, 2026-08-02);
+    /// extra fields prove tolerant decoding.
+    private let workspaceList = #"{"id":"cli:workspace:list","result":{"#
+        + #""type":"workspace_list","workspaces":["#
+        + #"{"active_tab_id":"w2:t1","agent_status":"unknown","focused":false,"#
+        + #""label":"demo","number":2,"pane_count":1,"tab_count":1,"#
+        + #""workspace_id":"w2"},"#
+        + #"{"active_tab_id":"w1:t1","agent_status":"working","focused":true,"#
+        + #""label":"api","number":1,"pane_count":2,"tab_count":2,"#
+        + #""workspace_id":"w1"}"#
+        + #"]}}"#
+
+    func testWorkspaceListCommandScopesToTheSession() {
+        XCTAssertEqual(
+            HerdrProbe.workspaceListCommand(sessionName: "work"),
+            HerdrProbe.pathPrefix
+                + "herdr --session 'work' workspace list 2>/dev/null || true"
+        )
+    }
+
+    func testParseWorkspaceChoicesOrdersByNumberAndMarksTheFocusedRow() {
+        let choices = HerdrProbe.parseWorkspaceChoices("noise\n" + workspaceList + "\n")
+        XCTAssertEqual(choices, [
+            TmuxWindowChoice(tmuxID: "w1", index: 1, isActive: true, name: "api"),
+            TmuxWindowChoice(tmuxID: "w2", index: 2, isActive: false, name: "demo"),
+        ])
+        XCTAssertNil(HerdrProbe.parseWorkspaceChoices("Error: no server\n"),
+                     "unreadable is not the same as a valid empty list")
+    }
+
+    func testFocusWorkspaceCommandVetsTheResponseDerivedID() {
+        XCTAssertEqual(
+            HerdrProbe.focusWorkspaceCommand(sessionName: "work", workspaceID: "w2"),
+            HerdrProbe.pathPrefix
+                + "herdr --session 'work' workspace focus 'w2' 2>/dev/null || true"
+        )
+        XCTAssertNil(HerdrProbe.focusWorkspaceCommand(
+            sessionName: "work", workspaceID: "w2 evil"),
+            "an id with whitespace must never be spliced into a shell line")
+        XCTAssertNil(HerdrProbe.focusWorkspaceCommand(sessionName: "work", workspaceID: ""))
+    }
+
+    func testParseFocusedCloseTargetReadsExactlyWhatTheServerNamesFocused() {
+        let output = "login noise\n" + workSnapshot + "\n"
+        XCTAssertEqual(
+            HerdrProbe.parseFocusedCloseTarget(output, scope: .pane), "w1:p1")
+        XCTAssertEqual(
+            HerdrProbe.parseFocusedCloseTarget(output, scope: .tab), "w1:t1")
+        XCTAssertEqual(
+            HerdrProbe.parseFocusedCloseTarget(output, scope: .workspace), "w1")
+        XCTAssertNil(HerdrProbe.parseFocusedCloseTarget("garbage", scope: .pane),
+                     "a close must never guess its target")
+    }
+
+    func testParseFocusedCloseTargetFallsBackToTheFocusedWorkspacesActiveTab() {
+        // Same snapshot minus focused_tab_id: the focused workspace's
+        // active tab IS the focused tab, stated the other way.
+        let trimmed = workSnapshot.replacingOccurrences(
+            of: #""focused_tab_id":"w1:t1","#, with: "")
+        XCTAssertEqual(
+            HerdrProbe.parseFocusedCloseTarget(trimmed, scope: .tab), "w1:t1")
+    }
+
+    func testCloseShortcutCommandSpeaksEachScopeAndVetsTheID() {
+        XCTAssertEqual(
+            HerdrProbe.closeShortcutCommand(
+                sessionName: "work", scope: .pane, targetID: "w1:p2"),
+            HerdrProbe.pathPrefix
+                + "herdr --session 'work' pane close 'w1:p2' 2>/dev/null || true"
+        )
+        XCTAssertEqual(
+            HerdrProbe.closeShortcutCommand(
+                sessionName: "work", scope: .tab, targetID: "w1:t2"),
+            HerdrProbe.pathPrefix
+                + "herdr --session 'work' tab close 'w1:t2' 2>/dev/null || true"
+        )
+        XCTAssertEqual(
+            HerdrProbe.closeShortcutCommand(
+                sessionName: "work", scope: .workspace, targetID: "w2"),
+            HerdrProbe.pathPrefix
+                + "herdr --session 'work' workspace close 'w2' 2>/dev/null || true"
+        )
+        XCTAssertNil(HerdrProbe.closeShortcutCommand(
+            sessionName: "work", scope: .pane, targetID: "bad id"))
+    }
 }
 
 /// The tmux probe's herdr-presence line — the dead-tile switch hint's

--- a/MultiplexTests/HerdrShortcutTests.swift
+++ b/MultiplexTests/HerdrShortcutTests.swift
@@ -11,16 +11,11 @@ final class HerdrShortcutTests: XCTestCase {
             .splitLeftRight: Character("v").asciiValue!,
             .splitTopBottom: Character("-").asciiValue!,
             .nextPane: 0x09,
-            .togglePaneZoom: Character("z").asciiValue!,
-            .editScrollback: Character("e").asciiValue!,
             .newTab: Character("c").asciiValue!,
             .nextTab: Character("n").asciiValue!,
             .previousTab: Character("p").asciiValue!,
-            .renameTab: Character("T").asciiValue!,
             .newWorkspace: Character("N").asciiValue!,
-            .workspacePicker: Character("w").asciiValue!,
             .renameWorkspace: Character("W").asciiValue!,
-            .toggleSidebar: Character("b").asciiValue!,
         ]
 
         let safeShortcuts = HerdrShortcut.allCases.filter { !$0.requiresDoubleActivation }
@@ -37,7 +32,6 @@ final class HerdrShortcutTests: XCTestCase {
         XCTAssertEqual(HerdrShortcut.splitTopBottom.bindingLabel, "⌃B -")
         XCTAssertEqual(HerdrShortcut.nextPane.bindingLabel, "⌃B ⇥")
         XCTAssertEqual(HerdrShortcut.newWorkspace.bindingLabel, "⌃B ⇧N")
-        XCTAssertEqual(HerdrShortcut.renameTab.bindingLabel, "⌃B ⇧T")
         XCTAssertEqual(HerdrShortcut.renameWorkspace.bindingLabel, "⌃B ⇧W")
     }
 
@@ -61,7 +55,7 @@ final class HerdrShortcutTests: XCTestCase {
         XCTAssertEqual(HerdrShortcut.splitLeftRight.command, "split_vertical")
         XCTAssertEqual(HerdrShortcut.splitTopBottom.command, "split_horizontal")
         XCTAssertEqual(HerdrShortcut.nextPane.command, "cycle_pane_next")
-        XCTAssertEqual(HerdrShortcut.workspacePicker.command, "workspace_picker")
+        XCTAssertEqual(HerdrShortcut.renameWorkspace.command, "rename_workspace")
         XCTAssertEqual(HerdrShortcut.closeWorkspace.command, "close_workspace")
     }
 
@@ -71,8 +65,8 @@ final class HerdrShortcutTests: XCTestCase {
         XCTAssertEqual(HerdrShortcut.Group.allCases, [.panes, .tabs, .workspaces])
         XCTAssertEqual(grouped.count, HerdrShortcut.allCases.count)
         XCTAssertEqual(Set(grouped), Set(HerdrShortcut.allCases))
-        XCTAssertEqual(HerdrShortcut.togglePaneZoom.group, .panes)
+        XCTAssertEqual(HerdrShortcut.splitLeftRight.group, .panes)
         XCTAssertEqual(HerdrShortcut.newTab.group, .tabs)
-        XCTAssertEqual(HerdrShortcut.toggleSidebar.group, .workspaces)
+        XCTAssertEqual(HerdrShortcut.renameWorkspace.group, .workspaces)
     }
 }

--- a/MultiplexTests/HerdrShortcutTests.swift
+++ b/MultiplexTests/HerdrShortcutTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Multiplex
+
+/// Pins the HRDR panel's shortcut set to herdr 0.7.5's default keybindings
+/// (`herdr --default-config`; split/zoom/detach exercised against a real TUI
+/// attach 2026-08-02). herdr's default prefix is Control-B — the same 0x02
+/// tmux uses — and Shift-modified defaults ride as the uppercase byte.
+final class HerdrShortcutTests: XCTestCase {
+    func testShortcutsUseTheDefaultPrefixAndVerifiedBindings() {
+        let expected: [HerdrShortcut: UInt8] = [
+            .splitLeftRight: Character("v").asciiValue!,
+            .splitTopBottom: Character("-").asciiValue!,
+            .nextPane: 0x09,
+            .togglePaneZoom: Character("z").asciiValue!,
+            .editScrollback: Character("e").asciiValue!,
+            .newTab: Character("c").asciiValue!,
+            .nextTab: Character("n").asciiValue!,
+            .previousTab: Character("p").asciiValue!,
+            .renameTab: Character("T").asciiValue!,
+            .newWorkspace: Character("N").asciiValue!,
+            .workspacePicker: Character("w").asciiValue!,
+            .renameWorkspace: Character("W").asciiValue!,
+            .toggleSidebar: Character("b").asciiValue!,
+        ]
+
+        let safeShortcuts = HerdrShortcut.allCases.filter { !$0.requiresDoubleActivation }
+        XCTAssertEqual(safeShortcuts.count, expected.count)
+        for shortcut in safeShortcuts {
+            XCTAssertEqual(shortcut.bindingInput, [0x02, expected[shortcut]!],
+                           "\(shortcut) must send prefix + its stock key")
+            XCTAssertFalse(shortcut.command.isEmpty)
+        }
+    }
+
+    func testBindingLabelsSpellShiftAndTabHonestly() {
+        XCTAssertEqual(HerdrShortcut.splitLeftRight.bindingLabel, "⌃B V")
+        XCTAssertEqual(HerdrShortcut.splitTopBottom.bindingLabel, "⌃B -")
+        XCTAssertEqual(HerdrShortcut.nextPane.bindingLabel, "⌃B ⇥")
+        XCTAssertEqual(HerdrShortcut.newWorkspace.bindingLabel, "⌃B ⇧N")
+        XCTAssertEqual(HerdrShortcut.renameTab.bindingLabel, "⌃B ⇧T")
+        XCTAssertEqual(HerdrShortcut.renameWorkspace.bindingLabel, "⌃B ⇧W")
+    }
+
+    func testCloseActionsHaveNoTerminalInputAfterUIConfirmation() {
+        for (shortcut, scope) in [
+            (HerdrShortcut.closePane, HerdrShortcut.CloseScope.pane),
+            (.closeTab, .tab),
+            (.closeWorkspace, .workspace),
+        ] {
+            XCTAssertNil(shortcut.bindingInput)
+            XCTAssertTrue(shortcut.requiresDoubleActivation)
+            XCTAssertEqual(shortcut.bindingLabel, "2×")
+            XCTAssertEqual(shortcut.closeScope, scope)
+        }
+        XCTAssertNil(HerdrShortcut.splitLeftRight.closeScope)
+    }
+
+    func testCommandsAreTheConfigActionNames() {
+        // The subtext doubles as the `[keys]` rebinding reference — it must
+        // spell herdr's own action names, not invented prose.
+        XCTAssertEqual(HerdrShortcut.splitLeftRight.command, "split_vertical")
+        XCTAssertEqual(HerdrShortcut.splitTopBottom.command, "split_horizontal")
+        XCTAssertEqual(HerdrShortcut.nextPane.command, "cycle_pane_next")
+        XCTAssertEqual(HerdrShortcut.workspacePicker.command, "workspace_picker")
+        XCTAssertEqual(HerdrShortcut.closeWorkspace.command, "close_workspace")
+    }
+
+    func testEveryShortcutAppearsInExactlyOneMenuGroup() {
+        let grouped = HerdrShortcut.Group.allCases.flatMap(HerdrShortcut.shortcuts(in:))
+
+        XCTAssertEqual(HerdrShortcut.Group.allCases, [.panes, .tabs, .workspaces])
+        XCTAssertEqual(grouped.count, HerdrShortcut.allCases.count)
+        XCTAssertEqual(Set(grouped), Set(HerdrShortcut.allCases))
+        XCTAssertEqual(HerdrShortcut.togglePaneZoom.group, .panes)
+        XCTAssertEqual(HerdrShortcut.newTab.group, .tabs)
+        XCTAssertEqual(HerdrShortcut.toggleSidebar.group, .workspaces)
+    }
+}

--- a/MultiplexTests/ShortcutPanelUIKitTests.swift
+++ b/MultiplexTests/ShortcutPanelUIKitTests.swift
@@ -3,9 +3,9 @@ import XCTest
 @testable import Multiplex
 
 @MainActor
-final class TmuxShortcutPanelUIKitTests: XCTestCase {
+final class ShortcutPanelUIKitTests: XCTestCase {
     func testNativePanelRendersEveryGroupedShortcutWithTallySizingAndAccessibility() throws {
-        let controller = TmuxShortcutPanelViewController(select: { _ in })
+        let controller = ShortcutPanelViewController(content: .tmux, select: { _ in })
         controller.loadViewIfNeeded()
 
         let controls = descendants(of: UIControl.self, in: controller.view)
@@ -18,7 +18,7 @@ final class TmuxShortcutPanelUIKitTests: XCTestCase {
         XCTAssertEqual(headers, ["TMUX SHORTCUTS", "Panes", "Windows"])
 
         let size = controller.fittingContentSize()
-        XCTAssertEqual(size.width, TmuxShortcutPanelViewController.preferredWidth)
+        XCTAssertEqual(size.width, ShortcutPanelViewController.preferredWidth)
         XCTAssertGreaterThan(size.height, 0)
         XCTAssertEqual(controller.preferredContentSize, size)
 
@@ -36,22 +36,49 @@ final class TmuxShortcutPanelUIKitTests: XCTestCase {
         )
     }
 
+    func testHerdrPanelRendersItsOwnHeaderGroupsAndBindings() throws {
+        let controller = ShortcutPanelViewController(content: .herdr, select: { _ in })
+        controller.loadViewIfNeeded()
+
+        let controls = descendants(of: UIControl.self, in: controller.view)
+            .filter { $0.accessibilityIdentifier?.hasPrefix("herdrShortcut.") == true }
+        XCTAssertEqual(controls.count, HerdrShortcut.allCases.count)
+
+        let headers = descendants(of: UIKitChassisLabel.self, in: controller.view)
+            .filter { $0.accessibilityTraits.contains(.header) }
+            .compactMap(\.accessibilityLabel)
+        XCTAssertEqual(headers, ["HERDR SHORTCUTS", "Panes", "Tabs", "Workspaces"])
+
+        let split = try XCTUnwrap(
+            control("herdrShortcut.splitLeftRight", in: controller.view)
+        )
+        XCTAssertEqual(split.accessibilityLabel, "Split Left / Right, split_vertical, ⌃B V")
+
+        let closeWorkspace = try XCTUnwrap(
+            control("herdrShortcut.closeWorkspace", in: controller.view)
+        )
+        XCTAssertEqual(
+            closeWorkspace.accessibilityLabel,
+            "Close Workspace, close_workspace, press twice to confirm"
+        )
+    }
+
     func testSafeShortcutSelectsImmediatelyAndDestructiveShortcutRequiresSecondPress() throws {
-        var selected: [TmuxShortcut] = []
-        let controller = TmuxShortcutPanelViewController {
+        var selected: [ShortcutPanelItem] = []
+        let controller = ShortcutPanelViewController(content: .tmux) {
             selected.append($0)
         }
         controller.loadViewIfNeeded()
 
         let copyMode = try XCTUnwrap(control("tmuxShortcut.copyMode", in: controller.view))
         copyMode.sendActions(for: .touchUpInside)
-        XCTAssertEqual(selected, [.copyMode])
+        XCTAssertEqual(selected.map(\.payload), [.tmux(.copyMode)])
 
         let closeWindow = try XCTUnwrap(
             control("tmuxShortcut.closeWindow", in: controller.view)
         )
         closeWindow.sendActions(for: .touchUpInside)
-        XCTAssertEqual(selected, [.copyMode])
+        XCTAssertEqual(selected.map(\.payload), [.tmux(.copyMode)])
         XCTAssertEqual(
             closeWindow.accessibilityLabel,
             "Close Window, press again to close"
@@ -60,23 +87,38 @@ final class TmuxShortcutPanelUIKitTests: XCTestCase {
         XCTAssertTrue(renderedText(in: closeWindow).contains("AGAIN"))
 
         closeWindow.sendActions(for: .touchUpInside)
-        XCTAssertEqual(selected, [.copyMode, .closeWindow])
+        XCTAssertEqual(selected.map(\.payload), [.tmux(.copyMode), .tmux(.closeWindow)])
         XCTAssertEqual(
             closeWindow.accessibilityLabel,
             "Close Window, kill-window, press twice to confirm"
         )
     }
 
+    func testHerdrCloseRowsCarryTheirPayloadThroughTheSameConfirmation() throws {
+        var selected: [ShortcutPanelItem] = []
+        let controller = ShortcutPanelViewController(content: .herdr) {
+            selected.append($0)
+        }
+        controller.loadViewIfNeeded()
+
+        let closeTab = try XCTUnwrap(control("herdrShortcut.closeTab", in: controller.view))
+        closeTab.sendActions(for: .touchUpInside)
+        XCTAssertEqual(selected, [])
+        closeTab.sendActions(for: .touchUpInside)
+        XCTAssertEqual(selected.map(\.payload), [.herdr(.closeTab)])
+    }
+
     func testWindowChoicesOnlyRenderWhenSwitchingIsUsefulAndSelectionDisarmsClose() throws {
-        var selectedWindow: TmuxWindowChoice?
-        let controller = TmuxShortcutPanelViewController(
+        var selectedChoice: TmuxWindowChoice?
+        let controller = ShortcutPanelViewController(
+            content: .tmux,
             select: { _ in },
-            selectWindow: { selectedWindow = $0 }
+            selectChoice: { selectedChoice = $0 }
         )
         controller.loadViewIfNeeded()
         let baseHeight = controller.fittingContentSize().height
 
-        controller.applyWindows([
+        controller.applyChoices([
             TmuxWindowChoice(tmuxID: "@1", index: 0, isActive: true, name: "main")
         ])
         XCTAssertNil(control("tmuxWindow.@1", in: controller.view))
@@ -86,7 +128,7 @@ final class TmuxShortcutPanelUIKitTests: XCTestCase {
             TmuxWindowChoice(tmuxID: "@1", index: 0, isActive: true, name: "main"),
             TmuxWindowChoice(tmuxID: "@2", index: 1, isActive: false, name: "deploy"),
         ]
-        controller.applyWindows(choices)
+        controller.applyChoices(choices)
         XCTAssertGreaterThan(controller.fittingContentSize().height, baseHeight)
 
         let active = try XCTUnwrap(control("tmuxWindow.@1", in: controller.view))
@@ -99,17 +141,36 @@ final class TmuxShortcutPanelUIKitTests: XCTestCase {
         XCTAssertEqual(closePane.accessibilityLabel, "Close Pane, press again to close")
 
         deploy.sendActions(for: .touchUpInside)
-        XCTAssertEqual(selectedWindow, choices[1])
+        XCTAssertEqual(selectedChoice, choices[1])
         XCTAssertEqual(
             closePane.accessibilityLabel,
             "Close Pane, kill-pane, press twice to confirm"
         )
     }
 
-    func testManyWindowsUseCappedInternalScrollRegion() {
-        let controller = TmuxShortcutPanelViewController(select: { _ in })
+    func testHerdrPanelSpeaksWorkspaceInItsSwitchSection() throws {
+        let controller = ShortcutPanelViewController(content: .herdr, select: { _ in })
         controller.loadViewIfNeeded()
-        controller.applyWindows((0..<9).map {
+
+        controller.applyChoices([
+            TmuxWindowChoice(tmuxID: "w1", index: 1, isActive: true, name: "api"),
+            TmuxWindowChoice(tmuxID: "w2", index: 2, isActive: false, name: "web"),
+        ])
+
+        let title = descendants(of: UIKitChassisLabel.self, in: controller.view)
+            .first { $0.accessibilityIdentifier == "herdrWorkspaceSection.title" }
+        XCTAssertEqual(title?.accessibilityLabel, "Switch Workspace")
+
+        let active = try XCTUnwrap(control("herdrWorkspace.w1", in: controller.view))
+        XCTAssertEqual(active.accessibilityLabel, "Workspace 1, api, current workspace")
+        let other = try XCTUnwrap(control("herdrWorkspace.w2", in: controller.view))
+        XCTAssertEqual(other.accessibilityLabel, "Switch to workspace 2, web")
+    }
+
+    func testManyWindowsUseCappedInternalScrollRegion() {
+        let controller = ShortcutPanelViewController(content: .tmux, select: { _ in })
+        controller.loadViewIfNeeded()
+        controller.applyChoices((0..<9).map {
             TmuxWindowChoice(
                 tmuxID: "@\($0)",
                 index: $0,

--- a/MultiplexTests/TerminalKeyBarUIKitTests.swift
+++ b/MultiplexTests/TerminalKeyBarUIKitTests.swift
@@ -94,9 +94,9 @@ final class TerminalKeyBarUIKitTests: XCTestCase {
         let bar = TerminalKeyBar(
             terminal: terminal,
             controller: nil,
-            performTmuxShortcut: { _ in },
+            performShortcut: { _ in },
             finishTmuxCopyMode: {},
-            showsTmuxShortcuts: true
+            shortcutBackend: .tmux
         )
         bar.frame = CGRect(x: 0, y: 0, width: 420, height: TerminalKeyBar.barHeight)
         bar.layoutIfNeeded()

--- a/MultiplexTests/UMDBarUIKitTests.swift
+++ b/MultiplexTests/UMDBarUIKitTests.swift
@@ -83,6 +83,29 @@ final class UMDBarUIKitTests: XCTestCase {
         )
     }
 
+    func testHerdrBackendRelabelsTheShortcutChipAtTheSameSlot() throws {
+        let controller = UMDBarViewController(configuration: configuration(
+            newTabTarget: .herdrWorkspaceTab,
+            shortcutBackend: .herdr
+        ))
+        controller.loadViewIfNeeded()
+
+        let chip = try XCTUnwrap(control("umd.tmux", in: controller.view))
+        XCTAssertEqual(chip.accessibilityLabel, "Show herdr shortcuts")
+        XCTAssertTrue(
+            descendants(of: UILabel.self, in: chip).contains {
+                ($0.text ?? $0.attributedText?.string)?.contains("HRDR") == true
+            },
+            "the chip face reads HRDR — four mono characters, TMUX's width"
+        )
+
+        let none = UMDBarViewController(configuration: configuration(
+            shortcutBackend: nil
+        ))
+        none.loadViewIfNeeded()
+        XCTAssertNil(control("umd.tmux", in: none.view))
+    }
+
     func testRegularActionRouterAndDirectButtonsPreserveEveryCallback() throws {
         let first = UUID()
         let second = UUID()
@@ -335,6 +358,7 @@ final class UMDBarUIKitTests: XCTestCase {
         closeSession: (() -> Void)? = nil,
         keychainTip: (() -> Void)? = nil,
         newTabTarget: TerminalRoute.NewTabTarget = .session,
+        shortcutBackend: Host.SessionBackend? = .tmux,
         style: UMDBarStyle = .regular,
         deckControlLabel: String = "DECK",
         availableWidth: CGFloat? = nil,
@@ -354,7 +378,7 @@ final class UMDBarUIKitTests: XCTestCase {
             closeSession: closeSession,
             keychainTip: keychainTip,
             newTabTarget: newTabTarget,
-            showsTmuxShortcuts: true,
+            shortcutBackend: shortcutBackend,
             style: style,
             deckControlLabel: deckControlLabel,
             availableWidth: availableWidth,

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -446,10 +446,10 @@ HRDR SHORTCUTS — the TMUX panel's herdr sibling
 A herdr tab now has the shortcut panel tmux tabs always had: the rail key
 (and the top-bar chip) reads HRDR and opens HERDR SHORTCUTS — herdr's
 stock ⌃B defaults, with the config action names as the rebinding
-reference. Splits (⌃B V left/right, ⌃B − top/bottom), Next Pane, Toggle
-Pane Zoom, Edit Scrollback, tab commands, workspace commands, Toggle
-Sidebar. The three closes take a second press, then close exactly what
-the server says is focused — no keybinding involved, so a rebound prefix
+reference. A deliberately small set: Splits (⌃B V left/right, ⌃B −
+top/bottom), Next Pane, New/Next/Previous Tab, New/Rename Workspace.
+The three closes take a second press, then close exactly what the
+server says is focused — no keybinding involved, so a rebound prefix
 can't misfire them. A Switch Workspace section lists the session's
 workspaces; tapping one moves the whole session's focus (every attached
 client follows — that is herdr).
@@ -457,7 +457,7 @@ client follows — that is herdr).
 - Attach a herdr session on iPad: HRDR sits exactly where TMUX does on a
   tmux tab, same width; press it.
 - Split Left / Right, then Split Top / Bottom: panes land side by side,
-  then stacked. Toggle Pane Zoom fills and restores.
+  then stacked.
 - Close Pane once: the row arms ("press again to close"); press again and
   the focused pane closes. Same shape for Close Tab / Close Workspace.
 - With two or more workspaces, Switch Workspace lists them numbered, the

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -440,3 +440,28 @@ in Workspace" so the menu says what it does. tmux hosts are unchanged.
   tab (with your remembered model), not in a new session.
 - Attach a tmux session and + TAB: still "New Session", still opens its
   own Multiplex tab.
+
+HRDR SHORTCUTS — the TMUX panel's herdr sibling
+
+A herdr tab now has the shortcut panel tmux tabs always had: the rail key
+(and the top-bar chip) reads HRDR and opens HERDR SHORTCUTS — herdr's
+stock ⌃B defaults, with the config action names as the rebinding
+reference. Splits (⌃B V left/right, ⌃B − top/bottom), Next Pane, Toggle
+Pane Zoom, Edit Scrollback, tab commands, workspace commands, Toggle
+Sidebar. The three closes take a second press, then close exactly what
+the server says is focused — no keybinding involved, so a rebound prefix
+can't misfire them. A Switch Workspace section lists the session's
+workspaces; tapping one moves the whole session's focus (every attached
+client follows — that is herdr).
+
+- Attach a herdr session on iPad: HRDR sits exactly where TMUX does on a
+  tmux tab, same width; press it.
+- Split Left / Right, then Split Top / Bottom: panes land side by side,
+  then stacked. Toggle Pane Zoom fills and restores.
+- Close Pane once: the row arms ("press again to close"); press again and
+  the focused pane closes. Same shape for Close Tab / Close Workspace.
+- With two or more workspaces, Switch Workspace lists them numbered, the
+  current one marked ACTIVE; tap another and the TUI follows.
+- On iPhone the tall panel scrolls instead of clipping rows (the tmux
+  panel gained the same scroll).
+- tmux tabs are unchanged: same TMUX key, same panel as before.


### PR DESCRIPTION
A herdr tab had no shortcut chrome: the TMUX key and popover are gated on `route.usesTmux`, so touch users couldn't split panes, switch tabs, or move between workspaces without a hardware keyboard.

## What this adds

- **HRDR in the shortcut slot.** The rail key (and the UMD/top-bar chip) reads `HRDR` on herdr tabs — four mono characters, TMUX's exact width, so every `TerminalKeyBarLayout` tier and the 390/420 pt top-bar cutoffs hold unchanged for both backends. The panel became content-driven: `ShortcutPanelViewController` renders a `ShortcutPanelContent`, and `.tmux` / `.herdr` are the two contents.
- **A deliberately small herdr set, pinned to 0.7.5 defaults.** Read from `herdr --default-config` and exercised against a real TUI attach over a pty — which is how `split_vertical` ⌃B V proved to be **left/right** and `split_horizontal` ⌃B − **top/bottom** (the config names alone don't say). Panes: splits, Next Pane (⌃B ⇥), Close Pane. Tabs: New/Next/Previous/Close. Workspaces: New, Rename, Close. Subtext is herdr's config action name — the `[keys]` rebinding reference. (Zoom, Edit Scrollback, Rename Tab, Workspace Picker, and Toggle Sidebar were trimmed by request — herdr's TUI already surfaces them; the enum header records the trim.)
- **Closes stay app-confirmed, then run direct.** Double-press arms exactly like the tmux closes, then one snapshot exec resolves *strictly what the server names focused* (`HerdrProbe.parseFocusedCloseTarget` — never a guess) and one `pane|tab|workspace close <id>` exec closes it over the SSH control connection. A user-rebound prefix can't misfire a destructive action, and herdr's own confirm dialog never asks twice.
- **Switch Workspace** (the Switch Window analog): `workspace list` fills the rows — reusing `TmuxWindowChoice` the way the probe reuses the tmux records — ACTIVE marks the focused one, and a tap runs `workspace focus <id>`; the session's ONE global focus moves and every attached client follows. Response-derived ids pass the bake vet before splicing.
- **Phones scroll instead of clipping.** The panel root hosts its content in a scroll view: a tall grid plus a workspace list overflows an iPhone popover, which clamps tall content — the clamped panel now scrolls (the tmux panel gains the same on phones with many windows).

## Verification

- `HerdrShortcutTests` pins bindings/labels/groups; `HerdrProbeTests` gains workspace-list/focus/close-target/close-command cases against captured 0.7.5 envelopes; `ShortcutPanelUIKitTests` covers both contents (headers, double-press arming, workspace nouns, capped choice scroll). Full suite: 1079/1079.
- Live on the iPhone simulator against real herdr 0.7.5 (`harness.sh herdr`, `mpx-demo`): HRDR key in the rail, full panel with no clipped rows, Switch Workspace listing the session's live workspaces with ACTIVE, on a LIVE attach.
- Split direction, `workspace focus`, and all three close verbs were exercised against a real herdr server before the enum was written.
- `build vos` + `build ipad` clean, SwiftLint 0 violations. TestFlight changelog appended.