### PR TITLE
Keep the shortcut panel open while moving around

### DIFF
--- a/Multiplex/Models/HerdrShortcut.swift
+++ b/Multiplex/Models/HerdrShortcut.swift
@@ -114,6 +114,16 @@ enum HerdrShortcut: String, CaseIterable, Identifiable, Sendable {
 
     var requiresDoubleActivation: Bool { closeScope != nil }
 
+    /// Cycling panes and tabs keeps the panel up so the hop can be repeated,
+    /// the same rule `TmuxShortcut.keepsPanelOpen` states.
+    var keepsPanelOpen: Bool {
+        switch self {
+        case .nextPane, .nextTab, .previousTab: true
+        case .splitLeftRight, .splitTopBottom, .closePane, .newTab, .closeTab,
+             .newWorkspace, .renameWorkspace, .closeWorkspace: false
+        }
+    }
+
     var bindingLabel: String {
         guard !requiresDoubleActivation else { return "2×" }
         switch self {

--- a/Multiplex/Models/ShortcutPanelContent.swift
+++ b/Multiplex/Models/ShortcutPanelContent.swift
@@ -16,6 +16,9 @@ struct ShortcutPanelItem: Equatable, Sendable, Identifiable {
     var command: String
     var bindingLabel: String
     var requiresDoubleActivation: Bool
+    /// Whether performing this row leaves the panel on screen — see
+    /// `TmuxShortcut.keepsPanelOpen`.
+    var keepsPanelOpen: Bool
     var accessibilityIdentifier: String
 
     var id: String { accessibilityIdentifier }
@@ -26,6 +29,7 @@ struct ShortcutPanelItem: Equatable, Sendable, Identifiable {
         command = shortcut.command
         bindingLabel = shortcut.bindingLabel
         requiresDoubleActivation = shortcut.requiresDoubleActivation
+        keepsPanelOpen = shortcut.keepsPanelOpen
         accessibilityIdentifier = "tmuxShortcut.\(shortcut.rawValue)"
     }
 
@@ -35,6 +39,7 @@ struct ShortcutPanelItem: Equatable, Sendable, Identifiable {
         command = shortcut.command
         bindingLabel = shortcut.bindingLabel
         requiresDoubleActivation = shortcut.requiresDoubleActivation
+        keepsPanelOpen = shortcut.keepsPanelOpen
         accessibilityIdentifier = "herdrShortcut.\(shortcut.rawValue)"
     }
 }

--- a/Multiplex/Models/TmuxShortcut.swift
+++ b/Multiplex/Models/TmuxShortcut.swift
@@ -96,6 +96,20 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         self == .closePane || self == .closeWindow
     }
 
+    /// Moving between panes and windows is a switchboard action: the panel
+    /// stays up so a hop can be repeated, exactly like its window list. Rows
+    /// that create, rename, close, or enter a mode dismiss it — what they
+    /// leave behind is the terminal, and it must not be covered.
+    var keepsPanelOpen: Bool {
+        switch self {
+        case .nextPane, .togglePaneZoom, .nextWindow, .previousWindow, .lastWindow:
+            true
+        case .splitLeftRight, .splitTopBottom, .copyMode, .closePane,
+             .newWindow, .chooseWindow, .renameWindow, .closeWindow:
+            false
+        }
+    }
+
     var bindingLabel: String {
         requiresDoubleActivation ? "2×" : "⌃B \(binding.uppercased())"
     }

--- a/Multiplex/Views/Terminal/ShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/ShortcutPanel.swift
@@ -347,6 +347,13 @@ final class ShortcutPanelViewController: UIViewController {
     }
 }
 
+/// Press feedback for the panel's rows: the pressed ground lands at once and
+/// fades away. A tap raises and clears the highlight inside one run loop, so
+/// clearing it outright drew no frame and only a long press ever looked
+/// pressed — the fade starts from the colour the touch already set, which is
+/// what makes a quick tap visible.
+private let shortcutPressFadeDuration: TimeInterval = 0.25
+
 @MainActor
 private final class ShortcutPanelRootView: UIKitTallyBorderedView {
     private var width: CGFloat
@@ -504,7 +511,9 @@ private final class ShortcutItemButton: UIControl {
     }
 
     override var isHighlighted: Bool {
-        didSet { refreshBackground() }
+        // Fading out of the pressed ground, rather than dropping it, is what
+        // makes a quick tap visible — see `shortcutPressFadeDuration`.
+        didSet { refreshBackground(animated: !isHighlighted) }
     }
 
     override func accessibilityActivate() -> Bool {
@@ -540,12 +549,18 @@ private final class ShortcutItemButton: UIControl {
         isHighlighted = false
     }
 
-    private func refreshBackground() {
-        // PROTOTYPE(GLASS): rest on strata over the popover's smoke, never
-        // opaque chassis.
-        backgroundColor = isArmed || isHighlighted
-            ? UIKitChassis.bezelHi
-            : GlassPrototype.strataChassis
+    // PROTOTYPE(GLASS): rest on strata over the popover's smoke, never
+    // opaque chassis.
+    private var restingBackgroundColor: UIColor {
+        isArmed ? UIKitChassis.bezelHi : GlassPrototype.strataChassis
+    }
+
+    private func refreshBackground(animated: Bool = false) {
+        let ground = isHighlighted ? UIKitChassis.bezelHi : restingBackgroundColor
+        guard animated else { return backgroundColor = ground }
+        UIView.animate(withDuration: shortcutPressFadeDuration) {
+            self.backgroundColor = ground
+        }
     }
 
     private func refreshBorder() {
@@ -636,7 +651,9 @@ private final class ShortcutChoiceButton: UIControl {
     }
 
     override var isHighlighted: Bool {
-        didSet { refreshBackground() }
+        // Fading out of the pressed ground, rather than dropping it, is what
+        // makes a quick tap visible — see `shortcutPressFadeDuration`.
+        didSet { refreshBackground(animated: !isHighlighted) }
     }
 
     override func accessibilityActivate() -> Bool {
@@ -652,10 +669,15 @@ private final class ShortcutChoiceButton: UIControl {
         isHighlighted = false
     }
 
-    private func refreshBackground() {
-        // PROTOTYPE(GLASS): rest on strata over the popover's smoke.
-        backgroundColor = isHighlighted
-            ? UIKitChassis.bezelHi : GlassPrototype.strataChassis
+    // PROTOTYPE(GLASS): rest on strata over the popover's smoke.
+    private var restingBackgroundColor: UIColor { GlassPrototype.strataChassis }
+
+    private func refreshBackground(animated: Bool = false) {
+        let ground = isHighlighted ? UIKitChassis.bezelHi : restingBackgroundColor
+        guard animated else { return backgroundColor = ground }
+        UIView.animate(withDuration: shortcutPressFadeDuration) {
+            self.backgroundColor = ground
+        }
     }
 }
 

--- a/Multiplex/Views/Terminal/ShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/ShortcutPanel.swift
@@ -10,6 +10,9 @@ final class ShortcutPanelViewController: UIViewController {
     nonisolated static let preferredWidth: CGFloat =
         402 + 2 * UIKitChassis.popoverPanelInset
     nonisolated static let confirmationWindow: UInt64 = 2_000_000_000
+    /// Long enough for a prefix binding to reach tmux/herdr and change the
+    /// active window before the panel re-reads the list.
+    nonisolated static let choiceRefreshDelay: UInt64 = 600_000_000
 
     private let content: ShortcutPanelContent
     private var panelWidth: CGFloat
@@ -21,7 +24,9 @@ final class ShortcutPanelViewController: UIViewController {
     private let contentStack = UIStackView()
     private let switchSection = UIStackView()
     private var itemButtons: [String: ShortcutItemButton] = [:]
+    private var choiceButtons: [ShortcutChoiceButton] = []
     private var choiceLoadTask: Task<Void, Never>?
+    private var choiceRefreshTask: Task<Void, Never>?
     private var disarmTask: Task<Void, Never>?
     private var armedItemID: String?
     private var didRequestChoices = false
@@ -62,6 +67,8 @@ final class ShortcutPanelViewController: UIViewController {
         disarm()
         choiceLoadTask?.cancel()
         choiceLoadTask = nil
+        choiceRefreshTask?.cancel()
+        choiceRefreshTask = nil
     }
 
     /// The view controller owns an intrinsic height so UIKit popovers follow
@@ -75,6 +82,7 @@ final class ShortcutPanelViewController: UIViewController {
     /// loader and by UIKit-focused tests. A single window/workspace has no
     /// useful switch action and therefore earns no section.
     func applyChoices(_ choices: [TmuxWindowChoice]) {
+        choiceButtons = []
         switchSection.arrangedSubviews.forEach {
             switchSection.removeArrangedSubview($0)
             $0.removeFromSuperview()
@@ -204,7 +212,7 @@ final class ShortcutPanelViewController: UIViewController {
     }
 
     private func makeChoiceGrid(_ choices: [TmuxWindowChoice]) -> UIView {
-        makeTwoColumnGrid(choices.map { choice in
+        choiceButtons = choices.map { choice in
             let button = ShortcutChoiceButton(
                 choice: choice,
                 noun: content.switchNoun,
@@ -212,7 +220,8 @@ final class ShortcutPanelViewController: UIViewController {
             )
             button.addTarget(self, action: #selector(choicePressed(_:)), for: .touchUpInside)
             return button
-        })
+        }
+        return makeTwoColumnGrid(choiceButtons)
     }
 
     private func makeTwoColumnGrid(_ controls: [UIControl]) -> UIView {
@@ -247,21 +256,31 @@ final class ShortcutPanelViewController: UIViewController {
         activate(sender.item)
     }
 
+    /// Switching does not dismiss the panel — the list is a switchboard, and
+    /// hopping between windows/workspaces should not cost a reopen. The rows
+    /// re-mark ACTIVE in place so the panel keeps telling the truth without a
+    /// reload round-trip against the switch that is still in flight.
     @objc private func choicePressed(_ sender: ShortcutChoiceButton) {
         disarm()
-        selectChoice?(sender.choice)
+        let choice = sender.choice
+        for button in choiceButtons {
+            button.setActive(button.choice.id == choice.id)
+        }
+        selectChoice?(choice)
     }
 
     private func activate(_ item: ShortcutPanelItem) {
         guard item.requiresDoubleActivation else {
             disarm()
             select(item)
+            scheduleChoiceRefreshIfPanelStays(item)
             return
         }
 
         if armedItemID == item.id {
             disarm()
             select(item)
+            scheduleChoiceRefreshIfPanelStays(item)
             return
         }
 
@@ -285,6 +304,23 @@ final class ShortcutPanelViewController: UIViewController {
         armedItemID = id
         for (candidate, button) in itemButtons {
             button.setArmed(candidate == id)
+        }
+    }
+
+    /// A row that leaves the panel up may have moved the very window the
+    /// switch list marks ACTIVE (Next / Previous / Last Window). The binding
+    /// travels through the terminal, so re-read the list once it has landed
+    /// rather than guess the destination.
+    private func scheduleChoiceRefreshIfPanelStays(_ item: ShortcutPanelItem) {
+        guard item.keepsPanelOpen, let loadChoices else { return }
+        choiceRefreshTask?.cancel()
+        choiceRefreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.choiceRefreshDelay)
+            guard !Task.isCancelled else { return }
+            let choices = await loadChoices() ?? []
+            guard !Task.isCancelled else { return }
+            self?.applyChoices(choices)
+            self?.choiceRefreshTask = nil
         }
     }
 
@@ -519,19 +555,27 @@ private final class ShortcutItemButton: UIControl {
 
 @MainActor
 private final class ShortcutChoiceButton: UIControl {
-    let choice: TmuxWindowChoice
+    private(set) var choice: TmuxWindowChoice
+
+    private let noun: String
+    private let activeLabel: ShortcutPanelLabel
 
     init(choice: TmuxWindowChoice, noun: String, accessibilityPrefix: String) {
         self.choice = choice
+        self.noun = noun
+        // Built for every row, hidden while inactive: the panel stays open
+        // across a switch, so the marker has to move without a rebuild.
+        activeLabel = ShortcutPanelLabel(
+            "ACTIVE",
+            font: UIKitChassis.monoFont(9, weight: .semibold),
+            color: UIKitChassis.signal2
+        )
         super.init(frame: .zero)
         minimumHeight(40)
         accessibilityIdentifier = accessibilityPrefix + choice.tmuxID
         isAccessibilityElement = true
         accessibilityTraits = .button
         hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
-        accessibilityLabel = choice.isActive
-            ? "\(noun.capitalized) \(choice.index), \(choice.name), current \(noun)"
-            : "Switch to \(noun) \(choice.index), \(choice.name)"
 
         let index = ShortcutPanelLabel(
             "\(choice.index)",
@@ -550,18 +594,8 @@ private final class ShortcutChoiceButton: UIControl {
         let spacer = UIView()
         spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
         spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        var content: [UIView] = [index, name, spacer]
-        if choice.isActive {
-            let active = ShortcutPanelLabel(
-                "ACTIVE",
-                font: UIKitChassis.monoFont(9, weight: .semibold),
-                color: UIKitChassis.signal2
-            )
-            active.setContentCompressionResistancePriority(.required, for: .horizontal)
-            content.append(active)
-        }
-
-        let row = UIStackView(arrangedSubviews: content)
+        activeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        let row = UIStackView(arrangedSubviews: [index, name, spacer, activeLabel])
         row.axis = .horizontal
         row.alignment = .center
         row.spacing = 10
@@ -586,11 +620,20 @@ private final class ShortcutChoiceButton: UIControl {
             action: #selector(endPress),
             for: [.touchCancel, .touchDragExit, .touchUpInside, .touchUpOutside]
         )
+        setActive(choice.isActive)
         refreshBackground()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
+
+    func setActive(_ active: Bool) {
+        choice.isActive = active
+        activeLabel.isHidden = !active
+        accessibilityLabel = active
+            ? "\(noun.capitalized) \(choice.index), \(choice.name), current \(noun)"
+            : "Switch to \(noun) \(choice.index), \(choice.name)"
+    }
 
     override var isHighlighted: Bool {
         didSet { refreshBackground() }

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -943,14 +943,17 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
             content: content,
             width: panelWidth,
             select: { [weak self] item in
-                self?.shortcutPopoverController?.dismiss(animated: true)
+                if !item.keepsPanelOpen {
+                    self?.shortcutPopoverController?.dismiss(animated: true)
+                }
                 self?.press(.shortcut(item))
             },
             loadChoices: { [weak self] in
                 await self?.controller?.loadShortcutSwitchChoices()
             },
+            // Switching leaves the panel up: the list is a switchboard, and
+            // hopping windows should not cost a reopen.
             selectChoice: { [weak self] choice in
-                self?.shortcutPopoverController?.dismiss(animated: true)
                 self?.click()
                 self?.controller?.selectShortcutSwitchChoice(choice)
             }

--- a/Multiplex/Views/Terminal/UMDBarUIKit.swift
+++ b/Multiplex/Views/Terminal/UMDBarUIKit.swift
@@ -981,20 +981,21 @@ final class UMDBarViewController: UIViewController,
             width: panelWidth,
             select: { [weak self] item in
                 guard let self else { return }
-                self.shortcutPopoverController?.dismiss(animated: true) {
-                    self.resumeFocusAfterShortcutPresentationIfNeeded()
+                if !item.keepsPanelOpen {
+                    self.shortcutPopoverController?.dismiss(animated: true) {
+                        self.resumeFocusAfterShortcutPresentationIfNeeded()
+                    }
                 }
                 self.configuration.controller?.performPanelShortcut(item)
             },
             loadChoices: { [weak controller = configuration.controller] in
                 await controller?.loadShortcutSwitchChoices()
             },
+            // Switching leaves the panel up: the list is a switchboard, and
+            // hopping workspaces should not cost a reopen. Focus resumes
+            // when the panel is actually dismissed.
             selectChoice: { [weak self] choice in
-                guard let self else { return }
-                self.shortcutPopoverController?.dismiss(animated: true) {
-                    self.resumeFocusAfterShortcutPresentationIfNeeded()
-                }
-                self.configuration.controller?.selectShortcutSwitchChoice(choice)
+                self?.configuration.controller?.selectShortcutSwitchChoice(choice)
             }
         )
         shortcutPopoverController = panel

--- a/MultiplexTests/HerdrShortcutTests.swift
+++ b/MultiplexTests/HerdrShortcutTests.swift
@@ -59,6 +59,15 @@ final class HerdrShortcutTests: XCTestCase {
         XCTAssertEqual(HerdrShortcut.closeWorkspace.command, "close_workspace")
     }
 
+    func testOnlyMovementRowsLeaveThePanelOpen() {
+        XCTAssertEqual(
+            Set(HerdrShortcut.allCases.filter(\.keepsPanelOpen)),
+            [.nextPane, .nextTab, .previousTab]
+        )
+        XCTAssertTrue(ShortcutPanelItem(HerdrShortcut.nextTab).keepsPanelOpen)
+        XCTAssertFalse(ShortcutPanelItem(HerdrShortcut.closeTab).keepsPanelOpen)
+    }
+
     func testEveryShortcutAppearsInExactlyOneMenuGroup() {
         let grouped = HerdrShortcut.Group.allCases.flatMap(HerdrShortcut.shortcuts(in:))
 

--- a/MultiplexTests/ShortcutPanelUIKitTests.swift
+++ b/MultiplexTests/ShortcutPanelUIKitTests.swift
@@ -119,6 +119,13 @@ final class ShortcutPanelUIKitTests: XCTestCase {
             closePane.accessibilityLabel,
             "Close Pane, kill-pane, press twice to confirm"
         )
+
+        // The panel survives a switch, so the ACTIVE marker has to move with
+        // the selection rather than wait for a reopen.
+        XCTAssertEqual(deploy.accessibilityLabel, "Window 1, deploy, current window")
+        XCTAssertEqual(active.accessibilityLabel, "Switch to window 0, main")
+        XCTAssertEqual(visibleText(in: deploy).filter { $0 == "ACTIVE" }.count, 1)
+        XCTAssertTrue(visibleText(in: active).allSatisfy { $0 != "ACTIVE" })
     }
 
     func testManyWindowsUseCappedInternalScrollRegion() {
@@ -155,6 +162,12 @@ final class ShortcutPanelUIKitTests: XCTestCase {
 
     private func renderedText(in root: UIView) -> [String] {
         descendants(of: UILabel.self, in: root).compactMap { $0.text ?? $0.attributedText?.string }
+    }
+
+    private func visibleText(in root: UIView) -> [String] {
+        descendants(of: UILabel.self, in: root)
+            .filter { !$0.isHidden }
+            .compactMap { $0.text ?? $0.attributedText?.string }
     }
 
     private func descendants<T: UIView>(of type: T.Type, in root: UIView) -> [T] {

--- a/MultiplexTests/TmuxShortcutTests.swift
+++ b/MultiplexTests/TmuxShortcutTests.swift
@@ -109,6 +109,26 @@ final class TmuxShortcutTests: XCTestCase {
         ))
     }
 
+    func testOnlyMovementRowsLeaveThePanelOpen() {
+        XCTAssertEqual(
+            Set(TmuxShortcut.allCases.filter(\.keepsPanelOpen)),
+            [.nextPane, .togglePaneZoom, .nextWindow, .previousWindow, .lastWindow]
+        )
+        // Anything that leaves you looking at the terminal — a new pane, a
+        // prompt, a mode, a close — must uncover it.
+        for shortcut in [
+            TmuxShortcut.splitLeftRight, .splitTopBottom, .copyMode, .closePane,
+            .newWindow, .chooseWindow, .renameWindow, .closeWindow,
+        ] {
+            XCTAssertFalse(shortcut.keepsPanelOpen, "\(shortcut) should dismiss")
+            XCTAssertFalse(
+                ShortcutPanelItem(shortcut).keepsPanelOpen,
+                "\(shortcut) should dismiss through the panel item too"
+            )
+        }
+        XCTAssertTrue(ShortcutPanelItem(TmuxShortcut.nextWindow).keepsPanelOpen)
+    }
+
     func testEveryShortcutAppearsInExactlyOneMenuGroup() {
         let grouped = TmuxShortcut.Group.allCases.flatMap(TmuxShortcut.shortcuts(in:))
 

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -12,6 +12,7 @@ NEW SINCE 1.3.0
 • OPEN FILE FROM SHORTCUTS — host, remote path, optional line number, opened read-only in a ▤ tab. `Sources/App.swift:10-15` highlights the range.
 • SCROLLING NO LONGER SWITCHES HERDR TABS (Vision Pro) — wheel events stay pinned to where the scroll began, off herdr's tab bar and the tmux status line.
 • HOST KEYS ARE VERIFIED — every connection checks the server against the host's recorded fingerprints (Bind Host, a pasted key in Add Host → Host key, or pinned on first connection). Host Settings → Host key lists them, with FORGET.
+• MOVING AROUND KEEPS THE SHORTCUT PANEL OPEN — in TMUX / HRDR shortcuts, the switch list and the movement rows (NEXT PANE, TOGGLE ZOOM, NEXT / PREVIOUS / LAST WINDOW, NEXT / PREVIOUS TAB) no longer close the panel, and ACTIVE follows where you land, so you can hop through several in a row. Rows that split, create, rename, close, or open Copy Mode still close it.
 • THE LAUNCH CARD RETURNS FOR 1.3.1 — the first launch after updating shows what 1.3.1 changed; FULL NOTES and Settings → About → What's New bank 1.3.1 above 1.3.
 
 PLEASE TRY

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,26 +1,11 @@
-NEW SINCE 1.3.0
-• FILE VIEWER AND VIEWPORT BARS FLOAT BELOW THE WINDOW (Vision Pro) — the ▤ and ⌗ bottom bars now sit outside the window, clear of the resize corners, holding their size as it resizes. File Viewer keeps one control row; the viewport gets back/reload, address, SYSTEM/CLOSE. iPad unchanged.
-• MARKDOWN IMAGES SHOW ON A PRESS — in a rendered README the “image: …” placeholder is a link. Press it and the picture appears inline, sized to the text column; press the caption to hide it, tap for full-screen. Web-hosted images go through the link confirmation, which now offers a docked ⌗ VIEWPORT — nothing is fetched until you press.
-• SELECT BLOCK STAYS WHERE YOU PRESSED — the SELECT / SELECT ALL / PASTE block and the SELECT TEXT bar no longer drift up on mosh tabs or in scrollback, and Select Text waits for a second client's resize to settle before clamping.
-• MOSH TABS NO LONGER GROW A JUNK SCROLL AREA — stale frames were archived above the live screen on every keyboard show/hide. Mosh tabs now hold only the live screen.
-• FILE PATHS WORK IN SPLIT PANES — a path wrapped at a pane border is stitched back together, never picks up the neighbouring pane's text, and a relative path opens against its own pane.
-• TMUX + MOSH FIXES — TMUX split shortcuts no longer type `%` on iPad; File Viewer starts in the current tmux or herdr pane directory.
-• RESTORE PURCHASES FIXED ON TESTFLIGHT — when the backend rejects the sync, Restore checks your owned purchases directly, and errors name something you can act on.
-• SMOOTHER STREAMING OUTPUT ON VISION PRO — repaints align to the 90 Hz display instead of a 60 Hz clock.
-• METAL RENDERER OPTION — Settings → Terminal renderer draws terminal text on the GPU. Off by default; applies to new windows.
-• KEY RAIL SITS ON THE WINDOW EDGE — on iPad (and iPhone landscape) the key rail runs to the bottom edge instead of floating above the home-indicator strip.
-• OPEN FILE FROM SHORTCUTS — host, remote path, optional line number, opened read-only in a ▤ tab. `Sources/App.swift:10-15` highlights the range.
-• SCROLLING NO LONGER SWITCHES HERDR TABS (Vision Pro) — wheel events stay pinned to where the scroll began, off herdr's tab bar and the tmux status line.
-• HOST KEYS ARE VERIFIED — every connection checks the server against the host's recorded fingerprints (Bind Host, a pasted key in Add Host → Host key, or pinned on first connection). Host Settings → Host key lists them, with FORGET.
-• MOVING AROUND KEEPS THE SHORTCUT PANEL OPEN — in TMUX / HRDR shortcuts, the switch list and the movement rows (NEXT PANE, TOGGLE ZOOM, NEXT / PREVIOUS / LAST WINDOW, NEXT / PREVIOUS TAB) no longer close the panel, and ACTIVE follows where you land, so you can hop through several in a row. Rows that split, create, rename, close, or open Copy Mode still close it.
-• THE LAUNCH CARD RETURNS FOR 1.3.1 — the first launch after updating shows what 1.3.1 changed; FULL NOTES and Settings → About → What's New bank 1.3.1 above 1.3.
+NEW SINCE 1.3.1
+• MOVING AROUND KEEPS THE SHORTCUT PANEL OPEN — in the terminal's TMUX / HRDR shortcut panel, the window/workspace switch list and the movement rows (NEXT PANE, TOGGLE ZOOM, NEXT / PREVIOUS / LAST WINDOW, NEXT / PREVIOUS TAB) no longer close the panel, and ACTIVE follows where you land. Rows that split, create, rename, close, or open Copy Mode still close it, so the terminal is never left covered.
 
 PLEASE TRY
-1. Vision Pro: open a ▤ File Viewer and a ⌗ viewport tab — both bars should float below the window, clear of the resize corners, holding width as you resize, every button working.
-2. Press “image: …” placeholders in a README — `../assets/x.png`, a %20-escaped space, one with a "title". Hide by caption, then resize the tab and text size with pictures open. An https:// image must raise the confirmation, not fetch.
-3. iPad: both TMUX split shortcuts (no `%`), then File Viewer from non-home tmux and herdr panes.
-4. In a split, long-press a path that wraps at the pane border — the confirmation should show all of it. Then `cd` the panes into different repos and press a relative path in the inactive pane.
-5. Shortcuts → Open File: an absolute path with a line number, then `:10-15`, then a bare filename.
-6. First launch after updating: the What's New card shows 1.3.1 once, and FULL NOTES lists 1.3.1 above 1.3.
+1. Attach a tmux session with three or more windows, open the panel (TMUX on the key rail / the shortcut button on Vision Pro), and tap through the switch list — the panel should stay up and ACTIVE should move to the row you picked.
+2. From the same open panel press NEXT WINDOW twice, then LAST WINDOW: the session should follow every press and ACTIVE should settle on the window you end up in.
+3. Press CLOSE PANE / CLOSE WINDOW once, then a switch row — the armed "press again to close" state must clear, not fire.
+4. Confirm the panel still closes on COPY MODE, a split, NEW WINDOW, RENAME, and on the second press of a close row.
+5. herdr hosts: the same passes with NEXT PANE and NEXT / PREVIOUS TAB, and the Switch Workspace list.
 
 Feedback: screenshot in TestFlight

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,11 +1,7 @@
 NEW SINCE 1.3.1
-• MOVING AROUND KEEPS THE SHORTCUT PANEL OPEN — in the terminal's TMUX / HRDR shortcut panel, the window/workspace switch list and the movement rows (NEXT PANE, TOGGLE ZOOM, NEXT / PREVIOUS / LAST WINDOW, NEXT / PREVIOUS TAB) no longer close the panel, and ACTIVE follows where you land. Rows that split, create, rename, close, or open Copy Mode still close it, so the terminal is never left covered.
+• THE SHORTCUT PANEL STAYS OPEN WHILE YOU MOVE — in the TMUX / HRDR panel, the window/workspace switch list and the movement rows keep the panel up, with ACTIVE following where you land. Splits, new/rename/close and Copy Mode still close it.
 
 PLEASE TRY
-1. Attach a tmux session with three or more windows, open the panel (TMUX on the key rail / the shortcut button on Vision Pro), and tap through the switch list — the panel should stay up and ACTIVE should move to the row you picked.
-2. From the same open panel press NEXT WINDOW twice, then LAST WINDOW: the session should follow every press and ACTIVE should settle on the window you end up in.
-3. Press CLOSE PANE / CLOSE WINDOW once, then a switch row — the armed "press again to close" state must clear, not fire.
-4. Confirm the panel still closes on COPY MODE, a split, NEW WINDOW, RENAME, and on the second press of a close row.
-5. herdr hosts: the same passes with NEXT PANE and NEXT / PREVIOUS TAB, and the Switch Workspace list.
+1. Open the panel on a session with three or more windows and hop through the switch list, then NEXT / LAST WINDOW — the panel should stay up and ACTIVE should follow.
 
 Feedback: screenshot in TestFlight


### PR DESCRIPTION
Switching windows or workspaces from the TMUX / HRDR panel's own list — and the movement rows next to it — are switchboard actions, but every one of them dismissed the panel, so a two-window hop cost a reopen.

## The rule

`keepsPanelOpen` on `TmuxShortcut` / `HerdrShortcut` names the split, so the models stay the source of truth and neither surface (iPad key rail, visionOS UMD) decides on its own:

- **Stays open** — Next Pane, Toggle Pane Zoom, Next / Previous / Last Window (tmux); Next Pane, Next / Previous Tab (herdr); plus the switch list itself.
- **Dismisses** — splits, New Window/Tab/Workspace, Choose Window, Rename, Copy Mode, and the confirmed closes. What those leave behind is the terminal, and it must not stay covered.

## Consequences handled

- The switch rows re-mark ACTIVE in place, so a row's ACTIVE label is now built for every row and hidden while inactive rather than added conditionally at build time.
- Next / Previous / Last Window move that same marker, and the binding travels through the terminal — so the panel re-reads the window list 600 ms after such a row instead of guessing the destination. The refresh is cancelled if the panel closes first.
- On visionOS, focus resumption is unaffected: it already ran from `presentationControllerDidDismiss`, which now fires when the panel is actually dismissed.

## Verification

- `./Tools/build.sh lint` — 0 violations.
- `MultiplexTests` green on visionOS and iPad. New: `testOnlyMovementRowsLeaveThePanelOpen` in both shortcut test files; the panel's window-choice test now asserts ACTIVE moves to the picked row and leaves the old one.
- Driven by hand on the iPad simulator against the dev-sshd harness (tmux `main`, 3 windows): hopping windows from both the switch list and the movement rows keeps the panel up with ACTIVE following; Copy Mode and the splits still dismiss; the two-press closes are unchanged.
- Changelog bullet appended to `fastlane/testflight-whats-new.txt`; `ruby Tools/check-metadata.rb` passes.