### PR TITLE
Resize herdr pane splits with a long-press drag

### DIFF
--- a/Multiplex/Models/HerdrPaneBorder.swift
+++ b/Multiplex/Models/HerdrPaneBorder.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Decides whether a terminal cell can be a herdr pane border — the gate for
+/// claiming a long press as a remote resize drag instead of the selection
+/// menu.
+///
+/// herdr draws its pane dividers with Unicode box-drawing glyphs and moves
+/// them by mouse drag (verified against herdr 0.7.5: an attached client's SGR
+/// press → motion → release on a divider column changes the split ratio). The
+/// app cannot know where the dividers are — layout lives host-side — but the
+/// glyph under the finger is a local, immediate discriminator: every divider
+/// cell is a box-drawing character, so everything else keeps the long press's
+/// existing meaning (links, the selection menu).
+///
+/// Accepted trade: a TUI running *inside* a pane can draw its own box borders
+/// (an agent's input frame), and a long press there also becomes a mouse
+/// drag. herdr receives it as an ordinary in-pane drag — selection or a
+/// forwarded mouse event, never destructive — and a plain long press one cell
+/// away still reaches the menu.
+enum HerdrPaneBorder {
+    /// The Unicode Box Drawing block (U+2500–U+257F): light/heavy/double
+    /// lines, every junction, and the rounded corners herdr's rounded panes
+    /// use.
+    static func isBorderCell(_ content: Character?) -> Bool {
+        guard let content, let scalar = content.unicodeScalars.first,
+              content.unicodeScalars.count == 1
+        else { return false }
+        return (0x2500...0x257F).contains(scalar.value)
+    }
+
+    /// The vertical-divider glyphs a headless validation drag can aim at —
+    /// deterministic targets for a horizontal drag (`debug.resizedrag`).
+    static func isVerticalBar(_ content: Character?) -> Bool {
+        guard let content else { return false }
+        return content == "│" || content == "┃" || content == "║"
+    }
+}

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -222,6 +222,16 @@ final class TerminalSessionController {
         view.linkActivationHandler = { [weak self] target, _, rowTexts in
             self?.activateLink(target, rowFragments: rowTexts) ?? false
         }
+        // herdr resizes its pane splits by mouse drag, so a long press on a
+        // border cell becomes a remote press-drag-release. herdr tabs only:
+        // the same drag under tmux starts a copy-mode selection, and the
+        // fork's filter is consulted only while the client requested button
+        // tracking, so a plain shell never loses its long press.
+        if route.sessionBackend == .herdr {
+            view.longPressMouseDragFilter = { _, content in
+                HerdrPaneBorder.isBorderCell(content)
+            }
+        }
         if !pendingOutput.isEmpty {
             view.feed(byteArray: pendingOutput[...])
             pendingOutput.removeAll()

--- a/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
+++ b/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
@@ -361,6 +361,65 @@ enum TerminalFocusArbiter {
         installDebugDismissHook()
         installDebugScrollHooks()
         installDebugKeyboardLockHook()
+        installDebugResizeDragHook()
+    }
+
+    /// Headless stand-in for the long-press-on-border resize drag (no
+    /// headless route can synthesize a touch): `… -p
+    /// app.multiplexterm.multiplex.debug.resizedrag` finds the first vertical
+    /// divider glyph the focused terminal's drag filter claims, then drives
+    /// the exact begin → motion → release path the gesture takes, dragging
+    /// six columns right. Proof is host-side: the herdr split ratio moves
+    /// (`herdr --session <name> pane layout`).
+    private static func installDebugResizeDragHook() {
+        var token: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.resizedrag", &token, .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                performDebugResizeDrag()
+            }
+        }
+    }
+
+    private static func performDebugResizeDrag() {
+        guard let view = current, let filter = view.longPressMouseDragFilter else { return }
+        let terminal = view.getTerminal()
+        // herdr draws several vertical-bar columns (sidebar edge, pane
+        // frames); the shared divider of a side-by-side split is the bar
+        // column nearest the grid's horizontal center. Drag at that column's
+        // median bar row.
+        var rowsByColumn: [Int: [Int]] = [:]
+        for row in 0..<terminal.rows {
+            for col in 0..<terminal.cols {
+                let content = terminal.getCharacter(col: col, row: row)
+                if HerdrPaneBorder.isVerticalBar(content), filter((col, row), content) {
+                    rowsByColumn[col, default: []].append(row)
+                }
+            }
+        }
+        guard let (column, rows) = rowsByColumn.min(by: {
+            abs($0.key - terminal.cols / 2) < abs($1.key - terminal.cols / 2)
+        }) else {
+            keyboardLogger.debug("resizedrag no vertical bar found cols=\(terminal.cols) rows=\(terminal.rows)")
+            return
+        }
+        let cell = (col: column, row: rows[rows.count / 2])
+        let candidates = rowsByColumn.keys.sorted().map { "\($0)x\(rowsByColumn[$0]!.count)" }
+            .joined(separator: ",")
+        keyboardLogger.debug(
+            "resizedrag grid=\(terminal.cols)x\(terminal.rows) candidates=\(candidates) chose=\(cell.col),\(cell.row)")
+        Task { @MainActor in
+            guard view.beginRemoteMouseDrag(at: view.pointForCell(col: cell.col, row: cell.row))
+            else { return }
+            for step in 1...6 {
+                try? await Task.sleep(nanoseconds: 40_000_000)
+                view.continueRemoteMouseDrag(
+                    at: view.pointForCell(col: cell.col + step, row: cell.row))
+            }
+            try? await Task.sleep(nanoseconds: 40_000_000)
+            view.endRemoteMouseDrag(at: view.pointForCell(col: cell.col + 6, row: cell.row))
+        }
     }
 
     /// Headless stand-in for the keyboard key's long press (no simulator

--- a/MultiplexTests/HerdrPaneBorderTests.swift
+++ b/MultiplexTests/HerdrPaneBorderTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Multiplex
+
+/// Pins the gate that turns a long press into a herdr resize drag: only a
+/// Unicode box-drawing cell qualifies, so links, prose, and empty cells keep
+/// the long press's existing meanings. The drag itself was verified against
+/// herdr 0.7.5 (an SGR press → motion → release on a divider moves the split
+/// ratio).
+final class HerdrPaneBorderTests: XCTestCase {
+    func testDividerGlyphsAreBorderCells() {
+        for glyph: Character in ["│", "─", "┃", "━", "║", "═",
+                                 "┌", "┐", "└", "┘", "├", "┤", "┬", "┴", "┼",
+                                 "╭", "╮", "╰", "╯"] {
+            XCTAssertTrue(HerdrPaneBorder.isBorderCell(glyph),
+                          "\(glyph) must count as a border cell")
+        }
+    }
+
+    func testOrdinaryContentIsNotABorderCell() {
+        for glyph: Character in ["a", "Z", "0", " ", "|", "-", "_", "+", "/",
+                                 "…", "•", "█", "▐", "░", "✳", "π"] {
+            XCTAssertFalse(HerdrPaneBorder.isBorderCell(glyph),
+                           "\(glyph) must not claim the long press")
+        }
+        XCTAssertFalse(HerdrPaneBorder.isBorderCell(nil),
+                       "an empty cell keeps the selection menu")
+    }
+
+    func testBlockElementsStayOutside() {
+        // U+2580… Block Elements sit right after Box Drawing — a full-block
+        // progress bar must never swallow a long press.
+        XCTAssertFalse(HerdrPaneBorder.isBorderCell("▀"))
+        XCTAssertFalse(HerdrPaneBorder.isBorderCell("▂"))
+    }
+
+    func testVerticalBarsAreTheHeadlessDragTargets() {
+        XCTAssertTrue(HerdrPaneBorder.isVerticalBar("│"))
+        XCTAssertTrue(HerdrPaneBorder.isVerticalBar("┃"))
+        XCTAssertTrue(HerdrPaneBorder.isVerticalBar("║"))
+        XCTAssertFalse(HerdrPaneBorder.isVerticalBar("─"),
+                       "a horizontal rule is no target for a horizontal drag")
+        XCTAssertFalse(HerdrPaneBorder.isVerticalBar("|"),
+                       "ASCII pipe is pane content, not a divider")
+        XCTAssertFalse(HerdrPaneBorder.isVerticalBar(nil))
+    }
+}

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSTerminalView.swift
@@ -739,7 +739,17 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
     
     @objc func longPress (_ gestureRecognizer: UILongPressGestureRecognizer)
     {
-         if gestureRecognizer.state == .began {
+         switch gestureRecognizer.state {
+         case .began:
+             // Multiplex patch: the app can claim a long press as the start of
+             // a remote mouse drag (press + motion + release) for cells it
+             // recognizes — a TUI multiplexer's pane-resize bar. Checked before
+             // link activation and the selection menu; everything the filter
+             // declines keeps the existing behavior.
+             if !shiftBypassesMouseReporting(for: gestureRecognizer),
+                beginRemoteMouseDrag(at: gestureRecognizer.location(in: self)) {
+                 return
+             }
              let _ = self.becomeFirstResponder()
              let tapLocation = gestureRecognizer.location(in: gestureRecognizer.view)
              let tapRegion = makeContextMenuRegionForTap (point: tapLocation)
@@ -757,7 +767,106 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
              }
 
              showContextMenu (forRegion: tapRegion, pos: hit)
+         case .changed:
+             continueRemoteMouseDrag(at: gestureRecognizer.location(in: self))
+         case .ended, .cancelled, .failed:
+             endRemoteMouseDrag(at: gestureRecognizer.location(in: self))
+         default:
+             break
           }
+    }
+
+    /// Multiplex patch: when set, a long press over a cell this filter claims
+    /// becomes a remote mouse drag instead of the selection menu. The filter
+    /// receives the screen cell (zero-based, what the wire will report) and
+    /// that cell's character, and must answer quickly — it runs at gesture
+    /// time. Only consulted while the client requested button tracking
+    /// (1002/1003), so a plain shell never loses its long press.
+    public var longPressMouseDragFilter: ((_ cell: (col: Int, row: Int), _ content: Character?) -> Bool)?
+
+    /// Multiplex patch: true between a claimed drag's press and its release.
+    public var remoteMouseDragActive: Bool { mouseDragPressFlags != nil }
+
+    private var mouseDragPressFlags: Int?
+    private var mouseDragReleaseFlags = 0
+    private var mouseDragLastCell: Position?
+
+    /// Converts a point in view coordinates to the screen cell a mouse report
+    /// should carry, clamped to the visible grid.
+    private func remoteMouseDragCell (at point: CGPoint) -> (grid: Position, pixels: Position)? {
+        guard let terminal else { return nil }
+        let hit = calculateTapHit(point: point)
+        guard let screen = hit.grid.toScreenCoordinate(from: terminal.displayBuffer) else { return nil }
+        let clamped = Position(col: min (max (0, screen.col), terminal.cols-1),
+                               row: min (max (0, screen.row), terminal.rows-1))
+        return (clamped, hit.pixels)
+    }
+
+    /// Multiplex patch: begins a remote mouse drag at `point` if the filter
+    /// claims that cell. Public so the app's DEBUG hooks can drive the exact
+    /// gesture path headlessly. Returns true when the press was sent.
+    @discardableResult
+    public func beginRemoteMouseDrag (at point: CGPoint) -> Bool {
+        guard let filter = longPressMouseDragFilter,
+              allowMouseReporting,
+              let terminal,
+              terminal.mouseMode.sendButtonTracking(),
+              !selection.active,
+              !contextMenuPresented,
+              mouseDragPressFlags == nil,
+              let hit = remoteMouseDragCell(at: point)
+        else { return false }
+        guard filter((hit.grid.col, hit.grid.row),
+                     terminal.getCharacter(col: hit.grid.col, row: hit.grid.row))
+        else { return false }
+        // Encode both flag values once at press time: encodeFlags clears the
+        // app's CTRL latch as a side effect, and a drag's many motion samples
+        // must all ride the modifiers the press carried.
+        let control = terminalAccessory?.controlModifier ?? controlModifier
+        let pressFlags = encodeFlags(release: false)
+        mouseDragPressFlags = pressFlags
+        mouseDragReleaseFlags = terminal.encodeButton(button: 0, release: true,
+                                                      shift: false, meta: false, control: control)
+        mouseDragLastCell = hit.grid
+        terminal.sendEvent(buttonFlags: pressFlags, x: hit.grid.col, y: hit.grid.row,
+                           pixelX: hit.pixels.col, pixelY: hit.pixels.row)
+        return true
+    }
+
+    /// Multiplex patch: sends a motion report when the drag has moved to a new
+    /// cell. Quantized to cells so a fast finger never floods the remote.
+    public func continueRemoteMouseDrag (at point: CGPoint) {
+        guard let pressFlags = mouseDragPressFlags,
+              let terminal,
+              let hit = remoteMouseDragCell(at: point),
+              hit.grid != mouseDragLastCell
+        else { return }
+        mouseDragLastCell = hit.grid
+        terminal.sendMotion(buttonFlags: pressFlags, x: hit.grid.col, y: hit.grid.row,
+                            pixelX: hit.pixels.col, pixelY: hit.pixels.row)
+    }
+
+    /// Multiplex patch: the inverse of `calculateTapHit` for a visible screen
+    /// cell — the view-coordinate center of that cell. What the app's DEBUG
+    /// hooks stand on to drive the drag path headlessly (no headless route
+    /// can synthesize a real touch).
+    public func pointForCell (col: Int, row: Int) -> CGPoint {
+        let bufferRow = CGFloat (row + (terminal?.displayBuffer.yDisp ?? 0))
+        return CGPoint (x: (CGFloat (col) + 0.5) * cellDimension.width,
+                        y: (bufferRow + 0.5) * cellDimension.height)
+    }
+
+    /// Multiplex patch: releases an active drag at `point` (falling back to
+    /// the last reported cell), always exactly once.
+    public func endRemoteMouseDrag (at point: CGPoint? = nil) {
+        guard mouseDragPressFlags != nil, let terminal else { return }
+        let hit = point.flatMap { remoteMouseDragCell(at: $0) }
+        let cell = hit?.grid ?? mouseDragLastCell ?? Position(col: 0, row: 0)
+        let pixels = hit?.pixels ?? Position(col: 0, row: 0)
+        terminal.sendEvent(buttonFlags: mouseDragReleaseFlags, x: cell.col, y: cell.row,
+                           pixelX: pixels.col, pixelY: pixels.row)
+        mouseDragPressFlags = nil
+        mouseDragLastCell = nil
     }
     
     /// This controls whether the backspace should send ^? or ^H, the default is ^?

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -8,6 +8,7 @@
   - LIVE lamp: a herdr tile reads ● LIVE while one of your own terminal windows is attached to it.
   - FILE attach: FILE and drag-and-drop work on herdr tabs — upload into the focused pane's directory, path typed, never submitted.
   - Agent strip: switch tabs or workspaces inside herdr; the helper chips should follow the focused agent in about one second instead of waiting for the five-second wall refresh.
+  - RESIZE BY TOUCH: on a herdr tab, long-press a pane divider line and drag — the split follows your finger (herdr resizes it live). A long press anywhere else keeps its usual meaning (links, selection menu).
 - UIKIT REBUILD: every surface (deck, terminals, shell, Settings, Add Host, paywall, file viewer, viewport) now runs on UIKit — sweep your usual flows; anything that looks or feels different from the last beta is a find.
 - FASTER TAPS: under mouse reporting each tap reaches tmux immediately, one click per tap, so remote double-clicks work.
 - VISION PRO GLASS: Settings ▸ Appearance adds GLASS beside SYSTEM / LIGHT / DARK, applied live to deck, terminals, forms, and popovers.


### PR DESCRIPTION
## Summary

On a herdr tab, long-pressing a pane divider line and dragging now resizes the split live. The long press begins a remote mouse drag — SGR press at the cell, one motion report per crossed cell, release on lift — which herdr's own mouse UI turns into a divider move (verified against herdr 0.7.5: the divider travels exactly the dragged columns).

- **SwiftTerm fork patch** (`iOSTerminalView.swift`, marked `Multiplex patch`): new app-settable `longPressMouseDragFilter` consulted at long-press `.began`, before link activation and the selection menu, and only while the client requested button tracking (1002/1003) — so a plain shell, an active selection, or the context menu never lose the existing behavior. Public `beginRemoteMouseDrag`/`continueRemoteMouseDrag`/`endRemoteMouseDrag` carry the sequence (motion quantized to cells so a fast finger can't flood the remote; release sent exactly once), and `pointForCell` is the inverse of the tap hit-test for headless driving. Flags are encoded once at press time — `encodeFlags` clears the CTRL latch as a side effect, and every motion sample must ride the press's modifiers.
- **App wiring**: `TerminalSessionController.bind` installs the filter for herdr session routes only. The gate is the new pure `HerdrPaneBorder` — a cell qualifies iff it's a Unicode Box Drawing glyph (herdr draws every divider with them; verified from a live attach capture). tmux tabs deliberately stay out: the same drag under tmux starts a copy-mode selection.
- **DEBUG hook** `debug.resizedrag` (TerminalFocusArbiter): finds the claimed vertical-bar column nearest the grid center and drives the exact begin → motion → release path the gesture takes, logging grid/candidates/choice under category `kbd`.

## Verification

- E2E on the iPad Pro 13-inch (M5) simulator against a real herdr 0.7.5 session over the dev-sshd harness: split a session 50/50 (`pane split`), auto-attach, fire `debug.resizedrag` → host-side `herdr pane layout` reports ratio 0.5 → 0.58, the divider moved exactly the 6 dragged columns.
- Unit tests: 1063 pass, including the new `HerdrPaneBorderTests` (glyph gate: Box Drawing in, Block Elements / ASCII `|` / prose out). The one red on my churned sim, `StoreKitIntegrationTests`, passes on a clean iPad sim — environmental, untouched by this diff.
- SwiftLint strict: 0 violations. Builds on visionOS and iPad.
- Hands-on: the real finger gesture confirmed working.

## Notes

- Accepted trade (documented in `HerdrPaneBorder`): a TUI drawing its own box borders inside a pane can also claim the long press there; herdr receives it as an ordinary in-pane drag, never destructive, and one cell away the long press keeps its usual meaning.
- Observed once right after a fresh attach: a press on a pane-frame column resized the sidebar instead of the split (also by exactly the drag distance — the wire path is fine; herdr's grab resolution seems position/focus-sensitive immediately after attach). Worth keeping an eye on in beta.
- TestFlight changelog staged (RESIZE BY TOUCH entry).