### PR TITLE
Light a herdr tile's LIVE lamp from this app's own open tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -751,7 +751,13 @@ logic belongs — keep parsing/command-building out of views.
   dir — one field, one meaning; an unconfigured host falls to the
   session's world: tmux active-pane cwd / herdr server default). A dead
   target name falls back to the fresh-session mint; a failed in-session
-  create is a visible failure, never a fallback mint. herdr reports no client count or creation time.
+  create is a visible failure, never a fallback mint. herdr reports no client
+  count or creation time — nothing in `session list`, `api snapshot`,
+  `status`, or the bundled `api schema` names an attached client — so a herdr
+  tile's LIVE lamp answers for the one client the app can verify: its own open
+  terminal tab (`Host.SessionBackend.isSessionLive`, pure). A shell attached
+  on the host stays invisible there; the tile understates rather than guesses,
+  the same choice its blank client-count and age telemetry already make.
   The shortcut panel has a herdr variant (`HerdrShortcut`, pure + tested;
   the rail key face reads HRDR; deliberately curated small — zoom,
   scrollback, rename-tab, picker, and sidebar rows were trimmed

--- a/Multiplex/Models/Host.swift
+++ b/Multiplex/Models/Host.swift
@@ -25,6 +25,27 @@ struct Host: Identifiable, Codable, Hashable {
     enum SessionBackend: String, Codable, CaseIterable {
         case tmux
         case herdr
+
+        /// Whether the probe can state how many clients a session has.
+        /// tmux answers `#{session_attached}`; herdr 0.7.5 / protocol 17
+        /// exposes no attached-client surface at all (verified 2026-08-02
+        /// across `session list --json`, `api snapshot`, `status --json`,
+        /// and the bundled API schema — only the socket-only
+        /// `client.window_title` reply leaks a `no_foreground_client`
+        /// reason, and no CLI verb reaches it), so its records carry
+        /// `clientCount == 0` whatever is really attached.
+        var reportsClientCount: Bool { self == .tmux }
+
+        /// Whether a session is live right now — said only where it can be
+        /// verified. tmux counts every client on the host. herdr can answer
+        /// for exactly one client: the one this app is, which is what an
+        /// open terminal tab means. A shell on the host attached to the same
+        /// herdr session therefore stays invisible; the tile understates
+        /// rather than guesses, the same choice its missing client count and
+        /// session age already make.
+        func isSessionLive(clientCount: Int, hasOpenTab: Bool) -> Bool {
+            reportsClientCount ? clientCount > 0 : hasOpenTab
+        }
     }
 
     var id: UUID = UUID()

--- a/Multiplex/Services/HerdrProbe.swift
+++ b/Multiplex/Services/HerdrProbe.swift
@@ -33,9 +33,14 @@ import Foundation
 /// - `session delete` requires `session stop` first, and herdr itself
 ///   refuses to delete the default session — the app never needs to know
 ///   which one that is.
-/// - No API surface reports attached clients, so herdr sessions never
-///   claim the ATTACHED lamp: `clientCount` stays 0 and the tile simply
-///   doesn't say what nothing can verify.
+/// - No API surface reports attached clients (re-verified 2026-08-02
+///   across `session list --json`, `api snapshot`, `status --json`, and
+///   the bundled `api schema`: only the socket-only `client.window_title`
+///   reply leaks a `no_foreground_client` reason, and no CLI verb reaches
+///   it), so `clientCount` stays 0 here and the tile's telemetry says
+///   nothing about clients. The LIVE lamp instead answers for the one
+///   client the app can verify — its own open terminal tab — through
+///   `Host.SessionBackend.isSessionLive`.
 ///
 /// The parser maps herdr's model onto the existing tmux records —
 /// **session → `TmuxSession`, workspace → `TmuxWindow`** (represented by

--- a/Multiplex/Views/Deck/FleetWall.swift
+++ b/Multiplex/Views/Deck/FleetWall.swift
@@ -1384,6 +1384,7 @@ private final class FleetHostSectionView: UIView {
                     usesTmuxAttentionFallback: snapshot.hasLiveProbe
                         && host.sessionBackend == .tmux,
                     hasOpenTab: snapshot.openSessionNames.contains(session.name),
+                    sessionBackend: host.sessionBackend,
                     compact: configuration.presentation == .shellRail,
                     selected: configuration.selectedTerminal?.hostID == host.id
                         && configuration.selectedTerminal?.sessionName == session.name
@@ -2258,6 +2259,9 @@ struct FleetSessionTileConfiguration {
     /// across every pane and must never fall back to title heuristics.
     let usesTmuxAttentionFallback: Bool
     let hasOpenTab: Bool
+    /// Which multiplexer this tile speaks for. Only the LIVE lamp reads it:
+    /// a herdr session has no client count to light it with.
+    let sessionBackend: Host.SessionBackend
     let compact: Bool
     let selected: Bool
     let duplicateAttachTitle: String
@@ -2266,6 +2270,15 @@ struct FleetSessionTileConfiguration {
     let attachNewWindow: () -> Void
     let delete: () -> Void
     let droppedSession: (String) -> Void
+
+    /// Whether the session is attached right now — the LIVE lamp's one
+    /// authority, resolved per backend by `SessionBackend.isSessionLive`.
+    var isLive: Bool {
+        sessionBackend.isSessionLive(
+            clientCount: session.clientCount,
+            hasOpenTab: hasOpenTab
+        )
+    }
 
     /// Data equality of everything the tile draws. The actions are the only
     /// exclusions: equal data means their captured host/session inputs are
@@ -2277,6 +2290,7 @@ struct FleetSessionTileConfiguration {
             && attention == other.attention
             && usesTmuxAttentionFallback == other.usesTmuxAttentionFallback
             && hasOpenTab == other.hasOpenTab
+            && sessionBackend == other.sessionBackend
             && compact == other.compact
             && selected == other.selected
             && duplicateAttachTitle == other.duplicateAttachTitle
@@ -2579,10 +2593,11 @@ final class FleetSessionTileView: FleetPressView,
         row.addArrangedSubview(name)
 
         let attachSlot = UIView()
+        let isLive = configuration.isLive
         let attach = FleetBadgeView(caption: "ATTACH")
-        attach.alpha = configuration.session.isAttached ? 0 : 1
+        attach.alpha = isLive ? 0 : 1
         let live = UIKitTallyLamp(caption: "LIVE", color: TallyPalette.tally)
-        live.isHidden = !configuration.session.isAttached
+        live.isHidden = !isLive
         attachSlot.addSubview(attach)
         attachSlot.addSubview(live)
         attach.translatesAutoresizingMaskIntoConstraints = false
@@ -2721,7 +2736,7 @@ final class FleetSessionTileView: FleetPressView,
         agentNeedsYou: Bool
     ) -> String {
         let session = configuration.session
-        var parts = [session.name, session.isAttached ? "live" : "not attached"]
+        var parts = [session.name, configuration.isLive ? "live" : "not attached"]
         if agentNeedsYou { parts.append("agent needs your input") }
         if agentRunning { parts.append("agent running") }
         parts.append("\(session.windowCount) windows and \(session.paneCount) panes")

--- a/MultiplexTests/FleetWallUIKitTests.swift
+++ b/MultiplexTests/FleetWallUIKitTests.swift
@@ -429,6 +429,7 @@ final class FleetWallUIKitTests: XCTestCase {
             attention: .needsYou(.permission),
             usesTmuxAttentionFallback: true,
             hasOpenTab: true,
+            sessionBackend: .tmux,
             compact: false,
             selected: true,
             duplicateAttachTitle: "Attach in New Window",
@@ -455,6 +456,57 @@ final class FleetWallUIKitTests: XCTestCase {
         XCTAssertTrue(copy.contains("LIVE"))
     }
 
+    /// herdr states no client count, so a herdr tile's lamp answers for the
+    /// one client the app can verify: its own open terminal tab. Without one
+    /// the tile keeps offering ATTACH rather than claiming a state nothing
+    /// reported.
+    func testHerdrSessionTileLampFollowsThisAppsOwnOpenTab() {
+        // The record herdr's adapter produces: no clients, ever.
+        var session = makeSession(name: "main")
+        session.clientCount = 0
+
+        func tile(hasOpenTab: Bool) -> FleetSessionTileView {
+            let tile = FleetSessionTileView()
+            tile.configure(FleetSessionTileConfiguration(
+                hostID: UUID(),
+                session: session,
+                lines: ["$ herdr"],
+                attention: nil,
+                usesTmuxAttentionFallback: false,
+                hasOpenTab: hasOpenTab,
+                sessionBackend: .herdr,
+                compact: false,
+                selected: false,
+                duplicateAttachTitle: "Attach in New Window",
+                openTabAccessibilityText: "Shows its open window",
+                attach: {},
+                attachNewWindow: {},
+                delete: {},
+                droppedSession: { _ in }
+            ))
+            tile.frame = CGRect(x: 0, y: 0, width: 360, height: 190)
+            tile.layoutIfNeeded()
+            return tile
+        }
+
+        let open = tile(hasOpenTab: true)
+        XCTAssertTrue(shownText(in: open).contains("LIVE"))
+        XCTAssertFalse(shownText(in: open).contains("ATTACH"))
+        XCTAssertTrue(open.accessibilityLabel?.contains("live") == true)
+
+        let closed = tile(hasOpenTab: false)
+        XCTAssertFalse(shownText(in: closed).contains("LIVE"))
+        XCTAssertTrue(shownText(in: closed).contains("ATTACH"))
+        XCTAssertTrue(closed.accessibilityLabel?.contains("not attached") == true)
+
+        // A tmux tile still reads the probe: an open tab is not what makes
+        // it live, and a client attached elsewhere still does.
+        XCTAssertTrue(Host.SessionBackend.tmux.isSessionLive(
+            clientCount: 1, hasOpenTab: false))
+        XCTAssertFalse(Host.SessionBackend.tmux.isSessionLive(
+            clientCount: 0, hasOpenTab: true))
+    }
+
     func testSessionTileDragIsLocalStableAndHasNoBrightPreviewPlatter() throws {
         let hostID = UUID()
         let sourceSession = makeSession(name: "agent")
@@ -473,6 +525,7 @@ final class FleetWallUIKitTests: XCTestCase {
                 attention: nil,
                 usesTmuxAttentionFallback: true,
                 hasOpenTab: false,
+                sessionBackend: .tmux,
                 compact: false,
                 selected: false,
                 duplicateAttachTitle: "Attach in New Window",
@@ -553,6 +606,7 @@ final class FleetWallUIKitTests: XCTestCase {
             attention: nil,
             usesTmuxAttentionFallback: true,
             hasOpenTab: false,
+            sessionBackend: .tmux,
             compact: false,
             selected: false,
             duplicateAttachTitle: "Attach in New Window",
@@ -776,6 +830,19 @@ final class FleetWallUIKitTests: XCTestCase {
             if let submenu = child as? UIMenu { return menuTitles(submenu) }
             return []
         }
+    }
+
+    /// `visibleText` reads the whole label tree — the tile keeps both faces
+    /// of its attach slot mounted so the row can't resize, so only this
+    /// walk (which honours hidden/zero-alpha branches) can tell which one
+    /// the eye actually sees.
+    private func shownText(in root: UIView) -> String {
+        guard !root.isHidden, root.alpha > 0 else { return "" }
+        let own = (root as? UILabel).flatMap { $0.attributedText?.string ?? $0.text } ?? ""
+        return ([own] + root.subviews.map { shownText(in: $0) })
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+            .uppercased()
     }
 
     private func visibleText(in root: UIView) -> String {

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -465,3 +465,20 @@ client follows — that is herdr).
 - On iPhone the tall panel scrolls instead of clipping rows (the tmux
   panel gained the same scroll).
 - tmux tabs are unchanged: same TMUX key, same panel as before.
+
+DECK — a herdr session you have open now shows LIVE
+
+A herdr tile used to offer ATTACH even while one of your terminal
+windows was already attached to it (herdr, unlike tmux, publishes no
+attached-client count anywhere, so the lamp had nothing to read). The
+tile now lights LIVE whenever Multiplex itself has a window open on
+that session.
+
+- On a herdr host, attach a session from the deck, then go back to the
+  deck: its tile reads ● LIVE instead of the ATTACH badge.
+- Close that terminal window (or its tab): the tile returns to ATTACH.
+- Attach the same session from a shell ON the host instead: the tile
+  still says ATTACH — herdr tells the app nothing about other clients,
+  and the tile won't claim what it can't check.
+- tmux tiles are unchanged: they keep counting every client on the host,
+  yours and other people's, and still show "2 CLIENTS" telemetry.


### PR DESCRIPTION
## The bug

A herdr session with one of Multiplex's own terminal windows already attached still showed the **ATTACH** badge on its deck tile — the LIVE lamp never lit on a herdr host.

## Why

herdr publishes no attached-client count anywhere. Re-verified against **0.7.5 / protocol 17** (2026-08-02):

| surface | client info |
| --- | --- |
| `herdr session list --json` | none |
| `herdr --session <s> api snapshot` | none |
| `herdr status --json` | none |
| `herdr api schema --json` (full) | none |

The only trace of client presence in the whole protocol is the socket-only `client.window_title.{set,clear}` reply, whose `reason` can be `no_foreground_client` — and **no CLI verb reaches it**, so the probe (which speaks CLI over an SSH exec channel) cannot ask.

`HerdrProbe` therefore sets `clientCount: 0` unconditionally, and the tile's lamp read `session.isAttached` (`clientCount > 0`). Nothing could ever light it.

## The fix

The lamp now resolves per backend, through a pure model member:

```swift
func isSessionLive(clientCount: Int, hasOpenTab: Bool) -> Bool {
    reportsClientCount ? clientCount > 0 : hasOpenTab
}
```

- **tmux** is unchanged: it keeps counting every client on the host, yours and other people's, and still shows its `2 CLIENTS` telemetry.
- **herdr** answers for the one client the app can verify — its own open terminal tab. The deck already computes `hasOpenTab` for press routing (focus-existing vs. attach) and reads it inside `withObservationTracking`, so opening or closing a window re-renders the tile with no new plumbing.

`FleetSessionTileConfiguration` carries `sessionBackend` and exposes `isLive`; the ATTACH badge, the LIVE lamp, and the accessibility summary (`"live"` / `"not attached"`) all read the one value.

## Accepted limitation

A herdr session attached from a shell **on the host** still reads ATTACH. herdr tells the app nothing about other clients, so the tile understates rather than guesses — the same choice its blank client-count and session-age telemetry already make. Stated in the `HerdrProbe` header, in `AGENTS.md`, and in the TestFlight changelog so a tester isn't surprised.

## Also updated

- `HerdrProbe`'s header fact, with the dated re-verification and a pointer to where the lamp's authority now lives.
- The herdr paragraph in `AGENTS.md`.
- `fastlane/testflight-whats-new.txt` — a test script for the attach → deck → detach loop, including the host-shell case that deliberately stays ATTACH.

## Verification

- New `testHerdrSessionTileLampFollowsThisAppsOwnOpenTab` renders both states through real UIKit and asserts on what is actually *shown* — the tile keeps both faces of its attach slot mounted so the row can't resize, so the test needed a new `shownText(in:)` walk that honours hidden/zero-alpha branches. It also pins tmux's behaviour (an open tab alone is not live; a client elsewhere is).
- Full `MultiplexTests` suite green on the visionOS simulator.
- SwiftLint `--strict`: 0 violations.

Not run against a live herdr host in the simulator — the change is deck-side and covered at the view layer, but happy to seed `state/seed-herdr.json` and confirm the lamp flips on attach/detach if you want that before merge.