### PR TITLE
Let dictation listen in any preferred language

### DIFF
--- a/Multiplex/Models/DictationLanguages.swift
+++ b/Multiplex/Models/DictationLanguages.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// One language the dictation mic can listen in: a recognizer-supported
+/// locale matched to one of the user's preferred languages.
+struct DictationLanguageChoice: Equatable, Identifiable {
+    /// The recognizer's own locale identifier (`"zh-TW"`, `"en-US"`) — what
+    /// the Speech engines are handed, not necessarily what Settings shows.
+    let id: String
+    /// The language named in itself — "English", "中文", "日本語" — the way
+    /// the system's own language pickers label their rows.
+    let name: String
+    /// The region tag ("US", "TW") that keeps two variants of one language
+    /// apart in the menu; empty when the identifier carries none.
+    let region: String
+
+    /// "EN·US" — the compact face of the bar's language chip; the endonym
+    /// is the menu's job, where there is room to spell it.
+    var tag: String {
+        id.uppercased().replacingOccurrences(of: "-", with: "·")
+    }
+}
+
+/// Builds the dictation language menu the way the system keyboard builds its
+/// own: the user's preferred languages (Settings → General → Language &
+/// Region), in their order, kept only where the speech recognizer actually
+/// supports the language.
+enum DictationLanguages {
+    /// `preferred` is `Locale.preferredLanguages`; `supported` is the
+    /// recognizer's locale identifiers. Order follows `preferred`; languages
+    /// the recognizer cannot hear are silently dropped, and two preferred
+    /// entries that resolve to the same recognizer locale (zh-Hant beside
+    /// zh-Hant-TW) collapse into one.
+    static func choices(
+        preferred: [String],
+        supported: some Sequence<String>
+    ) -> [DictationLanguageChoice] {
+        // Shorter identifier first, so a language's plain entry ("hi-IN")
+        // beats its variant siblings ("hi-IN-translit") when both collapse
+        // to the same skeleton — `supported` arrives as an unordered set.
+        var supportedBySkeleton: [String: String] = [:]
+        for identifier in supported.sorted(by: { ($0.count, $0) < ($1.count, $1) }) {
+            let key = skeleton(identifier)
+            if supportedBySkeleton[key] == nil { supportedBySkeleton[key] = identifier }
+        }
+
+        var taken: Set<String> = []
+        return preferred.compactMap { language in
+            guard let match = resolve(language, in: supportedBySkeleton),
+                  taken.insert(match).inserted
+            else { return nil }
+            let locale = Locale(identifier: match)
+            return DictationLanguageChoice(
+                id: match,
+                name: displayName(match, in: locale),
+                region: locale.region?.identifier ?? ""
+            )
+        }
+    }
+
+    /// One preferred language → the recognizer locale that hears it, or nil.
+    ///
+    /// A real device tags EVERY preferred language with the device's own
+    /// region — a Taiwan-region phone reports "en-TW" and "ja-TW", locales
+    /// no recognizer has — so an exact match alone made the menu collapse to
+    /// one row on real hardware while seeded simulators looked fine. When
+    /// exact fails, the region is dropped and the language retried in its
+    /// own home region ("en-TW" → "en" → en-Latn-US → en-US), keeping the
+    /// script so zh-Hant can never fall to Simplified. The last resort is
+    /// any supported locale of the same language and script, in sorted
+    /// order so the answer never depends on set ordering.
+    private static func resolve(
+        _ language: String,
+        in supportedBySkeleton: [String: String]
+    ) -> String? {
+        if let exact = supportedBySkeleton[skeleton(language)] { return exact }
+
+        var components = Locale.Language.Components(
+            identifier: Locale.Language(identifier: language).maximalIdentifier
+        )
+        components.region = nil
+        let regionless = Locale.Language(components: components)
+        if let home = supportedBySkeleton[regionless.maximalIdentifier.lowercased()] {
+            return home
+        }
+
+        // The map's keys ARE lowercased maximal identifiers, so same
+        // language + script is a prefix match on them — no re-maximalizing
+        // the candidates. Smallest key wins for determinism.
+        guard let code = regionless.languageCode?.identifier,
+              let script = regionless.script?.identifier
+        else { return nil }
+        let prefix = "\(code)-\(script)-".lowercased()
+        return supportedBySkeleton
+            .filter { $0.key.hasPrefix(prefix) }
+            .min { $0.key < $1.key }?
+            .value
+    }
+
+    /// The persisted pick, or nil when nothing valid is stored — the stored
+    /// language may have left the preferred list since it was chosen, and a
+    /// stale pick must fall back to the system default rather than keep
+    /// dictating in a language the user removed.
+    static func chosen(
+        stored: String?,
+        among choices: [DictationLanguageChoice]
+    ) -> DictationLanguageChoice? {
+        guard let stored else { return nil }
+        return choices.first { $0.id == stored }
+    }
+
+    /// What the LISTENING bar's chip shows and the menu marks, or nil when
+    /// there is no real choice — one preferred language means no chip,
+    /// matching the system keyboard's dictation. With nothing stored the
+    /// effective language is the top preferred one, which is what the
+    /// system-default recognizer listens in.
+    static func effective(
+        stored: String?,
+        among choices: [DictationLanguageChoice]
+    ) -> DictationLanguageChoice? {
+        guard choices.count > 1 else { return nil }
+        return chosen(stored: stored, among: choices) ?? choices.first
+    }
+
+    /// Two identifiers name the same dictation language when their maximal
+    /// forms agree: "zh-Hant-TW", "zh-Hant", and "zh-TW" all maximize to
+    /// zh-Hant-TW, and a bare "en" picks up Latn/US the same way the system
+    /// does — one rule covers script-tagged preferred languages, region-less
+    /// ones, and the recognizer's script-less identifiers alike.
+    private static func skeleton(_ identifier: String) -> String {
+        Locale.Language(identifier: identifier).maximalIdentifier.lowercased()
+    }
+
+    private static func displayName(_ identifier: String, in locale: Locale) -> String {
+        guard let code = locale.language.languageCode?.identifier,
+              let name = locale.localizedString(forLanguageCode: code)
+        else { return identifier }
+        // Endonyms arrive lowercased in many languages ("français"); the
+        // pickers this mirrors show them as titles.
+        return name.prefix(1).localizedUppercase + name.dropFirst()
+    }
+}

--- a/Multiplex/Services/DictationAnalyzer.swift
+++ b/Multiplex/Services/DictationAnalyzer.swift
@@ -45,12 +45,15 @@ final class DictationAnalyzer {
         self.feed = feed
     }
 
-    /// Build one for this device's language, or nil when it cannot run here —
+    /// Build one for the take's language, or nil when it cannot run here —
     /// an unsupported locale, or a model that is not installed. The caller
     /// falls back to `SFSpeechRecognizer` rather than failing the dictation.
-    static func make(inputFormat: AVAudioFormat) async -> DictationAnalyzer? {
+    static func make(
+        inputFormat: AVAudioFormat,
+        locale: Locale
+    ) async -> DictationAnalyzer? {
         guard let locale = await DictationTranscriber.supportedLocale(
-            equivalentTo: Locale.current
+            equivalentTo: locale
         ) else {
             logger.debug("dictation-analyzer-unsupported-locale")
             return nil

--- a/Multiplex/Services/DictationLanguageSetting.swift
+++ b/Multiplex/Services/DictationLanguageSetting.swift
@@ -1,0 +1,74 @@
+#if !os(visionOS)
+import Foundation
+import Speech
+
+/// The dictation language pick, persisted app-wide: dictation is one feature
+/// reachable from two mic controls, and a language chosen at either applies
+/// everywhere. Nothing stored — the default — means the system language,
+/// exactly the behavior before picking existed.
+@MainActor
+enum DictationLanguageSetting {
+    nonisolated static let key = "MultiplexDictationLanguage"
+
+    /// What the recognizer can hear never changes within a run; the XPC
+    /// round trip behind `supportedLocales()` is paid once.
+    private static let supportedIdentifiers: [String] =
+        SFSpeechRecognizer.supportedLocales().map(\.identifier)
+
+    /// The LISTENING bar re-renders on every hypothesis while someone is
+    /// speaking, and building the menu walks ICU for every identifier —
+    /// memoized on the preferred-language list, which is also what
+    /// invalidates it when Settings change mid-run.
+    private static var cache: (preferred: [String], choices: [DictationLanguageChoice])?
+
+    /// The menu: preferred languages the recognizer can hear.
+    static func choices() -> [DictationLanguageChoice] {
+        let preferred = Locale.preferredLanguages
+        if let cache, cache.preferred == preferred { return cache.choices }
+        let built = DictationLanguages.choices(
+            preferred: preferred,
+            supported: supportedIdentifiers
+        )
+        cache = (preferred, built)
+        return built
+    }
+
+    /// The persisted pick, resolved against today's menu — nil when nothing
+    /// valid is stored, meaning the system default.
+    static func chosen(defaults: UserDefaults = .standard) -> DictationLanguageChoice? {
+        DictationLanguages.chosen(
+            stored: defaults.string(forKey: key),
+            among: choices()
+        )
+    }
+
+    /// The locale handed to the recognition engines, or nil for the system
+    /// default (the engines' own no-locale initializers).
+    static func chosenLocale(defaults: UserDefaults = .standard) -> Locale? {
+        chosen(defaults: defaults).map { Locale(identifier: $0.id) }
+    }
+
+    /// What the LISTENING bar's chip shows, resolved against an
+    /// already-built menu so a render pays for the list once.
+    static func effectiveChoice(
+        among choices: [DictationLanguageChoice],
+        defaults: UserDefaults = .standard
+    ) -> DictationLanguageChoice? {
+        DictationLanguages.effective(
+            stored: defaults.string(forKey: key),
+            among: choices
+        )
+    }
+
+    nonisolated static func setChosen(
+        _ identifier: String?,
+        defaults: UserDefaults = .standard
+    ) {
+        if let identifier {
+            defaults.set(identifier, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}
+#endif

--- a/Multiplex/Services/DictationSession.swift
+++ b/Multiplex/Services/DictationSession.swift
@@ -111,6 +111,10 @@ final class DictationSession {
         set { analyzerBox = newValue }
     }
     private var recognizer: SFSpeechRecognizer?
+    /// The take's language, decided at `start` and held for its whole life —
+    /// nil means the system language. A pick made mid-take applies to the
+    /// next one; the recognizer heard this whole take in one language.
+    private var locale: Locale?
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
     private var onStart: (() -> Void)?
@@ -151,7 +155,9 @@ final class DictationSession {
     /// ready to send verbatim. `onPending` tracks what has been heard but not
     /// yet typed. `onFinish` is called exactly once per start, including when
     /// authorization is refused or another session takes the mic away.
+    /// `locale` is the language to listen in; nil means the system language.
     func start(
+        locale: Locale? = nil,
         onStart: @escaping () -> Void,
         onText: @escaping (String) -> Void,
         onPending: @escaping (String) -> Void,
@@ -159,6 +165,7 @@ final class DictationSession {
     ) {
         guard !isListening else { return }
         Self.active?.cancel()
+        self.locale = locale
         self.onStart = onStart
         self.onText = onText
         self.onPending = onPending
@@ -280,11 +287,14 @@ final class DictationSession {
         // languages whose dictation model is not installed.
         let inputFormat = engine.inputNode.outputFormat(forBus: 0)
         if #available(iOS 26, *) {
-            analyzer = await DictationAnalyzer.make(inputFormat: inputFormat)
+            analyzer = await DictationAnalyzer.make(
+                inputFormat: inputFormat,
+                locale: locale ?? .current
+            )
         }
         guard onFinish != nil, !isListening else { return }
         if analyzerBox == nil {
-            guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            guard let recognizer = makeRecognizer(), recognizer.isAvailable else {
                 deliver(.failure("Dictation isn't available for this language"))
                 return
             }
@@ -309,7 +319,7 @@ final class DictationSession {
         segmentStart = nil
         observeAudioDisruption()
         Self.logger.debug(
-            "dictation-start engine=\(self.analyzerBox == nil ? "sfspeech" : "analyzer", privacy: .public) onDevice=\(self.onDeviceRecognition, privacy: .public)"
+            "dictation-start engine=\(self.analyzerBox == nil ? "sfspeech" : "analyzer", privacy: .public) onDevice=\(self.onDeviceRecognition, privacy: .public) locale=\(self.locale?.identifier ?? "system", privacy: .public)"
         )
         onStart?()
         onStart = nil
@@ -556,7 +566,7 @@ final class DictationSession {
         analyzerBox = nil
         audioSink.useAnalyzer(nil)
         if recognizer == nil {
-            recognizer = SFSpeechRecognizer()
+            recognizer = makeRecognizer()
             onDeviceRecognition = recognizer?.supportsOnDeviceRecognition ?? false
         }
         guard recognizer?.isAvailable == true else {
@@ -564,6 +574,13 @@ final class DictationSession {
             return
         }
         beginSegment()
+    }
+
+    /// The chosen language's recognizer, or the system one when nothing was
+    /// chosen — the same either/or in both places that build one.
+    private func makeRecognizer() -> SFSpeechRecognizer? {
+        if let locale { return SFSpeechRecognizer(locale: locale) }
+        return SFSpeechRecognizer()
     }
 
     /// The recognizer has finalized these words: it will not revise them, so

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -1176,6 +1176,22 @@ final class TerminalSessionController {
         dictationSession?.cancel()
     }
 
+    /// The LISTENING bar's language chip: persist the pick, and when a take
+    /// is live restart it in the new language — the recognizer heard the old
+    /// one, and "applies next time" from a control pressed mid-take would
+    /// read as the pick not working. The restart abandons only the unsettled
+    /// queue; words already typed stay, like any cancel. A full restart, not
+    /// an in-place engine swap: a recognition task created while the daemon
+    /// tears its predecessor down comes back dead (the session's whole
+    /// restart-backoff ladder exists for that), and the well-worn start path
+    /// costs one bar blink.
+    func selectDictationLanguage(_ choice: DictationLanguageChoice) {
+        DictationLanguageSetting.setChosen(choice.id)
+        guard dictationRequested else { return }
+        dictationSession?.cancel()
+        startDictation()
+    }
+
     private func startDictation() {
         guard status == .live else { return }
         // The jump search owns the pane's input while it pages the remote
@@ -1187,6 +1203,7 @@ final class TerminalSessionController {
         let session = dictationSession ?? DictationSession()
         dictationSession = session
         session.start(
+            locale: DictationLanguageSetting.chosenLocale(),
             onStart: { [weak self] in
                 guard let self, dictationRequested else { return }
                 dictation = .listening("")

--- a/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
@@ -458,10 +458,16 @@ final class TerminalPaneViewController: UIViewController, UIDropInteractionDeleg
         #if !os(visionOS)
         if let dictation = state.dictation {
             guard !state.tmuxCopyModeUIActive else { return }
+            let languageChoices = DictationLanguageSetting.choices()
             let bar = TerminalContextBarView.dictation(
                 dictation,
+                language: DictationLanguageSetting.effectiveChoice(among: languageChoices),
+                choices: languageChoices,
                 stop: { [weak controller] in controller?.stopDictation() },
-                cancel: { [weak controller] in controller?.cancelDictation() }
+                cancel: { [weak controller] in controller?.cancelDictation() },
+                selectLanguage: { [weak controller] choice in
+                    controller?.selectDictationLanguage(choice)
+                }
             )
             bar.accessibilityIdentifier = "terminalPane.context.dictation"
             topCenterStack.addArrangedSubview(bar)
@@ -1002,14 +1008,29 @@ extension TerminalContextBarView {
     #if !os(visionOS)
     static func dictation(
         _ state: TerminalSessionController.DictationState,
+        language: DictationLanguageChoice?,
+        choices: [DictationLanguageChoice],
         stop: @escaping () -> Void,
-        cancel: @escaping () -> Void
+        cancel: @escaping () -> Void,
+        selectLanguage: @escaping (DictationLanguageChoice) -> Void
     ) -> TerminalContextBarView {
         switch state {
         case .listening(let pending):
             var items: [UIView] = [
                 UIKitTallyLamp(caption: "LISTENING", color: TallyPalette.tally),
             ]
+            if let language {
+                // The language lives in the bar, visible every take — a
+                // long-press on the mic was tried first and nobody would
+                // ever find it. The rows are the system's own menu: it
+                // does not need TALLY dress, and native padding beats a
+                // hand-built popover fighting iOS 26's corner curves.
+                items.append(Self.languageMenuButton(
+                    language: language,
+                    choices: choices,
+                    select: selectLanguage
+                ))
+            }
             if !pending.isEmpty {
                 let pendingLabel = UILabel()
                 pendingLabel.text = pending
@@ -1046,6 +1067,75 @@ extension TerminalContextBarView {
                 messageLabel,
             ])
         }
+    }
+
+    /// The bar's language control: a TALLY-bordered face over a native
+    /// `UIMenu` — the rows are the system's, so padding, checkmarks, and
+    /// dismissal come for free.
+    private static func languageMenuButton(
+        language: DictationLanguageChoice,
+        choices: [DictationLanguageChoice],
+        select: @escaping (DictationLanguageChoice) -> Void
+    ) -> UIView {
+        let button = UIButton(type: .custom)
+        button.accessibilityIdentifier = "terminalPane.dictation.language"
+        button.accessibilityLabel =
+            "Dictation language: \(language.name) \(language.region). Change"
+        button.showsMenuAsPrimaryAction = true
+        button.menu = UIMenu(
+            title: "Dictation language",
+            options: .singleSelection,
+            children: choices.map { choice in
+                UIAction(
+                    title: choice.region.isEmpty
+                        ? choice.name
+                        : "\(choice.name) (\(choice.region))",
+                    state: choice.id == language.id ? .on : .off
+                ) { _ in select(choice) }
+            }
+        )
+
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(
+            systemName: "globe",
+            withConfiguration: UIImage.SymbolConfiguration(
+                pointSize: 9 * Theme.typeScale,
+                weight: .semibold
+            )
+        )
+        config.imagePadding = 5
+        config.contentInsets = NSDirectionalEdgeInsets(
+            top: 5, leading: 9, bottom: 5, trailing: 9
+        )
+        var title = AttributedString(language.tag)
+        title.font = UIKitChassis.monoFont(9, weight: .semibold)
+        title.kern = 0.7
+        title.foregroundColor = UIKitChassis.signal2
+        config.attributedTitle = title
+        button.configuration = config
+        button.tintColor = UIKitChassis.signal2
+        button.hoverStyle = UIHoverStyle(
+            effect: .highlight,
+            shape: .rect(cornerRadius: 2)
+        )
+
+        // The chip family's dress: one-point border on strata ground.
+        let shell = UIKitTallyBorderedView()
+        shell.backgroundColor = GlassPrototype.enabled
+            ? GlassPrototype.material(
+                GlassPrototype.strataMaterial,
+                fallback: TallyPalette.chassis
+            )
+            : UIKitChassis.chassis
+        shell.addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            button.leadingAnchor.constraint(equalTo: shell.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: shell.trailingAnchor),
+            button.topAnchor.constraint(equalTo: shell.topAnchor),
+            button.bottomAnchor.constraint(equalTo: shell.bottomAnchor),
+        ])
+        return shell
     }
     #endif
 

--- a/MultiplexTests/DictationLanguageMenuUIKitTests.swift
+++ b/MultiplexTests/DictationLanguageMenuUIKitTests.swift
@@ -1,0 +1,71 @@
+#if !os(visionOS)
+import UIKit
+import XCTest
+@testable import Multiplex
+
+/// The LISTENING bar's language control: a native `UIMenu` behind a chip
+/// face. Built and inspected scene-less — menus are introspectable without
+/// presenting anything.
+@MainActor
+final class DictationLanguageMenuUIKitTests: XCTestCase {
+    private let english = DictationLanguageChoice(
+        id: "en-US", name: "English", region: "US"
+    )
+    private let chinese = DictationLanguageChoice(
+        id: "zh-TW", name: "中文", region: "TW"
+    )
+
+    func testTheListeningBarCarriesTheLanguageMenuOnlyWithARealChoice() throws {
+        let bar = TerminalContextBarView.dictation(
+            .listening(""),
+            language: chinese,
+            choices: [english, chinese],
+            stop: {}, cancel: {}, selectLanguage: { _ in }
+        )
+        let button = try XCTUnwrap(languageButton(in: bar))
+        XCTAssertTrue(button.showsMenuAsPrimaryAction)
+        XCTAssertEqual(
+            button.accessibilityLabel,
+            "Dictation language: 中文 TW. Change"
+        )
+        let actions = try XCTUnwrap(button.menu?.children as? [UIAction])
+        XCTAssertEqual(actions.map(\.title), ["English (US)", "中文 (TW)"])
+        // The mark sits on the effective language, so the menu tells the
+        // truth before any pick exists.
+        XCTAssertEqual(actions.map(\.state), [.off, .on])
+
+        // One preferred language means nothing to choose: no chip at all.
+        let single = TerminalContextBarView.dictation(
+            .listening(""),
+            language: nil,
+            choices: [english],
+            stop: {}, cancel: {}, selectLanguage: { _ in }
+        )
+        XCTAssertNil(languageButton(in: single))
+    }
+
+    func testThePickRoundTripsThroughItsStore() throws {
+        let suite = "DictationLanguageMenuUIKitTests"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        DictationLanguageSetting.setChosen("zh-TW", defaults: defaults)
+        XCTAssertEqual(
+            defaults.string(forKey: DictationLanguageSetting.key), "zh-TW"
+        )
+        DictationLanguageSetting.setChosen(nil, defaults: defaults)
+        XCTAssertNil(defaults.string(forKey: DictationLanguageSetting.key))
+    }
+
+    private func languageButton(in view: UIView) -> UIButton? {
+        if let button = view as? UIButton,
+           button.accessibilityIdentifier == "terminalPane.dictation.language" {
+            return button
+        }
+        for child in view.subviews {
+            if let found = languageButton(in: child) { return found }
+        }
+        return nil
+    }
+}
+#endif

--- a/MultiplexTests/DictationLanguagesTests.swift
+++ b/MultiplexTests/DictationLanguagesTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import Multiplex
+
+final class DictationLanguagesTests: XCTestCase {
+    /// The recognizer identifiers that matter for these cases, as
+    /// `SFSpeechRecognizer.supportedLocales()` reports them (script-less,
+    /// hyphenated, unordered).
+    private let supported: Set<String> = [
+        "en-US", "en-GB", "en-AU", "ja-JP", "ko-KR",
+        "zh-TW", "zh-CN", "zh-HK", "yue-CN", "fr-FR", "es-419",
+        "hi-IN", "hi-IN-translit", "hi-Latn",
+    ]
+
+    // MARK: Building the menu
+
+    func testMenuKeepsSettingsOrderAndDropsUnheardLanguages() {
+        let choices = DictationLanguages.choices(
+            preferred: ["ja-JP", "en-US", "en-GB", "eo"],
+            supported: supported
+        )
+        XCTAssertEqual(choices.map(\.id), ["ja-JP", "en-US", "en-GB"])
+    }
+
+    /// Settings spells languages the recognizer doesn't: script tags
+    /// ("zh-Hant-TW" for Speech's "zh-TW"), region-less entries ("en",
+    /// "zh-Hant"), and two spellings of one language. All must land on one
+    /// recognizer locale each, in Settings order.
+    func testSettingsSpellingsCollapseOntoRecognizerLocales() {
+        let choices = DictationLanguages.choices(
+            preferred: ["zh-Hant", "zh-Hant-TW", "en"],
+            supported: supported
+        )
+        XCTAssertEqual(choices.map(\.id), ["zh-TW", "en-US"])
+    }
+
+    /// A real device tags EVERY preferred language with the device's own
+    /// region: a Taiwan phone reports "en-TW" and "ja-TW", locales no
+    /// recognizer has — those must land on the language's home locale, not
+    /// vanish (shipped-and-caught: the menu collapsed to one row on every
+    /// real device). The fallback must also never cross scripts:
+    /// "zh-Hant-US" is zh-TW, never Simplified.
+    func testDeviceRegionTaggedLanguagesLandOnTheLanguagesHomeLocale() {
+        let choices = DictationLanguages.choices(
+            preferred: ["zh-Hant-US", "en-TW", "ja-TW"],
+            supported: supported
+        )
+        XCTAssertEqual(choices.map(\.id), ["zh-TW", "en-US", "ja-JP"])
+    }
+
+    /// The recognizer ships variant siblings of one language (hi-IN beside
+    /// hi-IN-translit). The plain identifier must win deterministically —
+    /// `supportedLocales()` is a set, and hash order changing the language a
+    /// user dictates in would be a ghost bug.
+    func testPlainIdentifierBeatsItsVariantSiblings() {
+        let choices = DictationLanguages.choices(
+            preferred: ["hi-IN"],
+            supported: supported
+        )
+        XCTAssertEqual(choices.map(\.id), ["hi-IN"])
+    }
+
+    func testRowsCarryEndonymRegionAndTag() {
+        let choices = DictationLanguages.choices(
+            preferred: ["ja-JP", "fr-FR"],
+            supported: supported
+        )
+        XCTAssertEqual(choices.map(\.name), ["日本語", "Français"])
+        XCTAssertEqual(choices.map(\.region), ["JP", "FR"])
+        XCTAssertEqual(choices.map(\.tag), ["JA·JP", "FR·FR"])
+    }
+
+    // MARK: Resolving the pick
+
+    /// The pick outlives Settings changes: it resolves while its language
+    /// stays preferred, and a language removed from the list must stop
+    /// being dictated rather than linger via the stale stored identifier.
+    func testStoredPickResolvesOnlyWhileItsLanguageStaysPreferred() {
+        let both = DictationLanguages.choices(
+            preferred: ["en-US", "ja-JP"],
+            supported: supported
+        )
+        XCTAssertEqual(
+            DictationLanguages.chosen(stored: "ja-JP", among: both)?.id, "ja-JP"
+        )
+        XCTAssertNil(DictationLanguages.chosen(stored: nil, among: both))
+
+        let englishOnly = DictationLanguages.choices(
+            preferred: ["en-US"],
+            supported: supported
+        )
+        XCTAssertNil(DictationLanguages.chosen(stored: "ja-JP", among: englishOnly))
+    }
+
+    /// What the chip shows: the stored pick, else the top preferred
+    /// language (what the system-default recognizer listens in) — and nil
+    /// with a single choice, where no chip appears at all.
+    func testEffectiveLanguageIsStoredPickOrTopPreferredAndNeedsARealChoice() {
+        let both = DictationLanguages.choices(
+            preferred: ["en-US", "ja-JP"],
+            supported: supported
+        )
+        XCTAssertEqual(DictationLanguages.effective(stored: nil, among: both)?.id, "en-US")
+        XCTAssertEqual(DictationLanguages.effective(stored: "ja-JP", among: both)?.id, "ja-JP")
+
+        let englishOnly = DictationLanguages.choices(
+            preferred: ["en-US"],
+            supported: supported
+        )
+        XCTAssertNil(DictationLanguages.effective(stored: "en-US", among: englishOnly))
+    }
+}

--- a/docs/agents/e2e-headless.md
+++ b/docs/agents/e2e-headless.md
@@ -213,6 +213,12 @@ app.multiplexterm.multiplex.<name>`:
   audio session, engine + tap, rolling, restart cap, failure bar, nothing
   typed — while words landing in a pane need a real device. Logged under
   category `dictation` (debug level — `log stream`, not `log show`).
+  The LISTENING bar's language chip (globe + "EN·US") appears only with
+  ≥2 preferred languages the recognizer supports — seed them BEFORE boot
+  (a booted-sim switch rots iCloud state), e.g. `plutil -replace
+  AppleLanguages` in the sim's `.GlobalPreferences.plist`. The chip's
+  menu is a native `UIMenu`: no headless press exists, so proofs stop at
+  the chip's presence in the screenshot.
 - `keycluster` — visionOS ornament key-cluster proof: a raw-mode `dd bs=1
   count=3 | od -c` in the pane reads `033 \t 003`.
 - `debug.scrollup` / `debug.scrolldown` — one remote scroll tick (wheel

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -227,6 +227,28 @@ routing, tab moves, keyboard avoidance, or secret fields.
     no result within 10 s → fall back to `SFSpeechRecognizer` mid-flight
     (nothing typed yet, so it costs nothing); a missing dictation model
     falls back too and requests the model in the background.
+  - **The language is pickable from the LISTENING bar**: a globe chip
+    ("EN·US") opens a native `UIMenu` (checkmark rows — deliberately NOT a
+    TALLY panel; a hand-built popover fought iOS 26's corner curves and
+    was replaced) listing `Locale.preferredLanguages` kept where the
+    recognizer supports them (`DictationLanguages` pure + tested —
+    identifiers match on *maximal* language forms, bridging Settings'
+    "zh-Hant-TW" to Speech's "zh-TW", with a region-stripping fallback
+    because a real device tags EVERY preferred language with the device
+    region: "en-TW" must land on en-US, not vanish). The pick is app-wide
+    (`DictationLanguageSetting`, UserDefaults; `choices()` memoized on the
+    preferred-language list — the bar re-renders per hypothesis), rides
+    `DictationSession.start(locale:)` into both engines, and a mid-take
+    pick RESTARTS the take in the new language (typed words stay; only the
+    unsettled queue drops — deliberate: an in-place engine swap walks into
+    the born-dead-task trap the restart ladder exists for). Nothing stored
+    means the system default; a stale pick falls back rather than lingers.
+    One preferred language → no chip and no menu
+    (`DictationLanguages.effective`), matching the system keyboard. ⚠ A
+    mic long-press was the first entry point and was replaced — nobody
+    discovers a hold with no visible affordance; don't rebuild it. The
+    chip is provable headlessly (`debug.dictation` + screenshot); the open
+    menu is system UI and is not.
   - The `SFSpeechRecognizer` path rolls tasks (one utterance per task, and
     the server-backed path dies after ~a minute). Every roll waits
     `restartDelays` (200 ms → 500 ms/1 s/2 s) — a task created while the

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,7 +1,9 @@
 NEW SINCE 1.3.1
 • THE SHORTCUT PANEL STAYS OPEN WHILE YOU MOVE — in the TMUX / HRDR panel, the window/workspace switch list and the movement rows keep the panel up, with ACTIVE following where you land. Splits, new/rename/close and Copy Mode still close it.
+• DICTATE IN YOUR OWN LANGUAGES — while dictating, the LISTENING bar shows your language next to a globe. Tap it to switch among the preferred languages from your device's Language Settings, like the system keyboard's dictation; the take restarts in the language you pick and it sticks for next time. With one language the mic works exactly as before.
 
 PLEASE TRY
 1. Open the panel on a session with three or more windows and hop through the switch list, then NEXT / LAST WINDOW — the panel should stay up and ACTIVE should follow.
+2. If your device lists several languages in Settings, start dictation and tap the globe chip in the LISTENING bar — the take should restart in the language you pick, the words should land in it, and the next take should remember it.
 
 Feedback: screenshot in TestFlight


### PR DESCRIPTION
## What

While dictating, the LISTENING bar shows a globe chip naming the take's language ("EN·US"). Tapping it opens a **native `UIMenu`** listing the device's preferred languages (Settings → General → Language & Region), filtered to what the speech recognizer supports, endonym + region per row with a checkmark on the active one — the same offer the system keyboard's dictation makes.

- A pick **persists app-wide** (`DictationLanguageSetting`, UserDefaults) and applies to every later take.
- A pick **mid-take restarts the take** in the new language: words already typed stay, only the unsettled queue drops. A full restart rather than an in-place engine swap is deliberate — a recognition task created while the daemon tears down its predecessor comes back dead (the session's restart-backoff ladder exists for exactly that).
- With **one preferred language nothing changes**: no chip, no menu, system default behavior.

## How

- `DictationLanguages` (new, pure Model, tested): builds the menu as preferred ∩ supported. Identifiers match on **maximal language forms**, bridging Settings' `zh-Hant-TW` to Speech's `zh-TW`; a **region-stripping fallback** handles real devices, which tag every preferred language with the device region (`en-TW` on a Taiwan phone must land on `en-US`, not vanish — without it the menu collapsed to one row on all real hardware). Script is preserved (`zh-Hant-US` → `zh-TW`, never Simplified), and variant siblings resolve deterministically (`hi-IN` beats `hi-IN-translit`).
- `DictationLanguageSetting` (new Service): persistence + a `choices()` memoized on the preferred-language list, since the bar re-renders on every speech hypothesis.
- The chosen locale rides `DictationSession.start(locale:)` into **both** engines: `DictationTranscriber` via `supportedLocale(equivalentTo:)` on iOS 26, `SFSpeechRecognizer(locale:)` on the rolling path; the `dictation-start` log line now records `locale=`.
- The menu rows are the system's — an earlier hand-built TALLY popover fought iOS 26's corner curves and was replaced; a mic long-press entry point before that proved undiscoverable. Both dead ends are recorded in `docs/agents/input-and-windows.md`.

## Testing

- 9 tests: 7 pure-model (matching, device-region fallback, script preservation, determinism, pick resolution) + 2 UIKit (bar carries the menu with truthful checkmark; store round-trip).
- Full suites green on both platforms (visionOS 1233 / iPad 1232), SwiftLint strict clean, `check-metadata.rb` passes.
- Verified live on the iPad + iPhone simulators (chip renders, menu correct with device-region-shaped `AppleLanguages`); words-arrive-in-中文 confirmed on a real device during development. Simulator speech transcription itself is broken by design (see `docs/agents/e2e-headless.md`).
