### PR TITLE
Add CI: lint/build/test on macOS 26, metadata format check on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+# Multiplex CI — two jobs, split by what they need.
+#
+#   metadata (Linux, seconds)  the TestFlight changelog and the App Store
+#                              listing files. No Xcode, no gems: it is the
+#                              fast answer on every push, and it catches the
+#                              class of mistake that otherwise surfaces after
+#                              two archives as an opaque upload failure.
+#   xcode (macOS 26)           lint, then build + unit tests on BOTH
+#                              platforms. macos-26 carries Xcode 26 and the
+#                              visionOS 26 simulator runtime; the app targets
+#                              visionOS 26 / iOS 17, so nothing older will do.
+#
+# Everything the macOS job runs is a Tools/build.sh subcommand — the same
+# entry point AGENTS.md points contributors at, so CI cannot drift into its
+# own private set of destinations and flags.
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+# A newer push to the same branch supersedes this run; a ~40-minute macOS job
+# is not worth spending on a commit that has already been replaced. `main` is
+# exempt so its history keeps a result per commit.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  metadata:
+    name: Metadata format
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check TestFlight changelog and App Store metadata
+        run: ruby Tools/check-metadata.rb
+
+  xcode:
+    name: Lint, build, test
+    runs-on: macos-26
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          xcrun simctl list runtimes | grep -E 'iOS|visionOS'
+
+      - name: Install XcodeGen and SwiftLint
+        run: brew install xcodegen swiftlint
+
+      # Citadel is the one dependency fetched over the network (SwiftTerm and
+      # swift-nio-ssh are vendored in-tree). Cache its checkout so a CI run is
+      # not at the mercy of a git host.
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v4
+        with:
+          path: DerivedData/SourcePackages
+          key: spm-${{ runner.os }}-${{ hashFiles('project.yml') }}
+          restore-keys: spm-${{ runner.os }}-
+
+      - name: Generate the Xcode project
+        run: ./Tools/build.sh gen
+
+      - name: Lint
+        run: ./Tools/build.sh lint
+
+      # visionOS and iPad must not run concurrently against the shared
+      # DerivedData (the build DB locks), so these stay four sequential steps
+      # rather than a matrix. `test` builds the app target too, but building
+      # first keeps a compile error reported as a build failure.
+      - name: Build (visionOS)
+        run: ./Tools/build.sh build vos
+
+      - name: Test (visionOS)
+        run: ./Tools/build.sh test vos
+
+      - name: Build (iPad)
+        run: ./Tools/build.sh build ipad
+
+      - name: Test (iPad)
+        run: ./Tools/build.sh test ipad

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,17 @@ Where one line genuinely can't comply, use a scoped
 `// swiftlint:disable:next <rule>` with the reason above it; prefer fixing
 the code.
 
+**CI** (`.github/workflows/ci.yml`) runs on every push and pull request, and
+runs nothing CI-only: the macOS job (macos-26 — Xcode 26 and the visionOS 26
+simulator runtime) is `Tools/build.sh gen`, `lint`, then `build` + `test` for
+visionOS and iPad in sequence, sequential because of the DerivedData lock
+above. A second job on Linux runs `ruby Tools/check-metadata.rb`, which needs
+neither Xcode nor gems and so answers in seconds: it holds the TestFlight
+changelog and the App Store listing files to the App Store Connect caps and
+the vetted glyph set in `Tools/metadata_limits.rb` (shared with
+`fastlane/Fastfile`, so a lane and a pull request can never disagree about
+them). Run it locally before committing metadata.
+
 ## Architecture
 
 One UIKit scene runtime (`MultiplexSceneDelegate` +

--- a/MultiplexTests/UIKitSceneRootViewControllerTests.swift
+++ b/MultiplexTests/UIKitSceneRootViewControllerTests.swift
@@ -14,7 +14,7 @@ final class UIKitSceneRootViewControllerTests: XCTestCase {
         XCTAssertEqual(harness.window.overrideUserInterfaceStyle, .dark)
 
         harness.themes.appearance = .light
-        drainObservation()
+        drainObservation(until: { harness.root.overrideUserInterfaceStyle == .light })
         XCTAssertEqual(harness.root.overrideUserInterfaceStyle, .light)
         XCTAssertEqual(harness.window.overrideUserInterfaceStyle, .light)
     }
@@ -31,7 +31,9 @@ final class UIKitSceneRootViewControllerTests: XCTestCase {
         XCTAssertTrue(harness.window.traitCollection[GlassAppearanceTrait.self])
 
         harness.themes.appearance = .dark
-        drainObservation()
+        drainObservation(until: {
+            !harness.root.traitCollection[GlassAppearanceTrait.self]
+        })
         XCTAssertFalse(harness.root.traitCollection[GlassAppearanceTrait.self])
         XCTAssertFalse(harness.window.traitCollection[GlassAppearanceTrait.self])
     }
@@ -195,7 +197,7 @@ final class UIKitSceneRootViewControllerTests: XCTestCase {
         ))
 
         XCTAssertTrue(harness.root.receive(url))
-        drainObservation()
+        drainObservation(until: { !intents.isEmpty })
 
         XCTAssertEqual(harness.externalActions.pendingSignal, before + 1)
         XCTAssertEqual(intents, [.openDeck(.main)])
@@ -264,8 +266,20 @@ final class UIKitSceneRootViewControllerTests: XCTestCase {
         )
     }
 
-    private func drainObservation() {
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+    /// Observation reaches the controller through `onChange` → a `@MainActor`
+    /// Task, so a test is waiting for a scheduling hop, not for a duration. A
+    /// fixed 10ms spin passed on an idle laptop and failed on a loaded CI
+    /// runner (the iPad job, run 31545939526). Spin until the effect shows,
+    /// capped so a real regression still fails the assertion instead of
+    /// hanging the suite.
+    private func drainObservation(
+        until effectIsVisible: () -> Bool,
+        timeout: TimeInterval = 5
+    ) {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while !effectIsVisible(), Date() < deadline {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        }
     }
 
     private func drainObservationTasks() async {

--- a/Tools/build.sh
+++ b/Tools/build.sh
@@ -3,8 +3,10 @@
 #
 #   ./Tools/build.sh gen                 regenerate the Xcode project (XcodeGen)
 #   ./Tools/build.sh lint [--fix]        SwiftLint over the app + tests + tools
-#   ./Tools/build.sh build [vos|ipad]    build for a platform (default: vos)
-#   ./Tools/build.sh test  [vos|ipad]    run unit tests (default: vos)
+#   ./Tools/build.sh build [vos|ipad] [xcodebuild args...]
+#                                        build for a platform (default: vos)
+#   ./Tools/build.sh test  [vos|ipad] [xcodebuild args...]
+#                                        run unit tests (default: vos)
 #   ./Tools/build.sh verify [vos|ipad]   build + install + drive end-to-end
 #                                        against the local sshd/tmux harness
 #   ./Tools/build.sh interop             round-trip against real mosh-server
@@ -29,16 +31,25 @@ SEED="$ROOT/Tools/dev-sshd/state/seed.json"
 # xcodebuild destinations are ambiguous the moment several runtimes carry an
 # "Apple Vision Pro" — prefer a booted device (what the user is looking at),
 # else the newest runtime (simctl lists runtimes ascending).
+#
+# Each platform names its preferred device first and then falls back: a CI
+# runner's Xcode ships whatever iPad generation it ships, and the device set
+# a laptop accumulated is not the one a fresh image creates. `iPad` last
+# matches any of them, so the build never dies on a model name.
 sim_udid() {
-    local name list
+    local candidates name list
     case "$1" in
-        vos|visionos|xr) name="Apple Vision Pro" ;;
-        ipad|ios)        name="iPad Pro 13-inch (M5)" ;;
+        vos|visionos|xr) candidates="Apple Vision Pro" ;;
+        ipad|ios)        candidates="iPad Pro 13-inch (M5)|iPad Pro 13-inch|iPad Pro|iPad Air|iPad" ;;
         *) echo "unknown platform '$1' (use vos|ipad)" >&2; exit 2 ;;
     esac
-    list="$(xcrun simctl list devices available | grep -F "$name (")"
-    { echo "$list" | grep -F '(Booted)' | head -1; echo "$list" | tail -1; } \
-        | grep -oE '[0-9A-F-]{36}' | head -1
+    while IFS= read -r name; do
+        list="$(xcrun simctl list devices available | grep -F "$name")"
+        [ -n "$list" ] || continue
+        { echo "$list" | grep -F '(Booted)' | head -1; echo "$list" | tail -1; } \
+            | grep -oE '[0-9A-F-]{36}' | head -1
+        return
+    done < <(echo "$candidates" | tr '|' '\n')
 }
 
 require_udid() {
@@ -67,18 +78,22 @@ lint() {
     swiftlint lint --strict "$@"
 }
 
+# Trailing arguments go straight to xcodebuild, so a caller (CI) can add
+# settings or flags without a second, drifting invocation of its own.
 build() {
     local plat="${1:-vos}"
+    shift || true
     xcodebuild -project "$PROJECT" -scheme "$SCHEME" \
         -destination "id=$(require_udid "$plat")" \
-        -derivedDataPath "$DERIVED" build
+        -derivedDataPath "$DERIVED" build "$@"
 }
 
 run_tests() {
     local plat="${1:-vos}"
+    shift || true
     xcodebuild -project "$PROJECT" -scheme "$TEST_SCHEME" \
         -destination "id=$(require_udid "$plat")" \
-        -derivedDataPath "$DERIVED" test
+        -derivedDataPath "$DERIVED" test "$@"
 }
 
 verify() {
@@ -150,8 +165,8 @@ interop() {
 case "${1:-}" in
     gen) gen ;;
     lint) shift; lint "$@" ;;
-    build) build "${2:-vos}" ;;
-    test) run_tests "${2:-vos}" ;;
+    build) shift; build "$@" ;;
+    test) shift; run_tests "$@" ;;
     verify) verify "${2:-vos}" ;;
     interop) interop ;;
     all) gen; lint; build vos; build ipad; run_tests vos ;;

--- a/Tools/check-metadata.rb
+++ b/Tools/check-metadata.rb
@@ -1,0 +1,229 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Format check for the TestFlight changelog and the App Store metadata.
+#
+#   ruby Tools/check-metadata.rb
+#
+# Deliberately dependency-free (no fastlane, no gems, no Xcode) so CI can run
+# it on Linux in seconds on every push — the failures it catches are the ones
+# that otherwise surface after two platform archives, as an opaque Spaceship
+# error mid-upload. Caps and the glyph allowlist come from
+# Tools/metadata_limits.rb, shared with fastlane/Fastfile.
+#
+# Rules, and why each one is here (docs/agents/release-and-metadata.md):
+#   - every field fits its App Store Connect cap, measured in CHARACTERS
+#   - no field is empty; deliver would push a blank listing field
+#   - descriptions and release notes are PER PLATFORM; a shared
+#     description.txt can put Vision Pro-only claims on the iOS listing
+#   - text is valid UTF-8, LF-only, free of control characters and of
+#     non-ASCII glyphs App Store Connect has not been proven to accept
+#   - URLs are single-line https://
+
+require_relative "metadata_limits"
+
+ROOT = File.expand_path("..", __dir__)
+METADATA = File.join(ROOT, "fastlane", "metadata")
+WHATS_NEW = File.join(ROOT, "fastlane", "testflight-whats-new.txt")
+
+# Files deliver reads per locale. Platform-split fields are listed under the
+# base name they inherit their cap from.
+LOCALIZED_FILES = %w[
+  name subtitle promotional_text keywords beta_app_description
+  description_ios description_visionos
+  release_notes_ios release_notes_visionos
+  marketing_url privacy_url support_url
+].freeze
+
+# A shared file here would silently override / mix the platform split.
+FORBIDDEN_FILES = %w[description.txt release_notes.txt].freeze
+
+URL_FILES = %w[marketing_url privacy_url support_url].freeze
+
+@errors = []
+
+def error(path, message)
+  @errors << "#{path.sub("#{ROOT}/", "")}: #{message}"
+end
+
+def relative(path)
+  path.sub("#{ROOT}/", "")
+end
+
+# The cap a file is measured against: `description_ios` is a `description`.
+def field_for(basename)
+  MetadataLimits::LOCALIZED.key?(basename) ? basename : basename.sub(/_(ios|visionos)\z/, "")
+end
+
+def read_text(path)
+  body = File.binread(path)
+  body.force_encoding(Encoding::UTF_8)
+  unless body.valid_encoding?
+    error(path, "is not valid UTF-8")
+    return nil
+  end
+  if body.include?("\r")
+    error(path, "has CRLF (or lone CR) line endings; App Store copy is LF-only")
+    return nil
+  end
+  body
+end
+
+# Control characters and unvetted glyphs. Tabs are included: they survive into
+# the listing as literal whitespace nobody sees in the editor.
+def check_characters(path, body)
+  body.each_char.with_index do |char, index|
+    next if char == "\n"
+    ord = char.ord
+    next if ord >= 0x20 && ord < 0x7F
+    next if MetadataLimits::ALLOWED_GLYPHS.key?(char)
+
+    line = body[0, index].count("\n") + 1
+    name = ord < 0x20 || ord == 0x7F ? "control character" : "character #{char}"
+    error(
+      path,
+      "line #{line}: #{name} (U+%04X) is not allowed. Use ASCII, or add it to " \
+      "MetadataLimits::ALLOWED_GLYPHS once an upload has accepted it." % ord,
+    )
+    break # one report per file is enough to act on
+  end
+end
+
+def check_length(path, body, limit)
+  length = body.strip.length
+  return if length <= limit
+
+  error(path, "is #{length} characters; App Store Connect allows #{limit}")
+end
+
+def check_file(path, limit)
+  body = read_text(path)
+  return if body.nil?
+
+  if body.strip.empty?
+    error(path, "is empty")
+    return
+  end
+  check_characters(path, body)
+  check_length(path, body, limit) if limit
+  body
+end
+
+def check_url(path, body)
+  return if body.nil?
+
+  url = body.strip
+  error(path, "must be a single line") if url.include?("\n")
+  error(path, "must be an https:// URL (got #{url.lines.first.to_s.strip})") unless url.start_with?("https://")
+end
+
+def check_keywords(path, body)
+  return if body.nil?
+
+  keywords = body.strip
+  error(path, "must not contain newlines; keywords are one comma-separated line") if keywords.include?("\n")
+  error(path, "must not put a space after a comma — the space costs a keyword character") if keywords.match?(/,\s/)
+  error(path, "has an empty keyword (double comma or a trailing comma)") if keywords.match?(/(\A|,),|,\z/)
+end
+
+def check_whats_new
+  unless File.exist?(WHATS_NEW)
+    error(WHATS_NEW, "is missing; every user-visible change appends to it (AGENTS.md)")
+    return
+  end
+  check_file(WHATS_NEW, MetadataLimits::WHATS_NEW)
+end
+
+def locale_directories
+  Dir.children(METADATA)
+     .select { |name| File.directory?(File.join(METADATA, name)) }
+     .grep(/\A[a-z]{2}(-[A-Z]{2})?\z/)
+     .sort
+end
+
+def check_locales
+  locales = locale_directories
+  if locales.empty?
+    error(METADATA, "has no locale directories (expected e.g. en-US/)")
+    return
+  end
+
+  locales.each do |locale|
+    dir = File.join(METADATA, locale)
+
+    FORBIDDEN_FILES.each do |name|
+      path = File.join(dir, name)
+      next unless File.exist?(path)
+
+      error(path, "must not exist: descriptions and release notes are per platform " \
+                  "(#{name.sub(".txt", "")}_ios.txt / _visionos.txt)")
+    end
+
+    LOCALIZED_FILES.each do |basename|
+      path = File.join(dir, "#{basename}.txt")
+      unless File.exist?(path)
+        error(path, "is missing (required for locale #{locale})")
+        next
+      end
+
+      body = check_file(path, MetadataLimits::LOCALIZED[field_for(basename)])
+      check_url(path, body) if URL_FILES.include?(basename)
+      check_keywords(path, body) if basename == "keywords"
+    end
+
+    # Anything else in the directory is either a deliver field this check does
+    # not know or a stray file deliver will happily upload.
+    Dir.children(dir).grep(/\.txt\z/).sort.each do |name|
+      basename = File.basename(name, ".txt")
+      next if LOCALIZED_FILES.include?(basename) || FORBIDDEN_FILES.include?(name)
+
+      error(File.join(dir, name), "is an unrecognized metadata file; add it to " \
+                                  "LOCALIZED_FILES in Tools/check-metadata.rb or delete it")
+    end
+  end
+end
+
+# Only notes.txt has a cap worth pre-flighting; the rest are short strings and
+# two of them are deliberately absent from git (see fastlane/SETUP.md).
+def check_review_information
+  path = File.join(METADATA, "review_information", "notes.txt")
+  return unless File.exist?(path)
+
+  check_file(path, MetadataLimits::REVIEW_NOTES)
+end
+
+def report_sizes
+  paths = [WHATS_NEW] + Dir.glob(File.join(METADATA, "*", "*.txt")).sort
+  puts "field                                                chars  limit"
+  paths.each do |path|
+    next unless File.exist?(path)
+
+    body = File.binread(path).force_encoding(Encoding::UTF_8)
+    next unless body.valid_encoding?
+
+    limit =
+      if path == WHATS_NEW
+        MetadataLimits::WHATS_NEW
+      elsif File.basename(File.dirname(path)) == "review_information"
+        File.basename(path) == "notes.txt" ? MetadataLimits::REVIEW_NOTES : nil
+      else
+        MetadataLimits::LOCALIZED[field_for(File.basename(path, ".txt"))]
+      end
+    printf("%-50s %6d  %5s\n", relative(path), body.strip.length, limit || "-")
+  end
+end
+
+check_whats_new
+check_locales
+check_review_information
+report_sizes
+
+if @errors.empty?
+  puts "\nOK: #{relative(WHATS_NEW)} and #{relative(METADATA)} pass the format check."
+  exit 0
+end
+
+warn "\n#{@errors.length} metadata problem#{"s" unless @errors.length == 1}:"
+@errors.each { |message| warn "  - #{message}" }
+warn "\nRules: docs/agents/release-and-metadata.md"
+exit 1

--- a/Tools/metadata_limits.rb
+++ b/Tools/metadata_limits.rb
@@ -1,0 +1,53 @@
+# Shared App Store Connect field caps and the glyph allowlist.
+#
+# Required by BOTH `fastlane/Fastfile` (which fails a lane before it archives)
+# and `Tools/check-metadata.rb` (which fails a pull request in seconds, on
+# Linux, without Xcode). One copy so the two can never disagree about what
+# App Store Connect accepts.
+#
+# Every cap is measured in CHARACTERS, which is what the API counts — this
+# text is full of em dashes, bullets and arrows, so its byte length runs
+# several hundred over its character length.
+module MetadataLimits
+  # App Store Connect rejects an over-long field mid-upload with the opaque
+  # "An attribute value is too long. - /data/attributes/<field>", after both
+  # platform archives are built. Hence the pre-flight.
+  WHATS_NEW = 4000        # TestFlight What to Test (build-level)
+  REVIEW_NOTES = 4000     # App Review / Beta App Review notes
+
+  # Per-locale listing fields. `description` and `release_notes` are stored
+  # per platform (`description_ios.txt` / `description_visionos.txt`) — see
+  # docs/agents/release-and-metadata.md for why there is no shared file.
+  LOCALIZED = {
+    "name" => 30,
+    "subtitle" => 30,
+    "promotional_text" => 170,
+    "keywords" => 100,
+    "description" => 4000,
+    "release_notes" => 4000,
+    "beta_app_description" => 4000,
+    "marketing_url" => 255,
+    "privacy_url" => 255,
+    "support_url" => 255,
+  }.freeze
+
+  # Non-ASCII characters App Store Connect is known to accept in this app's
+  # copy. Anything else is refused by the checker rather than by the API:
+  # 1.3.1 shipped ⟨…⟩ (U+27E8/27E9) in the TestFlight changelog and the
+  # upload failed on a character the file looked fine with everywhere else.
+  # Add a glyph here only after an upload has actually accepted it.
+  ALLOWED_GLYPHS = {
+    "—" => "em dash",
+    "“" => "left double quote",
+    "”" => "right double quote",
+    "’" => "right single quote",
+    "•" => "bullet",
+    "…" => "ellipsis",
+    "→" => "rightwards arrow",
+    "−" => "minus sign (A− / A+)",
+    "⌗" => "viewport tab glyph",
+    "▤" => "file viewer tab glyph",
+    "▸" => "forward glyph (File Viewer history)",
+    "◂" => "back glyph (File Viewer history)",
+  }.freeze
+end

--- a/Vendor/SwiftTerm/Package.resolved
+++ b/Vendor/SwiftTerm/Package.resolved
@@ -1,12 +1,66 @@
 {
   "pins" : [
     {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "citadel",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/orlandos-nl/Citadel.git",
+      "state" : {
+        "revision" : "a054a77eff9f2ef03051022a096377794dc16140",
+        "version" : "0.12.0"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {
@@ -25,6 +79,33 @@
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
       }
     }
   ],

--- a/docs/agents/release-and-metadata.md
+++ b/docs/agents/release-and-metadata.md
@@ -2,6 +2,20 @@
 
 Split from AGENTS.md — read before committing any user-visible change.
 
+`ruby Tools/check-metadata.rb` is the mechanical half of this document, and
+CI's Linux job runs it on every push. It reads
+`fastlane/testflight-whats-new.txt` and `fastlane/metadata/`, and fails on: a
+field over its App Store Connect cap (measured in CHARACTERS — this copy's
+dashes and arrows run its byte length several hundred higher), an empty or
+missing field, a shared `description.txt` / `release_notes.txt` breaking the
+platform split, CRLF, control characters, and any non-ASCII glyph not vetted
+in `Tools/metadata_limits.rb`. That last rule is the ⟨…⟩ incident: the
+changelog looked right in every editor and App Store Connect refused the
+character. The caps live in that one file, required by `fastlane/Fastfile`
+too, so the lane that fails an archive and the job that fails a pull request
+can never disagree. Add a glyph to the allowlist only after an upload has
+actually accepted it.
+
 - **App icon is a hand-authored Icon Composer package** (`AppIcon.icon`;
   spec + bake-off in `DESIGN.md`); icon.json lists groups
   frontmost-first. Validate headlessly with `xcrun actool AppIcon.icon

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,11 @@
 
 default_platform(:ios)
 
+# App Store Connect's field caps and the vetted glyph set, shared with
+# `ruby Tools/check-metadata.rb` — the Linux CI job that fails a pull request
+# in seconds with the same numbers this file would fail an archive on.
+require_relative "../Tools/metadata_limits"
+
 PROJECT = "Multiplex.xcodeproj"
 SCHEME  = "Multiplex"
 
@@ -86,7 +91,7 @@ end
 # both platform archives, as Spaceship's opaque "An attribute value is too
 # long. - /data/attributes/whatsNew". Measured in CHARACTERS, which is what the
 # API counts; this file's bullets and arrows make its byte length run higher.
-WHATS_NEW_LIMIT = 4000
+WHATS_NEW_LIMIT = MetadataLimits::WHATS_NEW
 
 def whats_new(external)
   path = File.expand_path("testflight-whats-new.txt", __dir__)
@@ -108,10 +113,7 @@ end
 # Deliver has one shared metadata path, so inject the fields that differ
 # between App Store platform versions instead of duplicating every shared file.
 # App Store Connect caps both localized fields at 4,000 characters.
-PLATFORM_LOCALIZED_LIMITS = {
-  "description" => 4000,
-  "release_notes" => 4000,
-}.freeze
+PLATFORM_LOCALIZED_LIMITS = MetadataLimits::LOCALIZED.slice("description", "release_notes").freeze
 
 def platform_localized_metadata(field, platform)
   field = field.to_s
@@ -160,7 +162,7 @@ REVIEW_INFORMATION = {
 # API counts: notes.txt is full of em dashes and arrows, so its byte length
 # runs several hundred over its character length.
 REVIEW_INFORMATION_LIMITS = {
-  notes: 4000,
+  notes: MetadataLimits::REVIEW_NOTES,
 }.freeze
 
 # deliver's key => pilot's key for the same App Store Connect field.


### PR DESCRIPTION
Two jobs, split by what they need — `.github/workflows/ci.yml`, on every push and pull request.

**`xcode` (macos-26, ~20 min).** `Tools/build.sh gen` → `lint` → `build` + `test` for visionOS, then for iPad. Sequential, not a matrix: the shared `DerivedData` build DB locks. macos-26 is the runner that carries Xcode 26 and the visionOS 26 simulator runtime the app's target needs. Every step is a `build.sh` subcommand, so CI cannot drift into its own private set of destinations and flags.

**`metadata` (ubuntu-latest, ~9 s).** `ruby Tools/check-metadata.rb` — dependency-free, no Xcode and no gems, so it is the fast answer on every push. It holds `fastlane/testflight-whats-new.txt` and `fastlane/metadata/` to their App Store Connect caps (measured in *characters* — this copy's dashes and arrows run its byte length several hundred higher), the per-platform description/release-notes split, https-only URLs, keyword format, and a vetted glyph set. The caps now live in `Tools/metadata_limits.rb`, required by `fastlane/Fastfile` as well, so the lane that fails an archive and the job that fails a pull request can never disagree about them.

The glyph rule encodes the ⟨…⟩ incident (e11fe19): the changelog looked right in every editor and App Store Connect refused the character. The allowlist is every non-ASCII character in copy that has actually been through an upload; anything new fails with a pointer to add it only once an upload accepts it.

## The metadata job is red, on purpose

```
fastlane/testflight-whats-new.txt: is 4241 characters; App Store Connect allows 4000
```

A real bug on `main` — the `beta` lane would have failed on that file — and the check's first catch. It goes green when the condensed changelog lands.

## Two fixes CI turned up

- **`Tools/build.sh`** — `sim_udid` falls back through iPad models (a runner's Xcode ships whatever generation it ships), and `build` / `test` pass trailing arguments through to xcodebuild.
- **`UIKitSceneRootViewControllerTests`** — the first run failed one iPad test. The deck raise for a pending external action reaches the controller through `withObservationTracking`'s `onChange` and a `@MainActor` Task, and the tests spun the runloop a fixed 10 ms before asserting: a bet on scheduling latency that pays on an idle laptop (the same test passes locally on the same simulator) and loses on a loaded runner. `drainObservation` now takes the effect it waits for and spins until it shows, capped at 5 s so a real regression still fails the assertion rather than hanging the suite. Worth noting the iPad suite had not been running anywhere — `build.sh all` runs `run_tests vos` only.

## Verification

Run [31547707424](https://github.com/multiplex-term/Multiplex/actions/runs/31547707424): `xcode` green on all steps, `metadata` red on the one line above.

Build plumbing, so no TestFlight changelog entry (AGENTS.md).