### PR TITLE
Name the App Store failure on the paywall and log commerce errors (main)

### DIFF
--- a/Multiplex/Services/EntitlementStore.swift
+++ b/Multiplex/Services/EntitlementStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import OSLog
 import StoreKit
 import SwiftUI
 
@@ -204,6 +205,11 @@ final class EntitlementStore {
         let task: Task<Bool, Never>
     }
 
+    private static let logger = Logger(
+        subsystem: "app.multiplexterm.multiplex",
+        category: "commerce"
+    )
+
     private static let unlockedKey = "MultiplexProUnlocked"
     private static let slashChipDayKey = "MultiplexSlashChipDay"
     private static let slashChipCountKey = "MultiplexSlashChipCount"
@@ -361,11 +367,15 @@ final class EntitlementStore {
                 do {
                     guard let product = try await storeClient.loadProduct(),
                           product.id == Self.proProductID else {
+                        Self.logger.error("product load returned no Pro product")
                         return .failed("Multiplex Pro is not available from the App Store right now.")
                     }
                     return .loaded(product)
                 } catch {
-                    return .failed(error.localizedDescription)
+                    Self.logger.error(
+                        "product load failed: \(String(describing: error), privacy: .public)"
+                    )
+                    return .failed(Self.storeErrorMessage(error))
                 }
             }
             load = ProductLoad(id: id, task: task)
@@ -432,6 +442,7 @@ final class EntitlementStore {
 
             switch result {
             case .success(.unverified):
+                Self.logger.error("purchase returned an unverified transaction")
                 return settlePurchase(withFallback: .failed(
                     "The App Store transaction could not be verified."
                 ))
@@ -474,7 +485,10 @@ final class EntitlementStore {
                 ))
             }
         } catch {
-            return settlePurchase(withFallback: .failed(error.localizedDescription))
+            Self.logger.error(
+                "purchase failed: \(String(describing: error), privacy: .public)"
+            )
+            return settlePurchase(withFallback: .failed(Self.storeErrorMessage(error)))
         }
     }
 
@@ -516,7 +530,10 @@ final class EntitlementStore {
                 commerceState = .restored
                 return true
             }
-            commerceState = .failed(error.localizedDescription)
+            Self.logger.error(
+                "restore failed: \(String(describing: error), privacy: .public)"
+            )
+            commerceState = .failed(Self.storeErrorMessage(error))
             return false
         }
     }
@@ -685,6 +702,9 @@ final class EntitlementStore {
                 }
                 await transaction.finish()
             case .unverified(let productID):
+                Self.logger.error(
+                    "unverified transaction update for \(productID ?? "?", privacy: .public)"
+                )
                 guard productID == Self.proProductID, purchaseAwaitingApproval else { continue }
                 purchaseAwaitingApproval = false
                 commerceState = .failed("The App Store transaction could not be verified.")
@@ -720,6 +740,35 @@ final class EntitlementStore {
         }
         commerceState = fallback
         return false
+    }
+
+    /// StoreKit's `localizedDescription` collapses most failures into "An
+    /// unknown error occurred", which is undiagnosable from a screenshot of
+    /// the paywall (the shape of the App Review sandbox reports). Name the
+    /// known StoreKit failure modes in actionable copy; anything else keeps
+    /// its own description.
+    static func storeErrorMessage(_ error: Error) -> String {
+        switch error {
+        case StoreKitError.networkError:
+            return "The App Store could not be reached. Check the internet "
+                + "connection and try again."
+        case StoreKitError.systemError(let underlying):
+            return "The App Store reported a system error. "
+                + "(\(underlying.localizedDescription))"
+        case StoreKitError.notAvailableInStorefront:
+            return "Multiplex Pro is not available in this App Store storefront."
+        case StoreKitError.notEntitled:
+            return "This copy of the app is not entitled to App Store purchases."
+        case StoreKitError.unknown:
+            return "The App Store could not complete the request. "
+                + "Try again in a moment."
+        case Product.PurchaseError.purchaseNotAllowed:
+            return "Purchases are not allowed for this Apple ID on this device."
+        case Product.PurchaseError.productUnavailable:
+            return "Multiplex Pro is not available for purchase right now."
+        default:
+            return error.localizedDescription
+        }
     }
 
     /// One policy function serves both compilation modes, so tests can pin

--- a/MultiplexTests/EntitlementStoreTests.swift
+++ b/MultiplexTests/EntitlementStoreTests.swift
@@ -1,3 +1,4 @@
+import StoreKit
 import XCTest
 @testable import Multiplex
 
@@ -1005,5 +1006,30 @@ final class EntitlementStoreTests: XCTestCase {
         XCTAssertFalse(store.hasVerifiedStoreEntitlementForTesting)
         XCTAssertFalse(store.purchaseIsUnavailable)
         storeDouble.finishUpdates()
+    }
+
+    // MARK: - Store error copy
+
+    func testStoreErrorMessageNamesKnownStoreKitFailures() {
+        XCTAssertEqual(
+            EntitlementStore.storeErrorMessage(
+                StoreKitError.networkError(URLError(.notConnectedToInternet))
+            ),
+            "The App Store could not be reached. Check the internet connection and try again."
+        )
+        XCTAssertEqual(
+            EntitlementStore.storeErrorMessage(StoreKitError.notAvailableInStorefront),
+            "Multiplex Pro is not available in this App Store storefront."
+        )
+        XCTAssertEqual(
+            EntitlementStore.storeErrorMessage(StoreKitError.unknown),
+            "The App Store could not complete the request. Try again in a moment."
+        )
+        // Errors StoreKit does not own keep their own description, so the
+        // injected-client suites above stay valid and app errors stay honest.
+        XCTAssertEqual(
+            EntitlementStore.storeErrorMessage(ProStoreDoubleError.purchase),
+            "purchase failed"
+        )
     }
 }

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -96,6 +96,34 @@ configuration. The local review screenshot was refreshed on 2026-07-15 for the
 two-host free-tier wording; confirm which revision the `COMPLETE` remote asset
 is before relying on it.
 
+Same-day triage facts (2026-08-03 readbacks; keep until the IAP first reaches
+`APPROVED`):
+
+- The empty-product failure **reproduced on the TestFlight 1.2.0 build** with
+  `Product.products` succeeding but returning zero products (the paywall's
+  "not available from the App Store right now" branch). TestFlight IAP rides
+  the sandbox with the user's real Apple ID — the Settings sandbox tester is
+  consulted only by development-signed builds.
+- Ruled out by API readback: IAP availability spans 175 territories (USA and
+  TWN included) and the `app.multiplexterm.multiplex` bundle ID has the
+  `IN_APP_PURCHASE` capability enabled. Per Apple DTS/TN3186, in-review state
+  does not gate sandbox availability.
+- **The IAP has never been `APPROVED`**: every visionOS review submission
+  (1.0, 1.0.1, 1.2.0 — `READY_FOR_SALE` since 2026-07-30) carried only the
+  app-version item; the IAP item rides only the iOS submissions (all removed
+  or rejected so far). Until an iOS submission carrying the IAP is approved,
+  the production catalog serves nothing — the live visionOS paywall shows the
+  same "not available" state, so no customer can buy Pro yet.
+- ASC UI state decoder: the product page's "In Review" is the IAP lifecycle
+  state (tied up in an open review cycle); the iOS submission item's "Ready
+  for Review" is that item's queue state after the app-version item was
+  rejected — resubmitting reviews both.
+- Business section (Paid Applications Agreement, banking, tax forms) was
+  confirmed all-active in the ASC UI on 2026-08-03 after this triage;
+  incomplete/outdated tax detail (e.g. W-8BEN / Certificate of Foreign
+  Status) is TN3186's remaining cause for an empty sandbox catalog and is
+  invisible to the API — re-verify it first if the symptom returns.
+
 | Field | Current value |
 | --- | --- |
 | App Store Connect IAP ID | `6790252556` |

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -85,9 +85,16 @@ developer portal before archiving).
 
 ## Multiplex Pro
 
-Last remote readback: **2026-07-13 — `READY_TO_SUBMIT`**. The local review
-screenshot was refreshed on 2026-07-15 for the two-host free-tier wording and
-still needs to be re-uploaded and read back before submission.
+Last remote readback: **2026-08-03 — `IN_REVIEW`** (App Store Connect API:
+en-US localization present, review screenshot asset `COMPLETE`, one open-ended
+$19.99 manual price, `availableInNewTerritories=true`). The readback was taken
+while triaging the 2026-08-03 App Review report "an error displayed upon
+purchasing Pro plan" — the IAP record itself is complete and attached to the
+submission, so that report points at the Paid Applications Agreement, a
+sandbox-environment fault, or a device-side condition, not missing product
+configuration. The local review screenshot was refreshed on 2026-07-15 for the
+two-host free-tier wording; confirm which revision the `COMPLETE` remote asset
+is before relying on it.
 
 | Field | Current value |
 | --- | --- |

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -185,3 +185,4 @@ itself. Genuinely wrapped long paths and URLs still join.
 - A long absolute path wrapped mid-segment still presses as the full path.
 - A schemeless URL below wrapped prose raises the link sheet, not a glued
   file path.
+- PAYWALL ERRORS SAY WHY: if a Pro purchase or restore fails, the paywall now names the actual App Store problem (no network, storefront availability, purchases not allowed) instead of "An unknown error occurred". If you can, try the paywall in Airplane Mode and confirm the message tells you to check the connection.


### PR DESCRIPTION
Cherry-pick of #38 onto main (main's older `EntitlementStore` shape auto-merged; the TestFlight what-to-test conflict resolved by appending the entry to main's file).

App Review (2026-08-03) reported "an error displayed upon purchasing Pro plan". A live App Store Connect readback shows the IAP record complete and IN_REVIEW, so app-side the fix is diagnosability: `EntitlementStore.storeErrorMessage` names known `StoreKitError` / `Product.PurchaseError` cases in actionable paywall copy instead of StoreKit's generic "An unknown error occurred", and purchase/restore/product-load failures plus unverified transactions log under category `commerce`.

38 EntitlementStoreTests + StoreKitIntegrationTests pass on the visionOS simulator against main; SwiftLint strict clean on the touched files.