### PR TITLE
Let a manually added host be verified on its first connection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,10 +108,10 @@ approaches. Don't re-litigate a recorded decision without new facts.
 
 ## Known limits (v1)
 
-- Host keys are pinned per host (`HostKeyPin`, `HostKeyVerifier`) — bound
-  hosts from the OFFER, everything else on first use. A host added before
-  pinning shipped takes its next connection as the trust anchor, which is the
-  standard TOFU weakness and the reason `mpx bind` is the better path.
+- Host keys are pinned per host (`HostKeyPin`, `HostKeyVerifier`). Three ways
+  a host gets one: the bind OFFER, an expected key pasted into Add Host, or
+  trust-on-first-use. Only the third has a window, and a host added before
+  pinning shipped is always in it — its next connection is the trust anchor.
 - csh/fish remote shells may need tmux on the default PATH (the probe
   prepends common Homebrew/local dirs but assumes POSIX-ish login shells).
 - Held-backspace auto-repeat rides an unverified input filler — see

--- a/Multiplex/Models/HostKeyPin.swift
+++ b/Multiplex/Models/HostKeyPin.swift
@@ -61,6 +61,61 @@ struct HostKeyPin: Equatable, Sendable {
             .replacingOccurrences(of: "=", with: "")
     }
 
+    /// Stands in for the algorithm when a person supplied only a fingerprint
+    /// — a provider console prints `SHA256:…` and nothing else. Never
+    /// collides with a real SSH algorithm name, which is a lowercase
+    /// identifier and never contains `*`.
+    static let anyAlgorithm = "*"
+
+    /// Reads what a person can actually get hold of and paste, rather than
+    /// demanding one shape. Whitespace-tolerant; nil when nothing usable is
+    /// in the text.
+    ///
+    /// Four sources cover the realistic ways someone learns a host key
+    /// out of band:
+    ///
+    ///   - an OpenSSH public line, from `cat /etc/ssh/ssh_host_*_key.pub` or
+    ///     `ssh-keyscan host` (which prefixes the hostname) — the exact path,
+    ///     since the fingerprint is computed here from the key itself;
+    ///   - this app's own stored form, so a pin can be copied between hosts;
+    ///   - `ssh-keygen -lf …` output, `256 SHA256:… comment (ED25519)`;
+    ///   - a bare `SHA256:…`, which is what most provider consoles show.
+    ///
+    /// The last two carry no SSH algorithm name — `(ED25519)` is a label, not
+    /// the `ssh-ed25519` the wire uses — so they pin `anyAlgorithm`. Nothing
+    /// is lost: the digest covers the whole blob, whose first field is the
+    /// algorithm name, so matching the fingerprint settles the type too.
+    init?(userInput: String) {
+        let trimmed = userInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let fields = trimmed.split(whereSeparator: \.isWhitespace).map(String.init)
+
+        // An OpenSSH public line: the algorithm followed by base64 key data.
+        // `ssh-keyscan` puts the host first, so try each adjacent pair.
+        for index in fields.indices.dropLast() {
+            let (algorithm, encoded) = (fields[index], fields[index + 1])
+            guard algorithm.contains("-"), !algorithm.hasPrefix("SHA256:"),
+                  let blob = Data(base64Encoded: encoded),
+                  let pin = HostKeyPin(keyBlob: blob),
+                  pin.algorithm == algorithm
+            else { continue }
+            self = pin
+            return
+        }
+
+        // Otherwise the text must carry a SHA256 digest somewhere.
+        guard let digest = fields.first(where: { $0.hasPrefix("SHA256:") }),
+              digest.count > "SHA256:".count
+        else { return nil }
+        // `<algorithm> SHA256:…` — this app's stored form.
+        if let index = fields.firstIndex(of: digest), index > 0,
+           fields[index - 1].contains("-") {
+            self.init(algorithm: fields[index - 1], fingerprint: digest)
+            return
+        }
+        self.init(algorithm: Self.anyAlgorithm, fingerprint: digest)
+    }
+
     /// Parses a `Host.pinnedHostKeys` array, dropping entries that don't
     /// parse. An unparsable entry is not a reason to connect unpinned — as
     /// long as one entry survives the host stays pinned, and a host whose
@@ -116,8 +171,15 @@ extension HostKeyPin {
     /// against a set the machine itself vouched for.
     static func decide(presented: HostKeyPin, against pins: [HostKeyPin]) -> HostKeyDecision {
         guard !pins.isEmpty else { return .learn(presented) }
-        if pins.contains(presented) { return .trusted }
-        if let expected = pins.first(where: { $0.algorithm == presented.algorithm }) {
+        // The fingerprint alone is the identity. SHA-256 is taken over the
+        // whole key blob, whose first field is the algorithm name, so a digest
+        // match settles the type as well — comparing the digest rather than
+        // the pair is identical for a pin that names its algorithm, and is
+        // what lets a person pin the bare `SHA256:…` a console showed them.
+        if pins.contains(where: { $0.fingerprint == presented.fingerprint }) { return .trusted }
+        if let expected = pins.first(where: {
+            $0.algorithm == presented.algorithm || $0.algorithm == anyAlgorithm
+        }) {
             return .refused(.changed(expected: expected, presented: presented))
         }
         return .refused(.unrecognizedAlgorithm(presented: presented, pinned: pins))

--- a/Multiplex/Services/HostTest.swift
+++ b/Multiplex/Services/HostTest.swift
@@ -102,18 +102,19 @@ enum HostTest {
             case .notConnected:
                 return "The connection closed before the check finished. Try again."
             case .hostKeyRefused(let refusal):
-                // The Host key section sits directly below this one, so
-                // "below" names a control the reader can actually see.
+                // Named rather than placed: Host key is the last section in
+                // the form, not the next one down, so "below" would send the
+                // reader looking in the wrong place.
                 switch refusal {
                 case .changed(let expected, let presented):
                     return "\(host.hostname) presented a different host key than the one "
                         + "recorded for this host — \(expected.fingerprint), got "
                         + "\(presented.fingerprint). Nothing was sent. If you rebuilt the "
-                        + "server, forget the recorded key below and check again."
+                        + "server, forget the recorded key under Host key and check again."
                 case .unrecognizedAlgorithm(let presented, _):
                     return "\(host.hostname) identified itself with a \(presented.algorithm) "
                         + "key, which isn't recorded for this host. Nothing was sent. If its "
-                        + "host keys changed, forget the recorded keys below and check again."
+                        + "host keys changed, forget the recorded keys under Host key and check again."
                 }
             }
         }

--- a/Multiplex/Views/Deck/AddHostSheet.swift
+++ b/Multiplex/Views/Deck/AddHostSheet.swift
@@ -756,22 +756,23 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
         backendSection = AddHostSectionView(title: "Backend", detail: nil, rows: [])
         backendSection.accessibilityIdentifier = "addhost.section.backend"
 
-        var sections: [AddHostSectionView] = [
+        // Host key sits last, after Transport. It stopped being a read-out
+        // beside Signal check the moment it grew a field to type into, and it
+        // is the section a person touches least — most hosts never need it,
+        // because the first connection or `mpx bind` fills it in.
+        [
             hostSection,
             monitoringSection,
             backendSection,
             credentialsSection,
             testSection,
-        ]
-        sections.append(hostKeySection)
-        sections += [
             workingDirectoriesSection,
             tmuxConfSection,
             scriptsSection,
             agentModelsSection,
             transportSection,
-        ]
-        sections.forEach { manualStack.addArrangedSubview($0) }
+            hostKeySection,
+        ].forEach { manualStack.addArrangedSubview($0) }
 
         renderCredentials()
         renderTestSection()

--- a/Multiplex/Views/Deck/AddHostSheet.swift
+++ b/Multiplex/Views/Deck/AddHostSheet.swift
@@ -62,6 +62,12 @@ struct AddHostFormState {
     var moshPorts = ""
     var workingDirectories: [WorkingDirectory] = []
     var newWorkingDirectory = ""
+    /// A host key the person already knows, pasted before the first
+    /// connection so it is *verified* rather than trusted. Raw text, parsed
+    /// by `HostKeyPin(userInput:)` on the way out — deliberately not seeded
+    /// from `editing`, because it is an input for something new, never an
+    /// editor for what was already recorded.
+    var expectedHostKey = ""
     var newSessionTmuxConf = Host.defaultNewSessionTmuxConf
     var scripts: [ScriptRow] = []
     var modelText: [AgentKind: String] = [:]
@@ -198,6 +204,15 @@ struct AddHostFormState {
             launchModels[agentRaw] = values
         }
         host.agentLaunchModels = Host.normalizedLaunchModels(launchModels)
+
+        // Additive, and only when the field holds something parseable: the
+        // recorded keys are not otherwise the form's to edit (FORGET writes
+        // through to the store on its own), so an empty or unreadable field
+        // must leave them exactly as they were.
+        if let expected = HostKeyPin(userInput: expectedHostKey),
+           !host.pinnedHostKeys.contains(expected.storage) {
+            host.pinnedHostKeys.append(expected.storage)
+        }
         return host
     }
 
@@ -321,6 +336,8 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     /// undismissed one is a known visionOS test hazard — so the confirmation
     /// lives in the row.
     private var forgetHostKeysArmed = false
+    private let expectedHostKeyField = UITextField()
+    private let expectedHostKeyStatus = UILabel()
     private var workingDirectoriesSection: AddHostSectionView!
     private var tmuxConfSection: AddHostSectionView!
     private var scriptsSection: AddHostSectionView!
@@ -746,10 +763,7 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
             credentialsSection,
             testSection,
         ]
-        // A host that has never been saved cannot have a recorded key, so the
-        // section doesn't exist on the Add road at all — the first connection
-        // after saving is what puts one there.
-        if form.editing != nil { sections.append(hostKeySection) }
+        sections.append(hostKeySection)
         sections += [
             workingDirectoriesSection,
             tmuxConfSection,
@@ -1151,23 +1165,17 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
     }
 
     private var hostKeyDetail: String {
-        forgetHostKeysArmed
-            ? "Tap again to forget. The next connection trusts whatever answers, and records that."
+        if forgetHostKeysArmed {
+            return "Tap again to forget. The next connection trusts whatever answers, and records that."
+        }
+        return recordedHostKeys.isEmpty
+            ? "With nothing here, the first connection trusts what answers and records it. "
+                + "Paste a key you already have and it is checked instead."
             : "Checked on every connection. Forget these only if you rebuilt the server."
     }
 
     private func renderHostKeys() {
         let pins = recordedHostKeys
-        guard !pins.isEmpty else {
-            // Nothing recorded yet — a host added before pinning existed. Its
-            // next connection writes the entry that makes this section appear,
-            // so an empty one would only puzzle.
-            hostKeySection.isHidden = true
-            hostKeySection.setRows([])
-            return
-        }
-        hostKeySection.isHidden = false
-
         var rows: [UIView] = pins.map { pin in
             let algorithm = UIKitChassisLabel(
                 pin.algorithm.uppercased(),
@@ -1186,21 +1194,98 @@ final class AddHostViewController: UIViewController, UITextFieldDelegate,
             return AddHostInsetRow(contentView: stack)
         }
 
-        let forget = UIKitChassisChip(
-            forgetHostKeysArmed ? "CONFIRM FORGET" : "FORGET",
-            accessibilityLabel: forgetHostKeysArmed
-                ? "Confirm forgetting recorded host keys"
-                : "Forget recorded host keys"
-        ) { [weak self] in self?.forgetHostKeysTapped() }
-        forget.accessibilityIdentifier = "addhost.hostkey.forget"
-        let forgetRow = UIStackView(arrangedSubviews: [forget, addHostFlexibleSpacer()])
-        forgetRow.axis = .horizontal
-        forgetRow.alignment = .center
-        forgetRow.spacing = 12
-        rows.append(AddHostInsetRow(contentView: forgetRow))
+        if !pins.isEmpty {
+            let forget = UIKitChassisChip(
+                forgetHostKeysArmed ? "CONFIRM FORGET" : "FORGET",
+                accessibilityLabel: forgetHostKeysArmed
+                    ? "Confirm forgetting recorded host keys"
+                    : "Forget recorded host keys"
+            ) { [weak self] in self?.forgetHostKeysTapped() }
+            forget.accessibilityIdentifier = "addhost.hostkey.forget"
+            let forgetRow = UIStackView(arrangedSubviews: [forget, addHostFlexibleSpacer()])
+            forgetRow.axis = .horizontal
+            forgetRow.alignment = .center
+            forgetRow.spacing = 12
+            rows.append(AddHostInsetRow(contentView: forgetRow))
+        }
 
+        rows.append(AddHostInsetRow(contentView: expectedHostKeyRow()))
         hostKeySection.setDetail(hostKeyDetail)
         hostKeySection.setRows(rows)
+    }
+
+    /// The paste target for a key learned out of band — `ssh-keyscan`, a
+    /// `.pub` file, `ssh-keygen -lf`, or the `SHA256:…` a provider console
+    /// shows. The field is reused across renders so typing never loses the
+    /// caret, and it reports what it made of the text as you go: a
+    /// fingerprint silently ignored would be worse than none at all, because
+    /// the person would believe they were verified when they were not.
+    private func expectedHostKeyRow() -> UIView {
+        configureInlineField(
+            expectedHostKeyField,
+            text: form.expectedHostKey,
+            placeholder: "SHA256:… or ssh-ed25519 AAAA…",
+            font: UIKitChassis.monoFont(11)
+        )
+        expectedHostKeyField.accessibilityLabel = "Expected host key"
+        expectedHostKeyField.accessibilityIdentifier = "addhost.hostkey.expected"
+        expectedHostKeyField.autocorrectionType = .no
+        expectedHostKeyField.autocapitalizationType = .none
+        expectedHostKeyField.returnKeyType = .done
+        expectedHostKeyField.delegate = self
+        expectedHostKeyField.removeTarget(
+            self, action: #selector(expectedHostKeyChanged), for: .editingChanged
+        )
+        expectedHostKeyField.addTarget(
+            self, action: #selector(expectedHostKeyChanged), for: .editingChanged
+        )
+
+        expectedHostKeyStatus.font = UIKitChassis.uiFont(10)
+        expectedHostKeyStatus.numberOfLines = 0
+        expectedHostKeyStatus.accessibilityIdentifier = "addhost.hostkey.expectedStatus"
+        updateExpectedHostKeyStatus()
+
+        let caption = addHostLabel(
+            "Expected key (optional)",
+            font: UIKitChassis.uiFont(10, weight: .semibold),
+            color: UIKitChassis.signal2
+        )
+        let stack = UIStackView(arrangedSubviews: [
+            caption,
+            AddHostInlineWell(contentView: expectedHostKeyField),
+            expectedHostKeyStatus,
+        ])
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 7
+        return stack
+    }
+
+    @objc private func expectedHostKeyChanged() {
+        form.expectedHostKey = expectedHostKeyField.text ?? ""
+        updateExpectedHostKeyStatus()
+    }
+
+    /// Says what the text was understood as, not merely whether it parsed:
+    /// someone pasting a key wants to see the digest it resolved to, because
+    /// that is the value they can hold against the machine.
+    private func updateExpectedHostKeyStatus() {
+        let text = form.expectedHostKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            expectedHostKeyStatus.isHidden = true
+            return
+        }
+        expectedHostKeyStatus.isHidden = false
+        guard let pin = HostKeyPin(userInput: text) else {
+            expectedHostKeyStatus.textColor = TallyPalette.caution
+            expectedHostKeyStatus.text = "Not a host key. Paste a SHA256: fingerprint, or a "
+                + "public key line from the machine's /etc/ssh."
+            return
+        }
+        expectedHostKeyStatus.textColor = UIKitChassis.signal2
+        expectedHostKeyStatus.text = pin.algorithm == HostKeyPin.anyAlgorithm
+            ? "Will verify against \(pin.fingerprint)"
+            : "Will verify against \(pin.algorithm) \(pin.fingerprint)"
     }
 
     private func forgetHostKeysTapped() {

--- a/MultiplexTests/AddHostUIKitTests.swift
+++ b/MultiplexTests/AddHostUIKitTests.swift
@@ -231,12 +231,12 @@ final class AddHostUIKitTests: XCTestCase {
             "Backend",
             "Credentials",
             "Signal check",
-            "Host key",
             "New session defaults",
             "New session tmux conf",
             "Session setup scripts",
             "Agent launch models",
             "Transport",
+            "Host key",
         ])
         XCTAssertEqual(fixture.controller.nameField.accessibilityLabel, "Name")
         XCTAssertEqual(fixture.controller.hostnameField.accessibilityLabel, "Address")

--- a/MultiplexTests/AddHostUIKitTests.swift
+++ b/MultiplexTests/AddHostUIKitTests.swift
@@ -91,6 +91,46 @@ final class AddHostFormStateTests: XCTestCase {
         XCTAssertEqual(resolved.pinnedHostKeys, ["ssh-ed25519 SHA256:live"])
     }
 
+    /// A key the person already holds turns the first connection from
+    /// trust-on-first-use into a check, so it has to reach the record before
+    /// anything dials.
+    func testExpectedHostKeyIsAppendedToTheRecord() {
+        var form = AddHostFormState(editing: nil)
+        form.hostname = "devbox.local"
+        form.username = "operator"
+        form.expectedHostKey =
+            "  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzvAzOMMkd4BHtz909gQaWthBZGQHtFP1QEVs9lsaih  "
+
+        XCTAssertEqual(
+            form.host(liveHost: nil).pinnedHostKeys,
+            ["ssh-ed25519 SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA"]
+        )
+    }
+
+    /// Additive, never a replacement: the field is for adding a key the user
+    /// knows, and the keys already recorded are not the form's to discard.
+    /// An unreadable field must not quietly drop them either.
+    func testExpectedHostKeyNeverDisplacesRecordedKeys() {
+        var live = Host(name: "box", hostname: "devbox.local", username: "operator")
+        live.pinnedHostKeys = ["ssh-ed25519 SHA256:live"]
+
+        var form = AddHostFormState(editing: live)
+        XCTAssertEqual(form.host(liveHost: live).pinnedHostKeys, ["ssh-ed25519 SHA256:live"])
+
+        form.expectedHostKey = "not a host key at all"
+        XCTAssertEqual(form.host(liveHost: live).pinnedHostKeys, ["ssh-ed25519 SHA256:live"])
+
+        form.expectedHostKey = "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA"
+        XCTAssertEqual(form.host(liveHost: live).pinnedHostKeys, [
+            "ssh-ed25519 SHA256:live",
+            "* SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA",
+        ])
+
+        // Saving twice must not record it twice.
+        let once = form.host(liveHost: live)
+        XCTAssertEqual(form.host(liveHost: once).pinnedHostKeys.count, 2)
+    }
+
     func testStableRowsMoveDeleteAndFoldPendingDirectoryIntoSave() {
         var form = AddHostFormState(editing: nil)
         let first = UUID()
@@ -191,6 +231,7 @@ final class AddHostUIKitTests: XCTestCase {
             "Backend",
             "Credentials",
             "Signal check",
+            "Host key",
             "New session defaults",
             "New session tmux conf",
             "Session setup scripts",

--- a/MultiplexTests/HostKeyPinTests.swift
+++ b/MultiplexTests/HostKeyPinTests.swift
@@ -81,6 +81,73 @@ struct HostKeyPinTests {
         #expect(pins.map(\.algorithm) == ["ssh-ed25519", "ecdsa-sha2-nistp256"])
     }
 
+    // MARK: What a person can paste
+
+    /// The exact path: a `.pub` line carries the key itself, so the digest is
+    /// computed here rather than taken on trust from the text.
+    @Test func acceptsAnOpenSSHPublicLine() throws {
+        let pin = try #require(HostKeyPin(userInput:
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzvAzOMMkd4BHtz909gQaWthBZGQHtFP1QEVs9lsaih me@box"))
+        #expect(pin.algorithm == "ssh-ed25519")
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    /// `ssh-keyscan` puts the host in front of the algorithm, and pasting its
+    /// output verbatim is the most likely way anyone gets a key here.
+    @Test func acceptsSSHKeyscanOutput() throws {
+        let pin = try #require(HostKeyPin(userInput:
+            "box.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzvAzOMMkd4BHtz909gQaWthBZGQHtFP1QEVs9lsaih"))
+        #expect(pin.algorithm == "ssh-ed25519")
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    /// `ssh-keygen -lf` names the type as `(ED25519)`, which is a label and
+    /// not the `ssh-ed25519` the wire uses — so this pins the digest alone
+    /// rather than inventing an algorithm name that would never match.
+    @Test func acceptsSSHKeygenListingAsADigestOnlyPin() throws {
+        let pin = try #require(HostKeyPin(userInput:
+            "256 SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA no comment (ED25519)"))
+        #expect(pin.algorithm == HostKeyPin.anyAlgorithm)
+        #expect(pin.fingerprint == "SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA")
+    }
+
+    /// What a VPS console usually shows.
+    @Test func acceptsABareFingerprint() throws {
+        let pin = try #require(
+            HostKeyPin(userInput: "  SHA256:JsAUX9CQFrzfXXeSw9rfsDuGvSDg9kwa/D4OFBI72AA  ")
+        )
+        #expect(pin.algorithm == HostKeyPin.anyAlgorithm)
+    }
+
+    @Test func acceptsTheAppsOwnStoredForm() throws {
+        let pin = try #require(HostKeyPin(userInput: Self.ed25519.storage))
+        #expect(pin == Self.ed25519)
+    }
+
+    @Test func rejectsTextThatIsNotAKey() {
+        #expect(HostKeyPin(userInput: "") == nil)
+        #expect(HostKeyPin(userInput: "    ") == nil)
+        #expect(HostKeyPin(userInput: "example.com") == nil)
+        #expect(HostKeyPin(userInput: "MD5:aa:bb:cc") == nil)
+        // An algorithm whose base64 body isn't that algorithm's key.
+        #expect(HostKeyPin(userInput: "ssh-ed25519 bm90LWEta2V5") == nil)
+    }
+
+    /// A digest-only pin still has to reject the wrong key — otherwise
+    /// pasting a fingerprint would be worse than pasting nothing.
+    @Test func aDigestOnlyPinTrustsItsKeyAndRefusesOthers() {
+        let digestOnly = HostKeyPin(
+            algorithm: HostKeyPin.anyAlgorithm,
+            fingerprint: Self.ed25519.fingerprint
+        )
+        #expect(HostKeyPin.decide(presented: Self.ed25519, against: [digestOnly]) == .trusted)
+        // Different algorithm, but the digest is the one pinned: still the
+        // same key, because the digest covers the algorithm name too.
+        #expect(HostKeyPin.decide(presented: Self.ecdsa, against: [digestOnly]) != .trusted)
+        #expect(HostKeyPin.decide(presented: Self.impostor, against: [digestOnly])
+            == .refused(.changed(expected: digestOnly, presented: Self.impostor)))
+    }
+
     // MARK: The trust rule
 
     private static let ed25519 = HostKeyPin(


### PR DESCRIPTION
> **Stacked on #46** — based on `ssh-host-key-pinning`, not `main`, because it builds on `HostKeyPin` / `HostKeyVerifier`. Merge #46 first and GitHub will retarget this to `main`.

#46 closed the ongoing exposure, but left one window: a manually added host still trusts whatever answers the *first* time and pins that. `mpx bind` has no such window — the machine's own fingerprints arrive before the app dials it — and this gives the manual path the same option for anyone who can get the key out of band.

Paste it into **Add Host → Host key** and the first connection is checked rather than trusted. Leave it blank and behaviour is exactly what it is today.

## Reads what people can actually get

`HostKeyPin(userInput:)` accepts the realistic sources rather than demanding one shape:

| Pasted | Source |
|---|---|
| `ssh-ed25519 AAAA… comment` | `cat /etc/ssh/ssh_host_*_key.pub` |
| `host ssh-ed25519 AAAA…` | `ssh-keyscan host` (leading hostname) |
| `256 SHA256:… (ED25519)` | `ssh-keygen -lf …` |
| `SHA256:…` | most VPS consoles |
| `ssh-ed25519 SHA256:…` | this app's own stored form |

For the first two the digest is computed here from the key itself, so nothing is taken on trust from the text.

## Digest-only pins, and why they lose nothing

`ssh-keygen -lf` and consoles carry no SSH algorithm name — `(ED25519)` is a label, not the `ssh-ed25519` the wire uses — so those pin the digest alone under `HostKeyPin.anyAlgorithm`.

That's safe because **the digest was always the identity**: SHA-256 runs over the whole key blob, whose first field *is* the algorithm name, so a digest match settles the type too. `decide` now compares fingerprints rather than the (algorithm, fingerprint) pair — provably identical for any pin that names its algorithm, and what makes a console-supplied digest usable. A digest-only pin still refuses a different key; there's a test for exactly that, since a pasted fingerprint that failed to reject would be worse than pasting nothing.

## Details worth a look

- **The field says what it understood**, live: *"Will verify against ssh-ed25519 SHA256:…"* or a clear rejection. A fingerprint silently ignored is the dangerous failure — the person believes they're verified when they aren't.
- **The write is additive and skips anything unparseable**, so a stray character can't discard keys a host already had. Two tests cover that, including saving twice without duplicating.
- The **Host key** section now appears on the Add road too (it was edit-only in #46), so `AddHostUIKitTests`' section-contract list gains one entry.
- `expectedHostKey` is deliberately **not** seeded from the host being edited: it's an input for something new, never an editor for what was already recorded. FORGET remains the way to remove.

## Verification

visionOS build, 1219 XCTest + 57 swift-testing cases with 0 failures, SwiftLint `--strict` clean, `check-metadata.rb` passing (the changelog needed tightening — it was 74 characters over the App Store cap before the trim).