### PR TITLE
Flag two announcements claiming one name in the bind pane

### DIFF
--- a/Multiplex/Models/Bind/BindProtocol.swift
+++ b/Multiplex/Models/Bind/BindProtocol.swift
@@ -209,6 +209,36 @@ struct BindAnnouncement: Identifiable, Equatable, Sendable {
     }
 }
 
+extension BindAnnouncement {
+    /// Names claimed by more than one announcement, case-folded to match the
+    /// pane's own ordering so the contested rows sit together.
+    ///
+    /// Discovery already dedupes by session key, so two entries sharing a name
+    /// are two *different* keys both claiming to be that machine. That is what
+    /// the rogue-announcer attack looks like from here: mDNS authenticates
+    /// nothing, so anyone on the network can advertise the machine's name —
+    /// and its fingerprint, which is just as unauthenticated — and wait to be
+    /// picked.
+    ///
+    /// A tell, not a control. The same lack of authentication lets an attacker
+    /// forge a goodbye record for the real row, or answer for its instance
+    /// name outright, and leave exactly one row standing. It is worth showing
+    /// because the version that leaves both rows up is the one a person can
+    /// still catch. The fix that doesn't depend on noticing is a short
+    /// authenticated string over `spub` — see `spec/bind-v1.md` §3.
+    ///
+    /// One honest false positive: two `mpx bind` runs on the same machine mint
+    /// two session keys and so contest their own name. The copy says so rather
+    /// than accusing.
+    static func contestedNames(in announcements: [BindAnnouncement]) -> Set<String> {
+        var counts: [String: Int] = [:]
+        for announcement in announcements {
+            counts[announcement.name.lowercased(), default: 0] += 1
+        }
+        return Set(counts.lazy.filter { $0.value > 1 }.map(\.key))
+    }
+}
+
 /// The host record OFFER carries — what the app saves.
 struct BindOffer: Equatable, Sendable {
     var name: String

--- a/Multiplex/Services/Bind/BindController.swift
+++ b/Multiplex/Services/Bind/BindController.swift
@@ -41,6 +41,13 @@ final class BindController {
         var source: Source
         var pin: String = ""
         var stage: Stage = .awaitingPIN
+        /// Whether another announcement is claiming this row's name. Context
+        /// rather than an identity fact derived from `source` — the same
+        /// machine is contested or not depending on who else is announcing —
+        /// so it is stored, and `syncDiscovered` recomputes it on every fold.
+        /// Never set on a payload row: a scanned or pasted offer carries the
+        /// machine's own session key, so nothing on the network can contest it.
+        var isNameContested: Bool = false
 
         var id: String {
             switch source {
@@ -249,6 +256,19 @@ final class BindController {
             if candidate.isBusy { return false }
             if case .bound = candidate.stage { return false }
             return true
+        }
+        // Recomputed over the surviving rows, not the raw browse list: a row
+        // held open by an in-flight enrollment still contests, and one already
+        // retired must stop.
+        let contested = BindAnnouncement.contestedNames(
+            in: updated.compactMap { candidate in
+                guard case .discovered(let announcement) = candidate.source else { return nil }
+                return announcement
+            }
+        )
+        for index in updated.indices {
+            guard case .discovered(let announcement) = updated[index].source else { continue }
+            updated[index].isNameContested = contested.contains(announcement.name.lowercased())
         }
         if updated != pending { pending = updated }
     }

--- a/Multiplex/Views/Deck/BindPane.swift
+++ b/Multiplex/Views/Deck/BindPane.swift
@@ -747,6 +747,7 @@ final class BindCandidateRowView: UIView {
     private let userLabel = UILabel()
     private let addressLabel = UILabel()
     private let fingerprintLabel = UILabel()
+    private let contestedLabel = UILabel()
     private let errorLabel = UILabel()
     private let pinInput = BindPINInputView()
     private let boundLabel = UILabel()
@@ -782,6 +783,7 @@ final class BindCandidateRowView: UIView {
         addressLabel.text = pending.addressSummary
         fingerprintLabel.text = pending.fingerprint
         fingerprintLabel.isHidden = pending.fingerprint == nil
+        contestedLabel.isHidden = !pending.isNameContested
 
         if case .failed(let message) = pending.stage {
             errorLabel.text = message
@@ -870,6 +872,14 @@ final class BindCandidateRowView: UIView {
             identityStack.bottomAnchor.constraint(equalTo: identity.bottomAnchor, constant: -9),
         ])
 
+        contestedLabel.font = UIKitChassis.uiFont(10)
+        contestedLabel.textColor = TallyPalette.caution
+        contestedLabel.numberOfLines = 0
+        contestedLabel.isHidden = true
+        contestedLabel.text = "Another announcement is using this name. If you started "
+            + "only one mpx bind, one of these isn't your machine — scan its QR instead."
+        contestedLabel.accessibilityIdentifier = "bind.candidate.contested"
+
         errorLabel.font = UIKitChassis.uiFont(10)
         errorLabel.textColor = TallyPalette.caution
         errorLabel.numberOfLines = 0
@@ -935,7 +945,7 @@ final class BindCandidateRowView: UIView {
         actionState.spacing = 0
 
         let content = UIStackView(arrangedSubviews: [
-            header, identity, errorLabel, actionState,
+            header, identity, contestedLabel, errorLabel, actionState,
         ])
         content.axis = .vertical
         content.alignment = .fill

--- a/MultiplexTests/BindProtocolTests.swift
+++ b/MultiplexTests/BindProtocolTests.swift
@@ -355,6 +355,44 @@ struct BindProtocolTests {
         #expect(announcement.id == spub.base64EncodedString())
     }
 
+    /// Two session keys claiming one name is what the rogue-announcer attack
+    /// looks like from the app's side — mDNS authenticates nothing, so the
+    /// name and the fingerprint are both copyable.
+    @Test func contestedNamesFindsTwoKeysClaimingOneMachine() throws {
+        let names = BindAnnouncement.contestedNames(in: [
+            try announcement(name: "devbox", spub: 1),
+            try announcement(name: "devbox", spub: 2),
+            try announcement(name: "laptop", spub: 3),
+        ])
+        #expect(names == ["devbox"])
+    }
+
+    /// The pane orders case-insensitively, so an impostor must not slip past
+    /// by changing the capitalization of a name it copied.
+    @Test func contestedNamesIgnoresCase() throws {
+        let names = BindAnnouncement.contestedNames(in: [
+            try announcement(name: "DevBox", spub: 1),
+            try announcement(name: "devbox", spub: 2),
+        ])
+        #expect(names == ["devbox"])
+    }
+
+    @Test func oneAnnouncementPerNameContestsNothing() throws {
+        #expect(BindAnnouncement.contestedNames(in: []).isEmpty)
+        #expect(BindAnnouncement.contestedNames(in: [
+            try announcement(name: "devbox", spub: 1),
+            try announcement(name: "laptop", spub: 2),
+        ]).isEmpty)
+    }
+
+    private func announcement(name: String, spub byte: UInt8) throws -> BindAnnouncement {
+        try #require(BindAnnouncement(txt: [
+            "v": "1",
+            "name": name,
+            "spub": Data(repeating: byte, count: 32).base64URLNoPadString,
+        ]))
+    }
+
     @Test func announcementRejectsIncompleteRecords() {
         #expect(BindAnnouncement(txt: [:]) == nil)
         #expect(BindAnnouncement(txt: ["v": "1", "name": "devbox"]) == nil)

--- a/docs/agents/bind-host.md
+++ b/docs/agents/bind-host.md
@@ -36,7 +36,16 @@ Load-bearing decisions split from AGENTS.md.
   endorses it); the PIN proof is transcript-bound (HKDF over PIN + both
   public keys, 3 attempts then the session locks) while a wrong token
   closes silently (counting 128-bit guesses would gift a LAN spammer a
-  DoS). **The whole flow is one modal**: Add Host opens on BIND | MANUAL
+  DoS). **Two announcements claiming one name raise a caution on both
+  rows** (`BindAnnouncement.contestedNames`; discovery dedupes by session
+  key, so a shared name means two keys claiming one machine). It is a
+  **tell, not a control** — do not let it grow into one: the same
+  unauthenticated mDNS lets an attacker forge a goodbye for the real row
+  or answer for its instance name and leave a single row standing, and
+  two `mpx bind` runs on one machine contest their own name, which is why
+  the copy says "if you started only one". The fix that doesn't depend on
+  someone noticing is a SAS over `spub` (`spec/bind-v1.md` §3).
+  **The whole flow is one modal**: Add Host opens on BIND | MANUAL
   (`AddHostSheet.Mode`); the deck has no bind surface at all (chip, rail,
   and ghost tiles shipped and were withdrawn 2026-07-28). Discovery
   browses only while `bindSurfaceOpen` OR an enrollment is in flight —

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,5 +1,6 @@
 NEW SINCE 1.3.0
 • FILE VIEWER AND VIEWPORT BARS FLOAT BELOW THE WINDOW (Vision Pro) — the ▤ and ⌗ bottom bars now sit outside the window, clear of the resize corners, holding their size as it resizes. File Viewer keeps one control row; the viewport gets back/reload, address, SYSTEM/CLOSE. iPad unchanged.
+• BIND FLAGS TWO MACHINES ANNOUNCING ONE NAME — in Add Host ▸ BIND, when more than one announcement claims the same name, both rows say so. Local-network discovery isn't authenticated, so another machine can advertise yours; if you started only one `mpx bind`, scan its QR instead.
 • MARKDOWN IMAGES SHOW ON A PRESS — in a rendered README the “image: …” placeholder is a link. Press it and the picture appears inline, sized to the text column; press the caption to hide it, tap for full-screen. Web-hosted images go through the link confirmation, which now offers a docked ⌗ VIEWPORT — nothing is fetched until you press.
 • SELECT BLOCK STAYS WHERE YOU PRESSED — the SELECT / SELECT ALL / PASTE block and the SELECT TEXT bar no longer drift up on mosh tabs or in scrollback, and Select Text waits for a second client's resize to settle before clamping.
 • MOSH TABS NO LONGER GROW A JUNK SCROLL AREA — stale frames were archived above the live screen on every keyboard show/hide. Mosh tabs now hold only the live screen.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,6 +1,5 @@
 NEW SINCE 1.3.0
 • FILE VIEWER AND VIEWPORT BARS FLOAT BELOW THE WINDOW (Vision Pro) — the ▤ and ⌗ bottom bars now sit outside the window, clear of the resize corners, holding their size as it resizes. File Viewer keeps one control row; the viewport gets back/reload, address, SYSTEM/CLOSE. iPad unchanged.
-• BIND FLAGS TWO MACHINES ANNOUNCING ONE NAME — in Add Host ▸ BIND, when more than one announcement claims the same name, both rows say so. Local-network discovery isn't authenticated, so another machine can advertise yours; if you started only one `mpx bind`, scan its QR instead.
 • MARKDOWN IMAGES SHOW ON A PRESS — in a rendered README the “image: …” placeholder is a link. Press it and the picture appears inline, sized to the text column; press the caption to hide it, tap for full-screen. Web-hosted images go through the link confirmation, which now offers a docked ⌗ VIEWPORT — nothing is fetched until you press.
 • SELECT BLOCK STAYS WHERE YOU PRESSED — the SELECT / SELECT ALL / PASTE block and the SELECT TEXT bar no longer drift up on mosh tabs or in scrollback, and Select Text waits for a second client's resize to settle before clamping.
 • MOSH TABS NO LONGER GROW A JUNK SCROLL AREA — stale frames were archived above the live screen on every keyboard show/hide. Mosh tabs now hold only the live screen.


### PR DESCRIPTION
Local-network discovery authenticates nothing, so anyone on the network can advertise `_multiplex-bind._tcp` under your machine's name — and under its fingerprint, which travels in the same unauthenticated TXT record. From the app's side, the naive version of that attack has one visible signature: two rows claiming the same machine.

`BindDiscovery` already dedupes by session key, so two entries sharing a name are two *different* keys claiming to be one machine. Both rows now carry a caution.

## Scope — a tell, not a control

This is deliberately not presented as a fix, and both the code and `docs/agents/bind-host.md` say so, because it would be easy to mistake for one later:

- An attacker can forge an mDNS goodbye for the real row, or answer for its instance name outright, and leave exactly one row standing.
- It only fires while both announcements are visible.

What closes the gap without depending on a person noticing is a short authenticated string over `spub`, per `spec/bind-v1.md` §3. This just makes the lazy version catchable, which is worth having while that decision is pending.

## False positive, handled in the copy

Two `mpx bind` runs on the same machine mint two session keys and therefore contest their own name. Rather than accuse, the copy reads: *"Another announcement is using this name. If you started only one mpx bind, one of these isn't your machine — scan its QR instead."*

## Implementation

- `BindAnnouncement.contestedNames(in:)` is pure and case-folded to match the pane's own ordering, so an impostor can't slip past by changing capitalization.
- `Pending.isNameContested` is stored rather than derived from `source`, because it is a fact about context, not identity — the same machine is contested or not depending on who else is announcing. `syncDiscovered` recomputes it on every fold.
- Recomputed over the **surviving** rows, not the raw browse list: a row held open by an in-flight enrollment still contests, and a retired one must stop.
- Payload rows are never flagged — a scanned or pasted offer carries the machine's own session key, so nothing on the network can contest it.

## Verification

visionOS build, 1217 XCTest + 39 swift-testing cases with 0 failures, SwiftLint `--strict` clean, `ruby Tools/check-metadata.rb` passes with the new changelog entry.

## Related

Independent of #46 (host-key pinning) and branched from `main`, so the two can land in either order. The changelog insertions sit at different anchors and should merge cleanly.

Still outstanding from that PR's follow-ups: `BindPane.swift:14` tells users to compare the announced fingerprint against the terminal, which offers false assurance for exactly the reason above.