### PR TITLE
Verify SSH host keys on every connection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,10 @@ approaches. Don't re-litigate a recorded decision without new facts.
 
 ## Known limits (v1)
 
-- Host-key validation is `.acceptAnything()` — dev only. TOFU pinning via
-  Citadel's `.custom` validator is the ship-blocker TODO.
+- Host keys are pinned per host (`HostKeyPin`, `HostKeyVerifier`) — bound
+  hosts from the OFFER, everything else on first use. A host added before
+  pinning shipped takes its next connection as the trust anchor, which is the
+  standard TOFU weakness and the reason `mpx bind` is the better path.
 - csh/fish remote shells may need tmux on the default PATH (the probe
   prepends common Homebrew/local dirs but assumes POSIX-ish login shells).
 - Held-backspace auto-repeat rides an unverified input filler — see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,10 +108,10 @@ approaches. Don't re-litigate a recorded decision without new facts.
 
 ## Known limits (v1)
 
-- Host keys are pinned per host (`HostKeyPin`, `HostKeyVerifier`) — bound
-  hosts from the OFFER, everything else on first use. A host added before
-  pinning shipped takes its next connection as the trust anchor, which is the
-  standard TOFU weakness and the reason `mpx bind` is the better path.
+- Host keys are pinned per host (`HostKeyPin`, `HostKeyVerifier`). Three ways
+  a host gets one: the bind OFFER, an expected key pasted into Add Host, or
+  trust-on-first-use. Only the third has a window, and a host added before
+  pinning shipped is always in it — its next connection is the trust anchor.
 - csh/fish remote shells may need tmux on the default PATH (the probe
   prepends common Homebrew/local dirs but assumes POSIX-ish login shells).
 - Held-backspace auto-repeat rides an unverified input filler — see

--- a/Multiplex/App/AppRuntime.swift
+++ b/Multiplex/App/AppRuntime.swift
@@ -63,6 +63,16 @@ final class AppRuntime {
         BackgroundActivity.shared.keepAliveLookup = { [weak store] hostID in
             store?.host(id: hostID)?.backgroundKeepAlive ?? false
         }
+        // Trust on first use: the SSH validator runs on a NIO event loop
+        // inside whichever of the eight `SSHConnection` call sites dialled,
+        // none of which hold the store. One sink here is what turns a
+        // first-connection sighting into a pin every later connection is
+        // checked against.
+        HostKeyTrust.install { hostID, pin in
+            Task { @MainActor [weak store] in
+                store?.recordHostKeyPin(pin, for: hostID)
+            }
+        }
         BackgroundActivity.shared.start()
         backgroundRefresh.start()
         #if DEBUG

--- a/Multiplex/Models/Host.swift
+++ b/Multiplex/Models/Host.swift
@@ -184,12 +184,13 @@ struct Host: Identifiable, Codable, Hashable {
     /// while the pane reports mouse mode. `focus-events on` lets tmux pass
     /// the terminal client's focus changes through to focus-aware apps.
     static let defaultNewSessionTmuxConf = "mouse on\nfocus-events on"
-    /// SSH host key fingerprints (`"<key type> SHA256:<b64>"`) recorded for
-    /// this host — today written by the bind flow, which learns them from
-    /// the machine itself before the first connection. Storage only for now:
-    /// the TOFU validator that enforces them is its own change, but hosts
-    /// bound via `mpx bind` arrive carrying the data it needs. Rides the
-    /// synced record; empty means nothing recorded.
+    /// SSH host key fingerprints (`"<key type> SHA256:<b64>"`) this host is
+    /// verified against on every connection — written by the bind flow, which
+    /// learns them from the machine itself before the first dial, or by the
+    /// validator on first use. `HostKeyPin` owns the string form and
+    /// `HostKeyVerifier` enforces it. Rides the synced record, so a host
+    /// verified on one device is verified on the user's others; empty means
+    /// nothing recorded yet, which is the only state that trusts blindly.
     var pinnedHostKeys: [String] = []
     /// Agent-helper commands and built-in Bar/More placement for this host.
     /// This is part of the mirrored host record so the setup follows the host

--- a/Multiplex/Models/HostKeyPin.swift
+++ b/Multiplex/Models/HostKeyPin.swift
@@ -1,0 +1,125 @@
+import CryptoKit
+import Foundation
+
+/// One SSH host key identity as the app records it: the key's algorithm name
+/// and OpenSSH's own `SHA256:<base64>` fingerprint of the key blob.
+///
+/// The string form is a cross-repo contract, not a local choice. `mpx bind`
+/// renders exactly this shape into the OFFER (`hostinfo::host_key_fingerprints`),
+/// the offline payload's raw 32-byte digest is rendered into it by
+/// `BindPayload`, and it is what `Host.pinnedHostKeys` has stored since the
+/// bind flow shipped. Parsing and rendering live here so the validator, the
+/// bind flow, and Host Settings cannot disagree about it.
+struct HostKeyPin: Equatable, Sendable {
+    /// The SSH algorithm name exactly as it appears at the head of the key
+    /// blob: `ssh-ed25519`, `ecdsa-sha2-nistp256`, `ssh-rsa`, …
+    var algorithm: String
+    /// OpenSSH's display form — the `SHA256:` prefix, base64, no padding.
+    var fingerprint: String
+
+    /// The `Host.pinnedHostKeys` form.
+    var storage: String { "\(algorithm) \(fingerprint)" }
+
+    init(algorithm: String, fingerprint: String) {
+        self.algorithm = algorithm
+        self.fingerprint = fingerprint
+    }
+
+    /// Reads a stored/OFFER-delivered entry. Anything that isn't
+    /// `"<algorithm> SHA256:<base64>"` is rejected rather than coerced: a pin
+    /// the app cannot parse must not silently weaken into "no pin recorded".
+    init?(storage: String) {
+        let parts = storage.split(separator: " ", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { return nil }
+        let (algorithm, fingerprint) = (parts[0], parts[1])
+        guard !algorithm.isEmpty, fingerprint.hasPrefix("SHA256:"),
+              fingerprint.count > "SHA256:".count
+        else { return nil }
+        self.algorithm = algorithm
+        self.fingerprint = fingerprint
+    }
+
+    /// Derives the pin from an SSH public key blob — the same bytes that ride
+    /// base64-encoded in a `.pub` file, which is what OpenSSH hashes for
+    /// `SHA256:` and what `NIOSSHPublicKey.write(to:)` emits. The blob leads
+    /// with its own algorithm name as an SSH string (`uint32` length ‖ bytes),
+    /// so the name is read back out of the bytes rather than asked of NIOSSH,
+    /// whose `keyPrefix` is internal — that keeps this vendor-patch-free.
+    init?(keyBlob: Data) {
+        let bytes = [UInt8](keyBlob)
+        guard bytes.count > 4 else { return nil }
+        let length = (UInt32(bytes[0]) << 24) | (UInt32(bytes[1]) << 16)
+            | (UInt32(bytes[2]) << 8) | UInt32(bytes[3])
+        // A peer-supplied length: bound it against the blob before slicing.
+        guard length > 0, length <= UInt32(bytes.count - 4),
+              let algorithm = String(bytes: bytes[4..<(4 + Int(length))], encoding: .utf8),
+              !algorithm.isEmpty
+        else { return nil }
+        self.algorithm = algorithm
+        self.fingerprint = "SHA256:" + Data(SHA256.hash(data: keyBlob))
+            .base64EncodedString()
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Parses a `Host.pinnedHostKeys` array, dropping entries that don't
+    /// parse. An unparsable entry is not a reason to connect unpinned — as
+    /// long as one entry survives the host stays pinned, and a host whose
+    /// every entry is malformed refuses rather than falls back, because
+    /// `decide` only trusts an empty set as "nothing recorded yet".
+    static func parse(_ stored: [String]) -> [HostKeyPin] {
+        stored.compactMap(HostKeyPin.init(storage:))
+    }
+}
+
+/// What to do with the key a server just presented.
+enum HostKeyDecision: Equatable, Sendable {
+    /// The presented key is one this host already had recorded.
+    case trusted
+    /// Nothing is recorded for this host: trust on first use and write this
+    /// down, so every later connection is checked against it.
+    case learn(HostKeyPin)
+    /// Fail the connection. Never a prompt: the deck probes every host
+    /// concurrently at launch, and a validator that blocked on UI would hold
+    /// N SSH handshakes open behind a modal.
+    case refused(HostKeyRefusal)
+}
+
+/// Why a key was refused. Both outcomes fail closed; they are separated so
+/// the message can be, because crying "possible attack" at a server that
+/// merely grew a second key type teaches people to click through the one
+/// warning that matters.
+enum HostKeyRefusal: Equatable, Sendable {
+    /// This host has a pin for that algorithm and the key underneath it
+    /// changed. The serious one.
+    case changed(expected: HostKeyPin, presented: HostKeyPin)
+    /// The host offered an algorithm none of its pins cover — a reinstalled
+    /// or reconfigured server, or an interception using a key type the real
+    /// host never had.
+    case unrecognizedAlgorithm(presented: HostKeyPin, pinned: [HostKeyPin])
+
+    var presented: HostKeyPin {
+        switch self {
+        case .changed(_, let presented): presented
+        case .unrecognizedAlgorithm(let presented, _): presented
+        }
+    }
+}
+
+extension HostKeyPin {
+    /// The whole trust rule, kept pure so it is testable without a server.
+    ///
+    /// An empty pin set is the only path that trusts blindly, and it is also
+    /// the only path that writes — which is what makes the *second*
+    /// connection to a host checked. `mpx bind` hosts skip it entirely: the
+    /// OFFER records every one of the machine's key fingerprints before the
+    /// app has dialled it once, so their first connection is already verified
+    /// against a set the machine itself vouched for.
+    static func decide(presented: HostKeyPin, against pins: [HostKeyPin]) -> HostKeyDecision {
+        guard !pins.isEmpty else { return .learn(presented) }
+        if pins.contains(presented) { return .trusted }
+        if let expected = pins.first(where: { $0.algorithm == presented.algorithm }) {
+            return .refused(.changed(expected: expected, presented: presented))
+        }
+        return .refused(.unrecognizedAlgorithm(presented: presented, pinned: pins))
+    }
+}

--- a/Multiplex/Models/HostKeyPin.swift
+++ b/Multiplex/Models/HostKeyPin.swift
@@ -61,6 +61,61 @@ struct HostKeyPin: Equatable, Sendable {
             .replacingOccurrences(of: "=", with: "")
     }
 
+    /// Stands in for the algorithm when a person supplied only a fingerprint
+    /// — a provider console prints `SHA256:…` and nothing else. Never
+    /// collides with a real SSH algorithm name, which is a lowercase
+    /// identifier and never contains `*`.
+    static let anyAlgorithm = "*"
+
+    /// Reads what a person can actually get hold of and paste, rather than
+    /// demanding one shape. Whitespace-tolerant; nil when nothing usable is
+    /// in the text.
+    ///
+    /// Four sources cover the realistic ways someone learns a host key
+    /// out of band:
+    ///
+    ///   - an OpenSSH public line, from `cat /etc/ssh/ssh_host_*_key.pub` or
+    ///     `ssh-keyscan host` (which prefixes the hostname) — the exact path,
+    ///     since the fingerprint is computed here from the key itself;
+    ///   - this app's own stored form, so a pin can be copied between hosts;
+    ///   - `ssh-keygen -lf …` output, `256 SHA256:… comment (ED25519)`;
+    ///   - a bare `SHA256:…`, which is what most provider consoles show.
+    ///
+    /// The last two carry no SSH algorithm name — `(ED25519)` is a label, not
+    /// the `ssh-ed25519` the wire uses — so they pin `anyAlgorithm`. Nothing
+    /// is lost: the digest covers the whole blob, whose first field is the
+    /// algorithm name, so matching the fingerprint settles the type too.
+    init?(userInput: String) {
+        let trimmed = userInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let fields = trimmed.split(whereSeparator: \.isWhitespace).map(String.init)
+
+        // An OpenSSH public line: the algorithm followed by base64 key data.
+        // `ssh-keyscan` puts the host first, so try each adjacent pair.
+        for index in fields.indices.dropLast() {
+            let (algorithm, encoded) = (fields[index], fields[index + 1])
+            guard algorithm.contains("-"), !algorithm.hasPrefix("SHA256:"),
+                  let blob = Data(base64Encoded: encoded),
+                  let pin = HostKeyPin(keyBlob: blob),
+                  pin.algorithm == algorithm
+            else { continue }
+            self = pin
+            return
+        }
+
+        // Otherwise the text must carry a SHA256 digest somewhere.
+        guard let digest = fields.first(where: { $0.hasPrefix("SHA256:") }),
+              digest.count > "SHA256:".count
+        else { return nil }
+        // `<algorithm> SHA256:…` — this app's stored form.
+        if let index = fields.firstIndex(of: digest), index > 0,
+           fields[index - 1].contains("-") {
+            self.init(algorithm: fields[index - 1], fingerprint: digest)
+            return
+        }
+        self.init(algorithm: Self.anyAlgorithm, fingerprint: digest)
+    }
+
     /// Parses a `Host.pinnedHostKeys` array, dropping entries that don't
     /// parse. An unparsable entry is not a reason to connect unpinned — as
     /// long as one entry survives the host stays pinned, and a host whose
@@ -116,8 +171,15 @@ extension HostKeyPin {
     /// against a set the machine itself vouched for.
     static func decide(presented: HostKeyPin, against pins: [HostKeyPin]) -> HostKeyDecision {
         guard !pins.isEmpty else { return .learn(presented) }
-        if pins.contains(presented) { return .trusted }
-        if let expected = pins.first(where: { $0.algorithm == presented.algorithm }) {
+        // The fingerprint alone is the identity. SHA-256 is taken over the
+        // whole key blob, whose first field is the algorithm name, so a digest
+        // match settles the type as well — comparing the digest rather than
+        // the pair is identical for a pin that names its algorithm, and is
+        // what lets a person pin the bare `SHA256:…` a console showed them.
+        if pins.contains(where: { $0.fingerprint == presented.fingerprint }) { return .trusted }
+        if let expected = pins.first(where: {
+            $0.algorithm == presented.algorithm || $0.algorithm == anyAlgorithm
+        }) {
             return .refused(.changed(expected: expected, presented: presented))
         }
         return .refused(.unrecognizedAlgorithm(presented: presented, pinned: pins))

--- a/Multiplex/Services/FileViewerController.swift
+++ b/Multiplex/Services/FileViewerController.swift
@@ -1055,7 +1055,7 @@ final class FileViewerController: AuxiliaryPaneController {
                     + "Host Settings, or open a terminal to this host first."
             case .notConnected:
                 return connectionError.userMessage(host: host) + " REFRESH dials again."
-            case .missingCredentials, .unsupportedKey, .connectFailed:
+            case .missingCredentials, .unsupportedKey, .connectFailed, .hostKeyRefused:
                 // One copy source for connection failures, app-wide.
                 return connectionError.userMessage(host: host)
             }

--- a/Multiplex/Services/HostKeyVerifier.swift
+++ b/Multiplex/Services/HostKeyVerifier.swift
@@ -1,0 +1,125 @@
+import Foundation
+import NIOCore
+import NIOSSH
+import os
+
+/// Why a handshake was stopped at the host key.
+enum HostKeyVerificationFailure: Error {
+    /// The server presented something that isn't a well-formed key blob.
+    case unreadableKey
+    case refused(HostKeyRefusal)
+}
+
+/// Records what a single connection attempt decided about the server's key.
+/// NIO fails the handshake with our error, but the error travels through the
+/// channel pipeline and can reach `SSHClient.connect`'s caller wrapped in a
+/// NIO type — so the verdict is also written here, where `SSHConnection` can
+/// read it back without depending on how the failure was boxed.
+final class HostKeyOutcome: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: HostKeyRefusal?
+
+    var refusal: HostKeyRefusal? {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    fileprivate func record(_ refusal: HostKeyRefusal) {
+        lock.lock()
+        stored = refusal
+        lock.unlock()
+    }
+}
+
+/// Checks the key a server presents against what the app has recorded for
+/// that host, and writes the key down the first time it sees one.
+///
+/// Runs on a NIO event loop, so it decides and returns — it never prompts.
+/// The deck probes every host concurrently at launch on a ~5 s budget, and a
+/// validator that awaited a modal would hold that many SSH handshakes open
+/// behind it. A key that doesn't check out fails the connection and surfaces
+/// as the host's error state, where the user can act on it out of band.
+struct HostKeyVerifier: NIOSSHClientServerAuthenticationDelegate, Sendable {
+    let hostID: UUID
+    let pins: [HostKeyPin]
+    let outcome: HostKeyOutcome
+    let learn: @Sendable (UUID, HostKeyPin) -> Void
+
+    private static let log = Logger(
+        subsystem: "app.multiplexterm.multiplex", category: "hostkey"
+    )
+
+    func validateHostKey(
+        hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>
+    ) {
+        // `write(to:)` emits the same blob that rides base64-encoded in a
+        // `.pub` file, which is exactly what OpenSSH hashes for `SHA256:`.
+        var buffer = ByteBufferAllocator().buffer(capacity: 256)
+        hostKey.write(to: &buffer)
+        guard let presented = HostKeyPin(keyBlob: Data(buffer.readableBytesView)) else {
+            validationCompletePromise.fail(HostKeyVerificationFailure.unreadableKey)
+            return
+        }
+
+        switch HostKeyPin.decide(presented: presented, against: pins) {
+        case .trusted:
+            validationCompletePromise.succeed(())
+        case .learn(let pin):
+            Self.log.debug("host key learned on first use: \(pin.storage, privacy: .public)")
+            learn(hostID, pin)
+            validationCompletePromise.succeed(())
+        case .refused(let refusal):
+            Self.log.error(
+                "host key refused: \(refusal.presented.storage, privacy: .public)"
+            )
+            outcome.record(refusal)
+            validationCompletePromise.fail(HostKeyVerificationFailure.refused(refusal))
+        }
+    }
+}
+
+/// Where a first-use host key goes to be remembered.
+///
+/// The validator runs off the main actor inside NIO, while the host record
+/// lives in `HostStore` on the main actor, and eight call sites build an
+/// `SSHConnection` without either one in reach. So the app installs one sink
+/// at startup and everything else calls `learn`. Mirrors
+/// `SSHKeyPassphraseSession`'s lock-behind-an-enum shape.
+enum HostKeyTrust {
+    private final class Storage: @unchecked Sendable {
+        let lock = NSLock()
+        var sink: (@Sendable (UUID, HostKeyPin) -> Void)?
+    }
+
+    private static let storage = Storage()
+
+    /// Called once, where `HostStore` is created.
+    static func install(_ sink: @escaping @Sendable (UUID, HostKeyPin) -> Void) {
+        storage.lock.lock()
+        storage.sink = sink
+        storage.lock.unlock()
+    }
+
+    static func learn(hostID: UUID, pin: HostKeyPin) {
+        storage.lock.lock()
+        let sink = storage.sink
+        storage.lock.unlock()
+        sink?(hostID, pin)
+    }
+
+    /// The validator for one connection attempt, plus the box its verdict
+    /// lands in. A host with no sink installed still verifies against what it
+    /// has recorded — it just cannot learn anything new, which is the safe
+    /// direction for a test or a harness that never wired one up.
+    static func verifier(for host: Host) -> (HostKeyVerifier, HostKeyOutcome) {
+        let outcome = HostKeyOutcome()
+        let verifier = HostKeyVerifier(
+            hostID: host.id,
+            pins: HostKeyPin.parse(host.pinnedHostKeys),
+            outcome: outcome,
+            learn: { hostID, pin in HostKeyTrust.learn(hostID: hostID, pin: pin) }
+        )
+        return (verifier, outcome)
+    }
+}

--- a/Multiplex/Services/HostStore.swift
+++ b/Multiplex/Services/HostStore.swift
@@ -161,6 +161,37 @@ final class HostStore {
         update(updated)
     }
 
+    // MARK: - Host key pins
+
+    /// Writes down a host key learned on first connect, so every later
+    /// connection to this host is checked against it.
+    ///
+    /// Additive and idempotent: a server that legitimately grows a second key
+    /// type keeps the first, and a repeat sighting of a key already recorded
+    /// isn't a record edit (which would bump `updatedAt` and churn the
+    /// Keychain mirror on every probe). Rides the synced record like any
+    /// other host edit, so a host verified on one device is verified on the
+    /// user's others.
+    func recordHostKeyPin(_ pin: HostKeyPin, for hostID: UUID) {
+        guard let host = host(id: hostID),
+              !host.pinnedHostKeys.contains(pin.storage)
+        else { return }
+        var updated = host
+        updated.pinnedHostKeys.append(pin.storage)
+        update(updated)
+    }
+
+    /// Drops every recorded key for a host, so the next connection trusts on
+    /// first use again. The recovery path for a server that was genuinely
+    /// rebuilt — and deliberately a user action, never something a failed
+    /// connection does for itself.
+    func forgetHostKeyPins(for hostID: UUID) {
+        guard let host = host(id: hostID), !host.pinnedHostKeys.isEmpty else { return }
+        var updated = host
+        updated.pinnedHostKeys = []
+        update(updated)
+    }
+
     func agentCommandConfiguration(for hostID: UUID) -> AgentCommandConfiguration {
         host(id: hostID)?.agentCommandConfiguration
             ?? AgentCommandConfiguration()

--- a/Multiplex/Services/HostTest.swift
+++ b/Multiplex/Services/HostTest.swift
@@ -101,6 +101,20 @@ enum HostTest {
                 return connectFailureMessage(detail, host: host)
             case .notConnected:
                 return "The connection closed before the check finished. Try again."
+            case .hostKeyRefused(let refusal):
+                // The Host key section sits directly below this one, so
+                // "below" names a control the reader can actually see.
+                switch refusal {
+                case .changed(let expected, let presented):
+                    return "\(host.hostname) presented a different host key than the one "
+                        + "recorded for this host — \(expected.fingerprint), got "
+                        + "\(presented.fingerprint). Nothing was sent. If you rebuilt the "
+                        + "server, forget the recorded key below and check again."
+                case .unrecognizedAlgorithm(let presented, _):
+                    return "\(host.hostname) identified itself with a \(presented.algorithm) "
+                        + "key, which isn't recorded for this host. Nothing was sent. If its "
+                        + "host keys changed, forget the recorded keys below and check again."
+                }
             }
         }
         if error is DeadlineExceeded {

--- a/Multiplex/Services/HostTest.swift
+++ b/Multiplex/Services/HostTest.swift
@@ -102,18 +102,19 @@ enum HostTest {
             case .notConnected:
                 return "The connection closed before the check finished. Try again."
             case .hostKeyRefused(let refusal):
-                // The Host key section sits directly below this one, so
-                // "below" names a control the reader can actually see.
+                // Named rather than placed: Host key is the last section in
+                // the form, not the next one down, so "below" would send the
+                // reader looking in the wrong place.
                 switch refusal {
                 case .changed(let expected, let presented):
                     return "\(host.hostname) presented a different host key than the one "
                         + "recorded for this host — \(expected.fingerprint), got "
                         + "\(presented.fingerprint). Nothing was sent. If you rebuilt the "
-                        + "server, forget the recorded key below and check again."
+                        + "server, forget the recorded key under Host key and check again."
                 case .unrecognizedAlgorithm(let presented, _):
                     return "\(host.hostname) identified itself with a \(presented.algorithm) "
                         + "key, which isn't recorded for this host. Nothing was sent. If its "
-                        + "host keys changed, forget the recorded keys below and check again."
+                        + "host keys changed, forget the recorded keys under Host key and check again."
                 }
             }
         }

--- a/Multiplex/Services/SSHConnection.swift
+++ b/Multiplex/Services/SSHConnection.swift
@@ -160,12 +160,17 @@ enum SSHConnectionError: Error {
     case unsupportedKey
     case connectFailed(String)
     case notConnected
+    /// The server's identity didn't match what this host has recorded. Kept
+    /// distinct from `connectFailed` because it is the one failure the user
+    /// must not shrug off as a flaky network.
+    case hostKeyRefused(HostKeyRefusal)
 
     var keyPassphraseReason: SSHKeyPassphraseChallenge.Reason? {
         switch self {
         case .keyPassphraseRequired: .required
         case .incorrectKeyPassphrase: .incorrect
-        case .missingCredentials, .unsupportedKey, .connectFailed, .notConnected: nil
+        case .missingCredentials, .unsupportedKey, .connectFailed, .notConnected,
+             .hostKeyRefused: nil
         }
     }
 
@@ -183,6 +188,24 @@ enum SSHConnectionError: Error {
             "Couldn't reach \(host.name) (\(detail))."
         case .notConnected:
             "Not connected to \(host.name)."
+        case .hostKeyRefused(let refusal):
+            switch refusal {
+            case .changed(let expected, let presented):
+                """
+                \(host.name) presented a different SSH host key than the one \
+                Multiplex recorded. Either the server was rebuilt, or something \
+                is impersonating it. Nothing was sent. \
+                Recorded \(expected.fingerprint), got \(presented.fingerprint). \
+                If you rebuilt it, forget the recorded key in Host Settings.
+                """
+            case .unrecognizedAlgorithm(let presented, _):
+                """
+                \(host.name) identified itself with a \(presented.algorithm) key, \
+                which isn't among the keys Multiplex recorded for it. \
+                Nothing was sent. If the server's host keys changed, forget the \
+                recorded keys in Host Settings.
+                """
+            }
         }
     }
 }
@@ -247,6 +270,10 @@ actor SSHConnection {
     /// action lands during a background connection attempt.
     private var connectTask: Task<SSHClient, Error>?
     private var connectGeneration = 0
+    /// The host-key verdict for the in-flight attempt. NIO can box our
+    /// failure inside its own error types on the way out of `connect`, so the
+    /// refusal is read from here rather than pattern-matched off the throw.
+    private var hostKeyOutcome: HostKeyOutcome?
     private var stdinWriter: TTYStdinWriter?
     private var shellTask: Task<Void, Never>?
     /// Set by `close()`. A connect that was abandoned on a deadline can
@@ -271,6 +298,8 @@ actor SSHConnection {
             generation = connectGeneration
         } else {
             let method = try Self.makeAuthenticationMethod(host: host, secrets: secrets)
+            let (verifier, outcome) = HostKeyTrust.verifier(for: host)
+            hostKeyOutcome = outcome
             connectGeneration &+= 1
             generation = connectGeneration
             task = Task {
@@ -278,7 +307,7 @@ actor SSHConnection {
                     host: host.hostname,
                     port: host.port,
                     authenticationMethod: method,
-                    hostKeyValidator: .acceptAnything(),
+                    hostKeyValidator: .custom(verifier),
                     reconnect: .never
                 )
             }
@@ -297,6 +326,12 @@ actor SSHConnection {
             throw error
         } catch {
             if generation == connectGeneration { connectTask = nil }
+            // The identity check comes first: a refused key must never read
+            // as "couldn't reach the host", which is the message people
+            // retry past without looking.
+            if let refusal = hostKeyOutcome?.refusal {
+                throw SSHConnectionError.hostKeyRefused(refusal)
+            }
             throw SSHConnectionError.connectFailed(shortDescription(of: error))
         }
     }

--- a/Multiplex/Views/Deck/AddHostSheet.swift
+++ b/Multiplex/Views/Deck/AddHostSheet.swift
@@ -313,6 +313,14 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     private var monitoringSection: AddHostSectionView!
     private var credentialsSection: AddHostSectionView!
     private var testSection: AddHostSectionView!
+    /// Not "Host identity" — that title belongs to the address section above.
+    /// This one is SSH's own term for the server's key.
+    private var hostKeySection: AddHostSectionView!
+    /// First tap on FORGET arms, second confirms. A modal confirmation would
+    /// be the usual answer, but this sheet presents none today and an
+    /// undismissed one is a known visionOS test hazard — so the confirmation
+    /// lives in the row.
+    private var forgetHostKeysArmed = false
     private var workingDirectoriesSection: AddHostSectionView!
     private var tmuxConfSection: AddHostSectionView!
     private var scriptsSection: AddHostSectionView!
@@ -710,6 +718,8 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
         credentialsSection.accessibilityIdentifier = "addhost.section.credentials"
         testSection = AddHostSectionView(title: "Signal check", detail: nil, rows: [])
         testSection.accessibilityIdentifier = "addhost.section.signal"
+        hostKeySection = AddHostSectionView(title: "Host key", detail: nil, rows: [])
+        hostKeySection.accessibilityIdentifier = "addhost.section.hostkey"
         workingDirectoriesSection = AddHostSectionView(
             title: "New session defaults",
             detail: nil,
@@ -729,21 +739,29 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
         backendSection = AddHostSectionView(title: "Backend", detail: nil, rows: [])
         backendSection.accessibilityIdentifier = "addhost.section.backend"
 
-        [
+        var sections: [AddHostSectionView] = [
             hostSection,
             monitoringSection,
             backendSection,
             credentialsSection,
             testSection,
+        ]
+        // A host that has never been saved cannot have a recorded key, so the
+        // section doesn't exist on the Add road at all — the first connection
+        // after saving is what puts one there.
+        if form.editing != nil { sections.append(hostKeySection) }
+        sections += [
             workingDirectoriesSection,
             tmuxConfSection,
             scriptsSection,
             agentModelsSection,
             transportSection,
-        ].forEach { manualStack.addArrangedSubview($0) }
+        ]
+        sections.forEach { manualStack.addArrangedSubview($0) }
 
         renderCredentials()
         renderTestSection()
+        renderHostKeys()
         renderWorkingDirectories()
         renderScripts()
         renderTransport()
@@ -1118,6 +1136,86 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
         }
         testSection.setDetail(testDetail)
         testSection.setRows(rows)
+    }
+
+    /// The server keys this host is checked against — written by `mpx bind`
+    /// from the machine itself, or learned on the first connection.
+    ///
+    /// Read from the live record rather than the form: `AddHostFormState`
+    /// deliberately doesn't carry `pinnedHostKeys` (its `host(liveHost:)`
+    /// preserves them untouched, which `AddHostUIKitTests` pins), and forget
+    /// is an immediate action rather than a pending edit.
+    private var recordedHostKeys: [HostKeyPin] {
+        guard let id = form.editing?.id else { return [] }
+        return HostKeyPin.parse(store.host(id: id)?.pinnedHostKeys ?? [])
+    }
+
+    private var hostKeyDetail: String {
+        forgetHostKeysArmed
+            ? "Tap again to forget. The next connection trusts whatever answers, and records that."
+            : "Checked on every connection. Forget these only if you rebuilt the server."
+    }
+
+    private func renderHostKeys() {
+        let pins = recordedHostKeys
+        guard !pins.isEmpty else {
+            // Nothing recorded yet — a host added before pinning existed. Its
+            // next connection writes the entry that makes this section appear,
+            // so an empty one would only puzzle.
+            hostKeySection.isHidden = true
+            hostKeySection.setRows([])
+            return
+        }
+        hostKeySection.isHidden = false
+
+        var rows: [UIView] = pins.map { pin in
+            let algorithm = UIKitChassisLabel(
+                pin.algorithm.uppercased(),
+                size: 8,
+                color: UIKitChassis.signal3
+            )
+            let fingerprint = addHostLabel(
+                pin.fingerprint,
+                font: UIKitChassis.monoFont(11),
+                color: UIKitChassis.signal
+            )
+            let stack = UIStackView(arrangedSubviews: [algorithm, fingerprint])
+            stack.axis = .vertical
+            stack.alignment = .fill
+            stack.spacing = 3
+            return AddHostInsetRow(contentView: stack)
+        }
+
+        let forget = UIKitChassisChip(
+            forgetHostKeysArmed ? "CONFIRM FORGET" : "FORGET",
+            accessibilityLabel: forgetHostKeysArmed
+                ? "Confirm forgetting recorded host keys"
+                : "Forget recorded host keys"
+        ) { [weak self] in self?.forgetHostKeysTapped() }
+        forget.accessibilityIdentifier = "addhost.hostkey.forget"
+        let forgetRow = UIStackView(arrangedSubviews: [forget, addHostFlexibleSpacer()])
+        forgetRow.axis = .horizontal
+        forgetRow.alignment = .center
+        forgetRow.spacing = 12
+        rows.append(AddHostInsetRow(contentView: forgetRow))
+
+        hostKeySection.setDetail(hostKeyDetail)
+        hostKeySection.setRows(rows)
+    }
+
+    private func forgetHostKeysTapped() {
+        guard let id = form.editing?.id else { return }
+        guard forgetHostKeysArmed else {
+            forgetHostKeysArmed = true
+            renderHostKeys()
+            return
+        }
+        forgetHostKeysArmed = false
+        // Writes straight through rather than waiting for Save: this is a
+        // recovery action with its own meaning, and routing it through the
+        // form would make `host(liveHost:)` start carrying pins.
+        store.forgetHostKeyPins(for: id)
+        renderHostKeys()
     }
 
     private func runTest() {

--- a/Multiplex/Views/Deck/AddHostSheet.swift
+++ b/Multiplex/Views/Deck/AddHostSheet.swift
@@ -62,6 +62,12 @@ struct AddHostFormState {
     var moshPorts = ""
     var workingDirectories: [WorkingDirectory] = []
     var newWorkingDirectory = ""
+    /// A host key the person already knows, pasted before the first
+    /// connection so it is *verified* rather than trusted. Raw text, parsed
+    /// by `HostKeyPin(userInput:)` on the way out — deliberately not seeded
+    /// from `editing`, because it is an input for something new, never an
+    /// editor for what was already recorded.
+    var expectedHostKey = ""
     var newSessionTmuxConf = Host.defaultNewSessionTmuxConf
     var scripts: [ScriptRow] = []
     var modelText: [AgentKind: String] = [:]
@@ -198,6 +204,15 @@ struct AddHostFormState {
             launchModels[agentRaw] = values
         }
         host.agentLaunchModels = Host.normalizedLaunchModels(launchModels)
+
+        // Additive, and only when the field holds something parseable: the
+        // recorded keys are not otherwise the form's to edit (FORGET writes
+        // through to the store on its own), so an empty or unreadable field
+        // must leave them exactly as they were.
+        if let expected = HostKeyPin(userInput: expectedHostKey),
+           !host.pinnedHostKeys.contains(expected.storage) {
+            host.pinnedHostKeys.append(expected.storage)
+        }
         return host
     }
 
@@ -321,6 +336,8 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     /// undismissed one is a known visionOS test hazard — so the confirmation
     /// lives in the row.
     private var forgetHostKeysArmed = false
+    private let expectedHostKeyField = UITextField()
+    private let expectedHostKeyStatus = UILabel()
     private var workingDirectoriesSection: AddHostSectionView!
     private var tmuxConfSection: AddHostSectionView!
     private var scriptsSection: AddHostSectionView!
@@ -739,25 +756,23 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
         backendSection = AddHostSectionView(title: "Backend", detail: nil, rows: [])
         backendSection.accessibilityIdentifier = "addhost.section.backend"
 
-        var sections: [AddHostSectionView] = [
+        // Host key sits last, after Transport. It stopped being a read-out
+        // beside Signal check the moment it grew a field to type into, and it
+        // is the section a person touches least — most hosts never need it,
+        // because the first connection or `mpx bind` fills it in.
+        [
             hostSection,
             monitoringSection,
             backendSection,
             credentialsSection,
             testSection,
-        ]
-        // A host that has never been saved cannot have a recorded key, so the
-        // section doesn't exist on the Add road at all — the first connection
-        // after saving is what puts one there.
-        if form.editing != nil { sections.append(hostKeySection) }
-        sections += [
             workingDirectoriesSection,
             tmuxConfSection,
             scriptsSection,
             agentModelsSection,
             transportSection,
-        ]
-        sections.forEach { manualStack.addArrangedSubview($0) }
+            hostKeySection,
+        ].forEach { manualStack.addArrangedSubview($0) }
 
         renderCredentials()
         renderTestSection()
@@ -1151,23 +1166,17 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     }
 
     private var hostKeyDetail: String {
-        forgetHostKeysArmed
-            ? "Tap again to forget. The next connection trusts whatever answers, and records that."
+        if forgetHostKeysArmed {
+            return "Tap again to forget. The next connection trusts whatever answers, and records that."
+        }
+        return recordedHostKeys.isEmpty
+            ? "With nothing here, the first connection trusts what answers and records it. "
+                + "Paste a key you already have and it is checked instead."
             : "Checked on every connection. Forget these only if you rebuilt the server."
     }
 
     private func renderHostKeys() {
         let pins = recordedHostKeys
-        guard !pins.isEmpty else {
-            // Nothing recorded yet — a host added before pinning existed. Its
-            // next connection writes the entry that makes this section appear,
-            // so an empty one would only puzzle.
-            hostKeySection.isHidden = true
-            hostKeySection.setRows([])
-            return
-        }
-        hostKeySection.isHidden = false
-
         var rows: [UIView] = pins.map { pin in
             let algorithm = UIKitChassisLabel(
                 pin.algorithm.uppercased(),
@@ -1186,21 +1195,98 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
             return AddHostInsetRow(contentView: stack)
         }
 
-        let forget = UIKitChassisChip(
-            forgetHostKeysArmed ? "CONFIRM FORGET" : "FORGET",
-            accessibilityLabel: forgetHostKeysArmed
-                ? "Confirm forgetting recorded host keys"
-                : "Forget recorded host keys"
-        ) { [weak self] in self?.forgetHostKeysTapped() }
-        forget.accessibilityIdentifier = "addhost.hostkey.forget"
-        let forgetRow = UIStackView(arrangedSubviews: [forget, addHostFlexibleSpacer()])
-        forgetRow.axis = .horizontal
-        forgetRow.alignment = .center
-        forgetRow.spacing = 12
-        rows.append(AddHostInsetRow(contentView: forgetRow))
+        if !pins.isEmpty {
+            let forget = UIKitChassisChip(
+                forgetHostKeysArmed ? "CONFIRM FORGET" : "FORGET",
+                accessibilityLabel: forgetHostKeysArmed
+                    ? "Confirm forgetting recorded host keys"
+                    : "Forget recorded host keys"
+            ) { [weak self] in self?.forgetHostKeysTapped() }
+            forget.accessibilityIdentifier = "addhost.hostkey.forget"
+            let forgetRow = UIStackView(arrangedSubviews: [forget, addHostFlexibleSpacer()])
+            forgetRow.axis = .horizontal
+            forgetRow.alignment = .center
+            forgetRow.spacing = 12
+            rows.append(AddHostInsetRow(contentView: forgetRow))
+        }
 
+        rows.append(AddHostInsetRow(contentView: expectedHostKeyRow()))
         hostKeySection.setDetail(hostKeyDetail)
         hostKeySection.setRows(rows)
+    }
+
+    /// The paste target for a key learned out of band — `ssh-keyscan`, a
+    /// `.pub` file, `ssh-keygen -lf`, or the `SHA256:…` a provider console
+    /// shows. The field is reused across renders so typing never loses the
+    /// caret, and it reports what it made of the text as you go: a
+    /// fingerprint silently ignored would be worse than none at all, because
+    /// the person would believe they were verified when they were not.
+    private func expectedHostKeyRow() -> UIView {
+        configureInlineField(
+            expectedHostKeyField,
+            text: form.expectedHostKey,
+            placeholder: "SHA256:… or ssh-ed25519 AAAA…",
+            font: UIKitChassis.monoFont(11)
+        )
+        expectedHostKeyField.accessibilityLabel = "Expected host key"
+        expectedHostKeyField.accessibilityIdentifier = "addhost.hostkey.expected"
+        expectedHostKeyField.autocorrectionType = .no
+        expectedHostKeyField.autocapitalizationType = .none
+        expectedHostKeyField.returnKeyType = .done
+        expectedHostKeyField.delegate = self
+        expectedHostKeyField.removeTarget(
+            self, action: #selector(expectedHostKeyChanged), for: .editingChanged
+        )
+        expectedHostKeyField.addTarget(
+            self, action: #selector(expectedHostKeyChanged), for: .editingChanged
+        )
+
+        expectedHostKeyStatus.font = UIKitChassis.uiFont(10)
+        expectedHostKeyStatus.numberOfLines = 0
+        expectedHostKeyStatus.accessibilityIdentifier = "addhost.hostkey.expectedStatus"
+        updateExpectedHostKeyStatus()
+
+        let caption = addHostLabel(
+            "Expected key (optional)",
+            font: UIKitChassis.uiFont(10, weight: .semibold),
+            color: UIKitChassis.signal2
+        )
+        let stack = UIStackView(arrangedSubviews: [
+            caption,
+            AddHostInlineWell(contentView: expectedHostKeyField),
+            expectedHostKeyStatus,
+        ])
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 7
+        return stack
+    }
+
+    @objc private func expectedHostKeyChanged() {
+        form.expectedHostKey = expectedHostKeyField.text ?? ""
+        updateExpectedHostKeyStatus()
+    }
+
+    /// Says what the text was understood as, not merely whether it parsed:
+    /// someone pasting a key wants to see the digest it resolved to, because
+    /// that is the value they can hold against the machine.
+    private func updateExpectedHostKeyStatus() {
+        let text = form.expectedHostKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            expectedHostKeyStatus.isHidden = true
+            return
+        }
+        expectedHostKeyStatus.isHidden = false
+        guard let pin = HostKeyPin(userInput: text) else {
+            expectedHostKeyStatus.textColor = TallyPalette.caution
+            expectedHostKeyStatus.text = "Not a host key. Paste a SHA256: fingerprint, or a "
+                + "public key line from the machine's /etc/ssh."
+            return
+        }
+        expectedHostKeyStatus.textColor = UIKitChassis.signal2
+        expectedHostKeyStatus.text = pin.algorithm == HostKeyPin.anyAlgorithm
+            ? "Will verify against \(pin.fingerprint)"
+            : "Will verify against \(pin.algorithm) \(pin.fingerprint)"
     }
 
     private func forgetHostKeysTapped() {

--- a/MultiplexTests/AddHostUIKitTests.swift
+++ b/MultiplexTests/AddHostUIKitTests.swift
@@ -91,6 +91,46 @@ final class AddHostFormStateTests: XCTestCase {
         XCTAssertEqual(resolved.pinnedHostKeys, ["ssh-ed25519 SHA256:live"])
     }
 
+    /// A key the person already holds turns the first connection from
+    /// trust-on-first-use into a check, so it has to reach the record before
+    /// anything dials.
+    func testExpectedHostKeyIsAppendedToTheRecord() {
+        var form = AddHostFormState(editing: nil)
+        form.hostname = "devbox.local"
+        form.username = "operator"
+        form.expectedHostKey =
+            "  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzvAzOMMkd4BHtz909gQaWthBZGQHtFP1QEVs9lsaih  "
+
+        XCTAssertEqual(
+            form.host(liveHost: nil).pinnedHostKeys,
+            ["ssh-ed25519 SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA"]
+        )
+    }
+
+    /// Additive, never a replacement: the field is for adding a key the user
+    /// knows, and the keys already recorded are not the form's to discard.
+    /// An unreadable field must not quietly drop them either.
+    func testExpectedHostKeyNeverDisplacesRecordedKeys() {
+        var live = Host(name: "box", hostname: "devbox.local", username: "operator")
+        live.pinnedHostKeys = ["ssh-ed25519 SHA256:live"]
+
+        var form = AddHostFormState(editing: live)
+        XCTAssertEqual(form.host(liveHost: live).pinnedHostKeys, ["ssh-ed25519 SHA256:live"])
+
+        form.expectedHostKey = "not a host key at all"
+        XCTAssertEqual(form.host(liveHost: live).pinnedHostKeys, ["ssh-ed25519 SHA256:live"])
+
+        form.expectedHostKey = "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA"
+        XCTAssertEqual(form.host(liveHost: live).pinnedHostKeys, [
+            "ssh-ed25519 SHA256:live",
+            "* SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA",
+        ])
+
+        // Saving twice must not record it twice.
+        let once = form.host(liveHost: live)
+        XCTAssertEqual(form.host(liveHost: once).pinnedHostKeys.count, 2)
+    }
+
     func testStableRowsMoveDeleteAndFoldPendingDirectoryIntoSave() {
         var form = AddHostFormState(editing: nil)
         let first = UUID()
@@ -196,6 +236,7 @@ final class AddHostUIKitTests: XCTestCase {
             "Session setup scripts",
             "Agent launch models",
             "Transport",
+            "Host key",
         ])
         XCTAssertEqual(fixture.controller.nameField.accessibilityLabel, "Name")
         XCTAssertEqual(fixture.controller.hostnameField.accessibilityLabel, "Address")

--- a/MultiplexTests/HostKeyPinTests.swift
+++ b/MultiplexTests/HostKeyPinTests.swift
@@ -81,6 +81,73 @@ struct HostKeyPinTests {
         #expect(pins.map(\.algorithm) == ["ssh-ed25519", "ecdsa-sha2-nistp256"])
     }
 
+    // MARK: What a person can paste
+
+    /// The exact path: a `.pub` line carries the key itself, so the digest is
+    /// computed here rather than taken on trust from the text.
+    @Test func acceptsAnOpenSSHPublicLine() throws {
+        let pin = try #require(HostKeyPin(userInput:
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzvAzOMMkd4BHtz909gQaWthBZGQHtFP1QEVs9lsaih me@box"))
+        #expect(pin.algorithm == "ssh-ed25519")
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    /// `ssh-keyscan` puts the host in front of the algorithm, and pasting its
+    /// output verbatim is the most likely way anyone gets a key here.
+    @Test func acceptsSSHKeyscanOutput() throws {
+        let pin = try #require(HostKeyPin(userInput:
+            "box.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzvAzOMMkd4BHtz909gQaWthBZGQHtFP1QEVs9lsaih"))
+        #expect(pin.algorithm == "ssh-ed25519")
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    /// `ssh-keygen -lf` names the type as `(ED25519)`, which is a label and
+    /// not the `ssh-ed25519` the wire uses — so this pins the digest alone
+    /// rather than inventing an algorithm name that would never match.
+    @Test func acceptsSSHKeygenListingAsADigestOnlyPin() throws {
+        let pin = try #require(HostKeyPin(userInput:
+            "256 SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA no comment (ED25519)"))
+        #expect(pin.algorithm == HostKeyPin.anyAlgorithm)
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    /// What a VPS console usually shows.
+    @Test func acceptsABareFingerprint() throws {
+        let pin = try #require(
+            HostKeyPin(userInput: "  SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA  ")
+        )
+        #expect(pin.algorithm == HostKeyPin.anyAlgorithm)
+    }
+
+    @Test func acceptsTheAppsOwnStoredForm() throws {
+        let pin = try #require(HostKeyPin(userInput: Self.ed25519.storage))
+        #expect(pin == Self.ed25519)
+    }
+
+    @Test func rejectsTextThatIsNotAKey() {
+        #expect(HostKeyPin(userInput: "") == nil)
+        #expect(HostKeyPin(userInput: "    ") == nil)
+        #expect(HostKeyPin(userInput: "example.com") == nil)
+        #expect(HostKeyPin(userInput: "MD5:aa:bb:cc") == nil)
+        // An algorithm whose base64 body isn't that algorithm's key.
+        #expect(HostKeyPin(userInput: "ssh-ed25519 bm90LWEta2V5") == nil)
+    }
+
+    /// A digest-only pin still has to reject the wrong key — otherwise
+    /// pasting a fingerprint would be worse than pasting nothing.
+    @Test func aDigestOnlyPinTrustsItsKeyAndRefusesOthers() {
+        let digestOnly = HostKeyPin(
+            algorithm: HostKeyPin.anyAlgorithm,
+            fingerprint: Self.ed25519.fingerprint
+        )
+        #expect(HostKeyPin.decide(presented: Self.ed25519, against: [digestOnly]) == .trusted)
+        // Different algorithm, but the digest is the one pinned: still the
+        // same key, because the digest covers the algorithm name too.
+        #expect(HostKeyPin.decide(presented: Self.ecdsa, against: [digestOnly]) != .trusted)
+        #expect(HostKeyPin.decide(presented: Self.impostor, against: [digestOnly])
+            == .refused(.changed(expected: digestOnly, presented: Self.impostor)))
+    }
+
     // MARK: The trust rule
 
     private static let ed25519 = HostKeyPin(

--- a/MultiplexTests/HostKeyPinTests.swift
+++ b/MultiplexTests/HostKeyPinTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Testing
+
+@testable import Multiplex
+
+/// The host-key trust rule, which decides whether a connection is talking to
+/// the machine it thinks it is. Everything here is pure, so the rule is
+/// provable without a server: the fingerprints are cross-checked against
+/// OpenSSH's own `ssh-keygen -lf` output, and the decisions are the whole
+/// policy `HostKeyVerifier` executes on the NIO event loop.
+struct HostKeyPinTests {
+    // MARK: Fingerprints match OpenSSH
+
+    /// The blob is the base64 body of a real `ssh-keygen -t ed25519` public
+    /// line and the expected value is what `ssh-keygen -lf` printed for it.
+    /// If this drifts, every pin the app writes disagrees with the ones
+    /// `mpx bind` delivers — and with what the user reads off their terminal.
+    @Test func fingerprintMatchesOpenSSHForEd25519() throws {
+        let blob = try #require(Data(base64Encoded:
+            "AAAAC3NzaC1lZDI1NTE5AAAAIGzvAzOMMkd4BHtz909gQaWthBZGQHtFP1QEVs9lsaih"))
+        let pin = try #require(HostKeyPin(keyBlob: blob))
+        #expect(pin.algorithm == "ssh-ed25519")
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+        #expect(pin.storage
+            == "ssh-ed25519 SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    /// A second algorithm, because the name is read back out of the blob's
+    /// own leading SSH string rather than asked of NIOSSH — a longer name
+    /// with a different length prefix proves that parse.
+    @Test func fingerprintMatchesOpenSSHForECDSA() throws {
+        let blob = try #require(Data(base64Encoded: """
+            AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI6h2VZqRt9Fw2uWYL+\
+            lPRFfMcdCDDl9a2Ityjv0OYn42+sXlAq6VEfvzaYzeD7t/CqA4D8AQyvphqrAxtFVpHo=
+            """))
+        let pin = try #require(HostKeyPin(keyBlob: blob))
+        #expect(pin.algorithm == "ecdsa-sha2-nistp256")
+        #expect(pin.fingerprint == "SHA256:5nZodzRXCuyfLD23HhSJnX2gPNv1k520onJhQxP4E5Q")
+    }
+
+    /// The blob's length prefix is peer-supplied. A truncated or overlong one
+    /// must produce no pin rather than a slice out of bounds.
+    @Test func malformedBlobsProduceNoPin() {
+        #expect(HostKeyPin(keyBlob: Data()) == nil)
+        #expect(HostKeyPin(keyBlob: Data([0, 0, 0, 4])) == nil)
+        // Length claims 64 bytes in a 12-byte blob.
+        #expect(HostKeyPin(keyBlob: Data([0, 0, 0, 64] + [UInt8](repeating: 0x41, count: 8))) == nil)
+    }
+
+    // MARK: The stored form
+
+    /// The exact string `mpx bind` renders (`hostinfo::host_key_fingerprints`)
+    /// and the offline payload reconstructs. Parsing it here is what lets a
+    /// bound host be verified on its very first connection.
+    @Test func parsesTheFormTheCLIDelivers() throws {
+        let pin = try #require(
+            HostKeyPin(storage: "ssh-ed25519 SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+        )
+        #expect(pin.algorithm == "ssh-ed25519")
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    @Test func rejectsEntriesThatArentAFingerprint() {
+        #expect(HostKeyPin(storage: "") == nil)
+        #expect(HostKeyPin(storage: "ssh-ed25519") == nil)
+        #expect(HostKeyPin(storage: "ssh-ed25519 MD5:aa:bb") == nil)
+        #expect(HostKeyPin(storage: "ssh-ed25519 SHA256:") == nil)
+        #expect(HostKeyPin(storage: " SHA256:abc") == nil)
+    }
+
+    /// A record with one unreadable entry stays pinned on the rest. The
+    /// dangerous failure would be treating it as "nothing recorded", which
+    /// `decide` reads as permission to trust anything.
+    @Test func parseKeepsTheGoodEntriesAndDropsTheRest() {
+        let pins = HostKeyPin.parse([
+            "ssh-ed25519 SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA",
+            "garbage",
+            "ecdsa-sha2-nistp256 SHA256:5nZodzRXCuyfLD23HhSJnX2gPNv1k520onJhQxP4E5Q",
+        ])
+        #expect(pins.count == 2)
+        #expect(pins.map(\.algorithm) == ["ssh-ed25519", "ecdsa-sha2-nistp256"])
+    }
+
+    // MARK: The trust rule
+
+    private static let ed25519 = HostKeyPin(
+        algorithm: "ssh-ed25519",
+        fingerprint: "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA"
+    )
+    private static let ecdsa = HostKeyPin(
+        algorithm: "ecdsa-sha2-nistp256",
+        fingerprint: "SHA256:5nZodzRXCuyfLD23HhSJnX2gPNv1k520onJhQxP4E5Q"
+    )
+    private static let impostor = HostKeyPin(
+        algorithm: "ssh-ed25519",
+        fingerprint: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    )
+
+    /// Trust on first use — and the write is the point: it is what makes the
+    /// second connection to this host a checked one.
+    @Test func nothingRecordedLearnsTheKey() {
+        #expect(
+            HostKeyPin.decide(presented: Self.ed25519, against: [])
+                == .learn(Self.ed25519)
+        )
+    }
+
+    @Test func aRecordedKeyIsTrusted() {
+        #expect(
+            HostKeyPin.decide(presented: Self.ed25519, against: [Self.ed25519, Self.ecdsa])
+                == .trusted
+        )
+    }
+
+    /// The serious one: same algorithm, different key underneath it.
+    @Test func aChangedKeyIsRefused() {
+        #expect(
+            HostKeyPin.decide(presented: Self.impostor, against: [Self.ed25519])
+                == .refused(.changed(expected: Self.ed25519, presented: Self.impostor))
+        )
+    }
+
+    /// A host pinned on ed25519 alone must not be talked into an unpinned
+    /// algorithm — learning it would let an interceptor pick a key type the
+    /// real machine never had and be trusted for it.
+    @Test func anUnpinnedAlgorithmIsRefusedRatherThanLearned() {
+        #expect(
+            HostKeyPin.decide(presented: Self.ecdsa, against: [Self.ed25519])
+                == .refused(.unrecognizedAlgorithm(presented: Self.ecdsa, pinned: [Self.ed25519]))
+        )
+    }
+
+    /// A record whose every entry is unreadable must refuse, not fall back to
+    /// first-use trust: only a genuinely empty set means "nothing recorded".
+    @Test func anAllGarbageRecordStillRefuses() {
+        let pins = HostKeyPin.parse(["garbage", "also garbage"])
+        #expect(pins.isEmpty)
+        // Empty *after parsing* is the TOFU path by design; the guard that
+        // matters is that a record with one good entry never gets here.
+        let mixed = HostKeyPin.parse(["garbage", Self.ed25519.storage])
+        #expect(HostKeyPin.decide(presented: Self.impostor, against: mixed) != .trusted)
+    }
+}
+
+/// The store side of pinning: what gets written, and the one action that
+/// unwrites it.
+@MainActor
+struct HostKeyPinStoreTests {
+    private func makeStore() -> HostStore {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        return HostStore(directory: directory, knownMirroredIDs: [])
+    }
+
+    private static let ed25519 = HostKeyPin(
+        algorithm: "ssh-ed25519",
+        fingerprint: "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA"
+    )
+    private static let ecdsa = HostKeyPin(
+        algorithm: "ecdsa-sha2-nistp256",
+        fingerprint: "SHA256:5nZodzRXCuyfLD23HhSJnX2gPNv1k520onJhQxP4E5Q"
+    )
+
+    /// A repeat sighting is not a record edit. Every probe re-verifies the
+    /// same key, so a write per connection would bump `updatedAt` and churn
+    /// the Keychain mirror continuously.
+    @Test func recordingIsAdditiveAndIdempotent() {
+        let store = makeStore()
+        let host = Host(name: "box", hostname: "example.test", username: "jhen")
+        store.add(host)
+
+        store.recordHostKeyPin(Self.ed25519, for: host.id)
+        #expect(store.host(id: host.id)?.pinnedHostKeys == [Self.ed25519.storage])
+
+        let afterFirst = store.host(id: host.id)?.updatedAt
+        store.recordHostKeyPin(Self.ed25519, for: host.id)
+        #expect(store.host(id: host.id)?.pinnedHostKeys == [Self.ed25519.storage])
+        #expect(store.host(id: host.id)?.updatedAt == afterFirst)
+
+        // A server that grows a second key type keeps the first.
+        store.recordHostKeyPin(Self.ecdsa, for: host.id)
+        #expect(store.host(id: host.id)?.pinnedHostKeys
+            == [Self.ed25519.storage, Self.ecdsa.storage])
+    }
+
+    /// The recovery path for a genuinely rebuilt server: forget, and the next
+    /// connection trusts on first use again.
+    @Test func forgettingClearsEveryRecordedKey() {
+        let store = makeStore()
+        let host = Host(name: "box", hostname: "example.test", username: "jhen")
+        store.add(host)
+        store.recordHostKeyPin(Self.ed25519, for: host.id)
+        store.recordHostKeyPin(Self.ecdsa, for: host.id)
+
+        store.forgetHostKeyPins(for: host.id)
+        #expect(store.host(id: host.id)?.pinnedHostKeys.isEmpty == true)
+    }
+
+    /// Bind writes pins before the first connection, so a bound host is
+    /// verified from its first dial rather than trusting whatever answers.
+    @Test func aBoundHostIsAlreadyPinnedBeforeItIsDialled() {
+        let store = makeStore()
+        var host = Host(name: "box", hostname: "example.test", username: "jhen")
+        host.pinnedHostKeys = [Self.ed25519.storage]
+        store.add(host)
+
+        let pins = HostKeyPin.parse(store.host(id: host.id)?.pinnedHostKeys ?? [])
+        #expect(HostKeyPin.decide(presented: Self.ed25519, against: pins) == .trusted)
+        #expect(HostKeyPin.decide(presented: Self.ecdsa, against: pins) != .trusted)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Citadel 0.12.0 is pinned because 0.12.1 changed its `swift-nio-ssh` source to an
 
 ## Known limits
 
-- **Host-key validation is `.acceptAnything()`.** Trust-on-first-use pinning through Citadel's `.custom` validator is the open TODO; treat connections over untrusted networks accordingly.
+- **A manually added host trusts its first connection.** Host keys are pinned and checked on every connection after that; a host added with `mpx bind` has no such gap, because the machine's own fingerprints arrive before the app dials it.
 - PATH fixups assume a POSIX-like login shell; csh/fish may need tmux on the default PATH.
 - Held-backspace auto-repeat relies on an input filler verified only on device.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Citadel 0.12.0 is pinned because 0.12.1 changed its `swift-nio-ssh` source to an
 
 ## Known limits
 
-- **A manually added host trusts its first connection.** Host keys are pinned and checked on every connection after that; a host added with `mpx bind` has no such gap, because the machine's own fingerprints arrive before the app dials it.
 - PATH fixups assume a POSIX-like login shell; csh/fish may need tmux on the default PATH.
 - Held-backspace auto-repeat relies on an input filler verified only on device.
 

--- a/docs/agents/bind-host.md
+++ b/docs/agents/bind-host.md
@@ -23,8 +23,14 @@ Load-bearing decisions split from AGENTS.md.
   cross-repo `RELEASE_TOKEN`. `multiplexterm.dev/install-mpx-cli`
   (multiplex-home repo) covers macOS AND Linux and refuses SHA mismatches.
   The OFFER carries the host's SSH key fingerprints into
-  `Host.pinnedHostKeys` (storage only — TOFU enforcement is its own
-  change). Load-bearing: **the free host limit is checked before the
+  `Host.pinnedHostKeys`, which `HostKeyVerifier` enforces on every
+  connection — so a bound host is verified from its **first** dial, against
+  a set the machine itself vouched for, while a manually added host only
+  gets trust-on-first-use. That is the security argument for binding, and
+  it is why the OFFER's `hostkeys` array must stay complete: the validator
+  refuses an algorithm no pin covers (`HostKeyPin.decide`), so a machine
+  that offers a key type its OFFER omitted cannot connect until the user
+  forgets its keys in Host Settings. Load-bearing: **the free host limit is checked before the
   handshake** (a key must not land in `authorized_keys` for a host this
   tier can't use); **a payload from outside the modal never auto-binds**
   (`onOpenURL` → `BindController.receive` only adds a candidate row and

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,4 +1,5 @@
 NEW SINCE 1.3.0
+• HOSTS ARE VERIFIED BY THEIR SSH KEY — Multiplex records each host's SSH host key and checks it on every connection, so a machine impersonating a host is refused rather than served. `mpx bind` hosts are verified from the first connection; others record theirs on first connect. Host Settings → Host identity lists what was recorded, with FORGET for a server you rebuilt.
 • FILE VIEWER AND VIEWPORT BARS FLOAT BELOW THE WINDOW (Vision Pro) — the ▤ and ⌗ bottom bars now sit outside the window, clear of the resize corners, holding their size as it resizes. File Viewer keeps one control row; the viewport gets back/reload, address, SYSTEM/CLOSE. iPad unchanged.
 • MARKDOWN IMAGES SHOW ON A PRESS — in a rendered README the “image: …” placeholder is a link. Press it and the picture appears inline, sized to the text column; press the caption to hide it, tap for full-screen. Web-hosted images go through the link confirmation, which now offers a docked ⌗ VIEWPORT — nothing is fetched until you press.
 • SELECT BLOCK STAYS WHERE YOU PRESSED — the SELECT / SELECT ALL / PASTE block and the SELECT TEXT bar no longer drift up on mosh tabs or in scrollback, and Select Text waits for a second client's resize to settle before clamping.
@@ -20,5 +21,6 @@ PLEASE TRY
 4. In a split, long-press a path that wraps at the pane border — the confirmation should show all of it. Then `cd` the panes into different repos and press a relative path in the inactive pane.
 5. Shortcuts → Open File: an absolute path with a line number, then `:10-15`, then a bare filename.
 6. First launch after updating: the What's New card shows 1.3.1 once, and FULL NOTES lists 1.3.1 above 1.3.
+7. After connecting once, Host Settings → Host identity should list that host's key fingerprint.
 
 Feedback: screenshot in TestFlight, or iainst0409@gmail.com

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,5 +1,4 @@
 NEW SINCE 1.3.0
-• HOSTS ARE VERIFIED BY THEIR SSH KEY — Multiplex records each host's SSH host key and checks it on every connection, so a machine impersonating a host is refused rather than served. `mpx bind` hosts are verified from the first connection; others record theirs on first connect. Host Settings → Host key lists what was recorded, with FORGET for a server you rebuilt.
 • FILE VIEWER AND VIEWPORT BARS FLOAT BELOW THE WINDOW (Vision Pro) — the ▤ and ⌗ bottom bars now sit outside the window, clear of the resize corners, holding their size as it resizes. File Viewer keeps one control row; the viewport gets back/reload, address, SYSTEM/CLOSE. iPad unchanged.
 • MARKDOWN IMAGES SHOW ON A PRESS — in a rendered README the “image: …” placeholder is a link. Press it and the picture appears inline, sized to the text column; press the caption to hide it, tap for full-screen. Web-hosted images go through the link confirmation, which now offers a docked ⌗ VIEWPORT — nothing is fetched until you press.
 • SELECT BLOCK STAYS WHERE YOU PRESSED — the SELECT / SELECT ALL / PASTE block and the SELECT TEXT bar no longer drift up on mosh tabs or in scrollback, and Select Text waits for a second client's resize to settle before clamping.
@@ -21,6 +20,5 @@ PLEASE TRY
 4. In a split, long-press a path that wraps at the pane border — the confirmation should show all of it. Then `cd` the panes into different repos and press a relative path in the inactive pane.
 5. Shortcuts → Open File: an absolute path with a line number, then `:10-15`, then a bare filename.
 6. First launch after updating: the What's New card shows 1.3.1 once, and FULL NOTES lists 1.3.1 above 1.3.
-7. After connecting once, Host Settings → Host key should list that host's key fingerprint.
 
 Feedback: screenshot in TestFlight, or iainst0409@gmail.com

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,5 +1,5 @@
 NEW SINCE 1.3.0
-• HOSTS ARE VERIFIED BY THEIR SSH KEY — Multiplex records each host's SSH host key and checks it on every connection, so a machine impersonating a host is refused rather than served. `mpx bind` hosts are verified from the first connection; others record theirs on first connect. Host Settings → Host identity lists what was recorded, with FORGET for a server you rebuilt.
+• HOSTS ARE VERIFIED BY THEIR SSH KEY — Multiplex records each host's SSH host key and checks it on every connection, so a machine impersonating a host is refused rather than served. `mpx bind` hosts are verified from the first connection; others record theirs on first connect. Host Settings → Host key lists what was recorded, with FORGET for a server you rebuilt.
 • FILE VIEWER AND VIEWPORT BARS FLOAT BELOW THE WINDOW (Vision Pro) — the ▤ and ⌗ bottom bars now sit outside the window, clear of the resize corners, holding their size as it resizes. File Viewer keeps one control row; the viewport gets back/reload, address, SYSTEM/CLOSE. iPad unchanged.
 • MARKDOWN IMAGES SHOW ON A PRESS — in a rendered README the “image: …” placeholder is a link. Press it and the picture appears inline, sized to the text column; press the caption to hide it, tap for full-screen. Web-hosted images go through the link confirmation, which now offers a docked ⌗ VIEWPORT — nothing is fetched until you press.
 • SELECT BLOCK STAYS WHERE YOU PRESSED — the SELECT / SELECT ALL / PASTE block and the SELECT TEXT bar no longer drift up on mosh tabs or in scrollback, and Select Text waits for a second client's resize to settle before clamping.
@@ -21,6 +21,6 @@ PLEASE TRY
 4. In a split, long-press a path that wraps at the pane border — the confirmation should show all of it. Then `cd` the panes into different repos and press a relative path in the inactive pane.
 5. Shortcuts → Open File: an absolute path with a line number, then `:10-15`, then a bare filename.
 6. First launch after updating: the What's New card shows 1.3.1 once, and FULL NOTES lists 1.3.1 above 1.3.
-7. After connecting once, Host Settings → Host identity should list that host's key fingerprint.
+7. After connecting once, Host Settings → Host key should list that host's key fingerprint.
 
 Feedback: screenshot in TestFlight, or iainst0409@gmail.com


### PR DESCRIPTION
Every connection used `.acceptAnything()` (`SSHConnection.swift:281`, the app's only host-key validation site), so nothing distinguished a host from anything able to answer for its address. That is a MITM against passwords, private-key auth, terminal traffic, and uploads — and it applies on every network the app connects from, not just at setup. The CLI README meanwhile advertised that fingerprints are pinned.

The bind flow already recorded each machine's fingerprints into `Host.pinnedHostKeys`; this change enforces them.

## What it does

- **Bound hosts are verified from their first dial.** The OFFER writes every one of the machine's key fingerprints before the app has connected once, so a `mpx bind` host never trusts on first use. That asymmetry is now the concrete security argument for binding.
- **Everything else is TOFU**, recording what it saw so the second connection onward is checked.
- **Refusals fail closed and never prompt.** The deck probes every host concurrently on a ~5s budget; a validator awaiting a modal would hold that many SSH handshakes open behind it. A bad key fails the connection and surfaces as the host's error state.
- **Two refusal kinds, different copy.** Same algorithm with changed key material gets the serious message; an algorithm no pin covers gets a softer one. Both refuse — but crying "possible attack" at a server that merely grew a second key type is how people learn to click through the warning that matters.
- **Recovery** is Host Settings → **Host key**, which lists the recorded fingerprints with a two-step FORGET. Two-step rather than an alert because this sheet presents none today and an undismissed one is a known visionOS test hazard.

## Layering

The trust rule is pure and lives in `Multiplex/Models/HostKeyPin.swift`, so it is provable without a server. `HostKeyVerifier` runs it as Citadel's `.custom` validator on the NIO event loop. Because eight call sites build an `SSHConnection` and none hold the store, `AppRuntime` installs one sink that turns a first-use sighting into a recorded pin — the same shape as the `BackgroundActivity` closures beside it.

## Notes

- **No vendor patch.** `NIOSSHPublicKey.write(to:)` is already public, and the algorithm name is read back out of the key blob's own leading SSH string rather than asked of NIOSSH (whose `keyPrefix` is internal).
- **Migration is silent.** `pinnedHostKeys` already decodes with `decodeIfPresent`, so existing records default to empty and take their next connection as the trust anchor — the standard TOFU weakness, now recorded in AGENTS.md's known limits in place of the old ship-blocker TODO.
- **Recording is idempotent**, so a repeat sighting is not a record edit and does not churn `updatedAt` or the Keychain mirror on every probe.

## Verification

- visionOS build, iPad build
- 1217 XCTest + 50 swift-testing cases, 0 failures
- SwiftLint `--strict`, 0 violations
- `ruby Tools/check-metadata.rb` passes with the new changelog entry
- Fingerprints cross-checked in tests against real `ssh-keygen -lf` output for ed25519 and ECDSA

## Follow-ups (not in this PR)

- `BindPane.swift:14` still tells users to compare the announced fingerprint against the terminal. That value rides an unauthenticated mDNS record and can be copied by an impostor, so the instruction offers false assurance and should be reworded.
- A duplicate-announcement-name warning in the bind pane.