### PR TITLE
Resize panes from the tmux shortcut panel

### DIFF
--- a/Multiplex/Models/ShortcutPanelContent.swift
+++ b/Multiplex/Models/ShortcutPanelContent.swift
@@ -19,6 +19,14 @@ struct ShortcutPanelItem: Equatable, Sendable, Identifiable {
     /// Whether performing this row leaves the panel on screen — see
     /// `TmuxShortcut.keepsPanelOpen`.
     var keepsPanelOpen: Bool
+    /// Whether performing this row can move the switch section's ACTIVE
+    /// choice, requiring the open panel to re-read the list.
+    var invalidatesSwitchChoices: Bool
+    /// SF Symbol name for a compact-row button's face (the tmux resize
+    /// directions); nil for the ordinary grid rows. A symbol, not a text
+    /// glyph: the Unicode arrow-to-bar characters come from different
+    /// blocks and the horizontal pair draws visibly smaller.
+    var symbolName: String?
     var accessibilityIdentifier: String
 
     var id: String { accessibilityIdentifier }
@@ -30,6 +38,8 @@ struct ShortcutPanelItem: Equatable, Sendable, Identifiable {
         bindingLabel = shortcut.bindingLabel
         requiresDoubleActivation = shortcut.requiresDoubleActivation
         keepsPanelOpen = shortcut.keepsPanelOpen
+        invalidatesSwitchChoices = shortcut.movesActiveWindow
+        symbolName = shortcut.resizeDirection.map { "arrow.\($0.rawValue).to.line" }
         accessibilityIdentifier = "tmuxShortcut.\(shortcut.rawValue)"
     }
 
@@ -40,6 +50,10 @@ struct ShortcutPanelItem: Equatable, Sendable, Identifiable {
         bindingLabel = shortcut.bindingLabel
         requiresDoubleActivation = shortcut.requiresDoubleActivation
         keepsPanelOpen = shortcut.keepsPanelOpen
+        // No herdr row moves the active workspace, so none invalidates the
+        // switch list (cycling panes/tabs happens inside one workspace).
+        invalidatesSwitchChoices = false
+        symbolName = nil
         accessibilityIdentifier = "herdrShortcut.\(shortcut.rawValue)"
     }
 }
@@ -48,6 +62,13 @@ struct ShortcutPanelSection: Equatable, Sendable {
     var title: String
     var accessibilityIdentifier: String
     var items: [ShortcutPanelItem]
+
+    /// A section whose every row carries a symbol face (the tmux resize
+    /// directions) lays out as one compact row of square glyph buttons
+    /// instead of the two-column grid of full rows.
+    var usesCompactRow: Bool {
+        !items.isEmpty && items.allSatisfy { $0.symbolName != nil }
+    }
 }
 
 /// Everything one backend's panel shows. The switch section is the live list

--- a/Multiplex/Models/TmuxShortcut.swift
+++ b/Multiplex/Models/TmuxShortcut.swift
@@ -6,6 +6,7 @@
 enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
     enum Group: String, CaseIterable, Sendable {
         case panes = "Panes"
+        case resize = "Resize Pane"
         case windows = "Windows"
     }
 
@@ -15,6 +16,10 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
     case togglePaneZoom
     case copyMode
     case closePane
+    case resizeLeft
+    case resizeDown
+    case resizeUp
+    case resizeRight
     case newWindow
     case chooseWindow
     case nextWindow
@@ -30,6 +35,8 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         case .splitLeftRight, .splitTopBottom, .nextPane, .togglePaneZoom,
              .copyMode, .closePane:
             .panes
+        case .resizeLeft, .resizeDown, .resizeUp, .resizeRight:
+            .resize
         case .newWindow, .chooseWindow, .nextWindow, .previousWindow,
              .lastWindow, .renameWindow, .closeWindow:
             .windows
@@ -44,6 +51,10 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         case .togglePaneZoom: "Toggle Pane Zoom"
         case .copyMode: "Copy Mode"
         case .closePane: "Close Pane"
+        case .resizeLeft: "Resize Left"
+        case .resizeDown: "Resize Down"
+        case .resizeUp: "Resize Up"
+        case .resizeRight: "Resize Right"
         case .newWindow: "New Window"
         case .chooseWindow: "Choose Window"
         case .nextWindow: "Next Window"
@@ -64,6 +75,12 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         case .togglePaneZoom: "resize-pane -Z"
         case .copyMode: "copy-mode"
         case .closePane: "kill-pane"
+        // No count: resize-pane's default adjustment is one cell, exactly
+        // the stock ⌃-arrow binding's step.
+        case .resizeLeft: "resize-pane -L"
+        case .resizeDown: "resize-pane -D"
+        case .resizeUp: "resize-pane -U"
+        case .resizeRight: "resize-pane -R"
         case .newWindow: "new-window"
         case .chooseWindow: "choose-tree"
         case .nextWindow: "next-window"
@@ -74,7 +91,9 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    var binding: Character {
+    /// The single key after the prefix; nil for the resize rows, whose stock
+    /// bindings are the ⌃-arrow chords `bindingLabel` documents instead.
+    var binding: Character? {
         switch self {
         case .splitLeftRight: "%"
         case .splitTopBottom: "\""
@@ -82,6 +101,7 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         case .togglePaneZoom: "z"
         case .copyMode: "["
         case .closePane: "x"
+        case .resizeLeft, .resizeDown, .resizeUp, .resizeRight: nil
         case .newWindow: "c"
         case .chooseWindow: "w"
         case .nextWindow: "n"
@@ -89,6 +109,39 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         case .lastWindow: "l"
         case .renameWindow: ","
         case .closeWindow: "&"
+        }
+    }
+
+    /// The one direction fact behind a resize row; nil for every ordinary
+    /// row. The command flag, the stock ⌃-arrow chord, and the panel's
+    /// button face all derive from it, so the four directions cannot drift.
+    enum ResizeDirection: String {
+        case left, down, up, right
+
+        var arrow: String {
+            switch self {
+            case .left: "←"
+            case .down: "↓"
+            case .up: "↑"
+            case .right: "→"
+            }
+        }
+    }
+
+    /// The held resize row's step, matching tmux's own coarse default (the
+    /// stock M-arrow binding resizes five cells where ⌃-arrow resizes one).
+    static let coarseResizeCells = 5
+
+    var resizeDirection: ResizeDirection? {
+        switch self {
+        case .resizeLeft: .left
+        case .resizeDown: .down
+        case .resizeUp: .up
+        case .resizeRight: .right
+        case .splitLeftRight, .splitTopBottom, .nextPane, .togglePaneZoom,
+             .copyMode, .closePane, .newWindow, .chooseWindow, .nextWindow,
+             .previousWindow, .lastWindow, .renameWindow, .closeWindow:
+            nil
         }
     }
 
@@ -102,7 +155,8 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
     /// leave behind is the terminal, and it must not be covered.
     var keepsPanelOpen: Bool {
         switch self {
-        case .nextPane, .togglePaneZoom, .nextWindow, .previousWindow, .lastWindow:
+        case .nextPane, .togglePaneZoom, .nextWindow, .previousWindow, .lastWindow,
+             .resizeLeft, .resizeDown, .resizeUp, .resizeRight:
             true
         case .splitLeftRight, .splitTopBottom, .copyMode, .closePane,
              .newWindow, .chooseWindow, .renameWindow, .closeWindow:
@@ -110,16 +164,35 @@ enum TmuxShortcut: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
+    /// Whether the row can land the session on a different window — the only
+    /// rows whose success invalidates the panel's switch list.
+    var movesActiveWindow: Bool {
+        switch self {
+        case .nextWindow, .previousWindow, .lastWindow:
+            true
+        case .splitLeftRight, .splitTopBottom, .nextPane, .togglePaneZoom,
+             .copyMode, .closePane, .resizeLeft, .resizeDown, .resizeUp,
+             .resizeRight, .newWindow, .chooseWindow, .renameWindow, .closeWindow:
+            false
+        }
+    }
+
     var bindingLabel: String {
-        requiresDoubleActivation ? "2×" : "⌃B \(binding.uppercased())"
+        if requiresDoubleActivation { return "2×" }
+        if let direction = resizeDirection { return "⌃B ⌃\(direction.arrow)" }
+        // Every non-resize row has a post-prefix key.
+        return "⌃B \(binding!.uppercased())"
     }
 
     /// Non-destructive actions use the stock binding through SwiftTerm.
     /// Close actions deliberately have no terminal input: after the panel's
     /// second press they execute through `TmuxProbe.directShortcutCommand`,
     /// avoiding both the timing-sensitive `:` prompt and tmux's own prompt.
+    /// Resize rows have none either — their stock chord is prefix plus a
+    /// multi-byte ⌃-arrow sequence, even more burst-fragile than the splits'
+    /// shifted `%`, so they only run through the control plane.
     var bindingInput: [UInt8]? {
-        guard !requiresDoubleActivation else { return nil }
+        guard !requiresDoubleActivation, let binding else { return nil }
         return [0x02, binding.asciiValue!]
     }
 

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -884,6 +884,15 @@ final class TerminalSessionController {
         }
     }
 
+    /// A held resize row: the same active-pane command at tmux's own coarse
+    /// step. Only resize rows hold, so anything else fails closed.
+    func performPanelShortcutCoarse(_ item: ShortcutPanelItem) {
+        guard case .tmux(let shortcut) = item.payload,
+              shortcut.resizeDirection != nil
+        else { return }
+        performTmuxShortcut(shortcut, resizeCells: TmuxShortcut.coarseResizeCells)
+    }
+
     /// Hand the visible screen to native selection on any session-backed
     /// tab. Entered from the selection block's SELECT/SELECT ALL, which carry
     /// the gesture's cell so selection targets that pane — and the backend's
@@ -997,7 +1006,7 @@ final class TerminalSessionController {
     /// into the pane, including on an SSH tab. Other ordinary rows enter
     /// through SwiftTerm exactly like keyboard input. Confirmed destructive
     /// rows already use the control path to avoid tmux's prompt.
-    func performTmuxShortcut(_ shortcut: TmuxShortcut) {
+    func performTmuxShortcut(_ shortcut: TmuxShortcut, resizeCells: Int = 1) {
         guard status == .live, route.usesTmux,
               let sessionName = route.sessionName
         else { return }
@@ -1005,7 +1014,9 @@ final class TerminalSessionController {
         // either be dropped by the input lock (leaving copy-mode UI stuck
         // half-armed) or race the remote script.
         if case .finding = historyJump { return }
-        switch TmuxProbe.shortcutDelivery(shortcut, sessionName: sessionName) {
+        switch TmuxProbe.shortcutDelivery(
+            shortcut, sessionName: sessionName, resizeCells: resizeCells
+        ) {
         case .controlCommand(let command):
             Task { await executeControlCommand(command) }
         case .terminalInput(let input):

--- a/Multiplex/Services/TmuxProbe.swift
+++ b/Multiplex/Services/TmuxProbe.swift
@@ -545,10 +545,10 @@ enum TmuxProbe {
     /// The panel's one dispatch decision. A direct command deliberately wins
     /// when a shortcut also documents stock binding bytes (both split rows).
     static func shortcutDelivery(
-        _ shortcut: TmuxShortcut, sessionName: String
+        _ shortcut: TmuxShortcut, sessionName: String, resizeCells: Int = 1
     ) -> ShortcutDelivery? {
         if let command = directShortcutCommand(
-            shortcut, sessionName: sessionName
+            shortcut, sessionName: sessionName, resizeCells: resizeCells
         ) {
             return .controlCommand(command)
         }
@@ -561,33 +561,39 @@ enum TmuxProbe {
     /// Execute one shortcut through the SSH control plane. Split rows on every
     /// transport use this because a stock-prefix burst can intermittently lose
     /// its Ctrl-B before a shifted `%` reaches tmux on iPad, leaving the
-    /// character in the pane. Confirmed
+    /// character in the pane. Resize rows use it for the same reason — their
+    /// stock chord is a multi-byte ⌃-arrow after the prefix. Confirmed
     /// closes use it so they never enter tmux's own confirmation prompt.
     /// Resolve the session's current pane/window to tmux's id first: pane
     /// commands reject `=name` targets on tmux 3.6a, and ids avoid prefix
     /// collisions. `#{pane_current_path}` is expanded by tmux against that
     /// target, preserving the stock split binding's working directory.
+    /// `resizeCells` widens a resize row's step (the panel's held press);
+    /// 1 rides resize-pane's own default and adds no argument.
     static func directShortcutCommand(
-        _ shortcut: TmuxShortcut, sessionName: String
+        _ shortcut: TmuxShortcut, sessionName: String, resizeCells: Int = 1
     ) -> String? {
         let exactSession = "=\(sessionName)".shellQuoted
+        let activePaneLookup = "\(tmuxCommand) list-panes -t \(exactSession)"
+            + " -F '#{?pane_active,#{pane_id},}' 2>/dev/null | grep -m1 ."
         let lookup: String
         let action: String
         switch shortcut {
         case .splitLeftRight:
-            lookup = "\(tmuxCommand) list-panes -t \(exactSession)"
-                + " -F '#{?pane_active,#{pane_id},}' 2>/dev/null | grep -m1 ."
+            lookup = activePaneLookup
             action = "\(tmuxCommand) split-window -h -t \"$target\""
                 + " -c '#{pane_current_path}'"
         case .splitTopBottom:
-            lookup = "\(tmuxCommand) list-panes -t \(exactSession)"
-                + " -F '#{?pane_active,#{pane_id},}' 2>/dev/null | grep -m1 ."
+            lookup = activePaneLookup
             action = "\(tmuxCommand) split-window -t \"$target\""
                 + " -c '#{pane_current_path}'"
         case .closePane:
-            lookup = "\(tmuxCommand) list-panes -t \(exactSession)"
-                + " -F '#{?pane_active,#{pane_id},}' 2>/dev/null | grep -m1 ."
+            lookup = activePaneLookup
             action = "\(tmuxCommand) kill-pane -t \"$target\""
+        case .resizeLeft, .resizeDown, .resizeUp, .resizeRight:
+            lookup = activePaneLookup
+            action = "\(tmuxCommand) \(shortcut.command) -t \"$target\""
+                + (resizeCells == 1 ? "" : " \(resizeCells)")
         case .closeWindow:
             lookup = "\(tmuxCommand) list-windows -t \(exactSession)"
                 + " -F '#{?window_active,#{window_id},}' 2>/dev/null | grep -m1 ."

--- a/Multiplex/Views/Terminal/ShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/ShortcutPanel.swift
@@ -17,6 +17,7 @@ final class ShortcutPanelViewController: UIViewController {
     private let content: ShortcutPanelContent
     private var panelWidth: CGFloat
     private var select: (ShortcutPanelItem) -> Void
+    private var selectCoarse: ((ShortcutPanelItem) -> Void)?
     private var loadChoices: (() async -> [TmuxWindowChoice]?)?
     private var selectChoice: ((TmuxWindowChoice) -> Void)?
 
@@ -35,12 +36,14 @@ final class ShortcutPanelViewController: UIViewController {
         content: ShortcutPanelContent,
         width: CGFloat = ShortcutPanelViewController.preferredWidth,
         select: @escaping (ShortcutPanelItem) -> Void,
+        selectCoarse: ((ShortcutPanelItem) -> Void)? = nil,
         loadChoices: (() async -> [TmuxWindowChoice]?)? = nil,
         selectChoice: ((TmuxWindowChoice) -> Void)? = nil
     ) {
         self.content = content
         panelWidth = width
         self.select = select
+        self.selectCoarse = selectCoarse
         self.loadChoices = loadChoices
         self.selectChoice = selectChoice
         panelView = ShortcutPanelRootView(width: width)
@@ -197,18 +200,42 @@ final class ShortcutPanelViewController: UIViewController {
         title.accessibilityTraits.insert(.header)
         title.accessibilityIdentifier = section.accessibilityIdentifier
 
-        let grid = makeTwoColumnGrid(section.items.map { item in
-            let button = ShortcutItemButton(item: item)
-            button.addTarget(self, action: #selector(itemPressed(_:)), for: .touchUpInside)
-            itemButtons[item.id] = button
-            return button
-        })
+        let grid: UIView
+        if section.usesCompactRow {
+            grid = makeCompactRow(section.items)
+        } else {
+            grid = makeGrid(section.items.map { item in
+                let button = ShortcutItemButton(item: item)
+                button.addTarget(self, action: #selector(itemPressed(_:)), for: .touchUpInside)
+                itemButtons[item.id] = button
+                return button
+            })
+        }
 
         let stack = UIStackView(arrangedSubviews: [title, grid])
         stack.axis = .vertical
         stack.alignment = .fill
         stack.spacing = 6
         return stack
+    }
+
+    /// One row of equal square symbol buttons — the resize directions. A tap
+    /// routes through the same `activate` path as the grid rows; a hold goes
+    /// coarse and repeats until release. Both leave the panel up.
+    private func makeCompactRow(_ items: [ShortcutPanelItem]) -> UIView {
+        makeGrid(
+            items.map { item in
+                let button = ShortcutCompactItemButton(item: item)
+                button.onTap = { [weak self] in self?.activate(item) }
+                button.onHoldStep = { [weak self] in
+                    guard let self else { return }
+                    disarm()
+                    (selectCoarse ?? select)(item)
+                }
+                return button
+            },
+            columns: max(items.count, 1)
+        )
     }
 
     private func makeChoiceGrid(_ choices: [TmuxWindowChoice]) -> UIView {
@@ -221,28 +248,29 @@ final class ShortcutPanelViewController: UIViewController {
             button.addTarget(self, action: #selector(choicePressed(_:)), for: .touchUpInside)
             return button
         }
-        return makeTwoColumnGrid(choiceButtons)
+        return makeGrid(choiceButtons)
     }
 
-    private func makeTwoColumnGrid(_ controls: [UIControl]) -> UIView {
+    /// Equal-width cells over the 1 pt bezel hairline — the panel's one grid
+    /// treatment, whether two columns of full rows or one compact row.
+    private func makeGrid(_ controls: [UIControl], columns: Int = 2) -> UIView {
         let grid = UIStackView()
         grid.axis = .vertical
         grid.alignment = .fill
         grid.spacing = 1
         grid.backgroundColor = UIKitChassis.bezelHi
 
-        for offset in stride(from: 0, to: controls.count, by: 2) {
-            let first = controls[offset]
-            let second: UIView
-            if controls.indices.contains(offset + 1) {
-                second = controls[offset + 1]
-            } else {
-                second = UIView()
-                second.backgroundColor = UIKitChassis.bezelHi
-                second.isAccessibilityElement = false
+        for offset in stride(from: 0, to: controls.count, by: columns) {
+            let cells = (offset..<offset + columns).map { index -> UIView in
+                guard controls.indices.contains(index) else {
+                    let filler = UIView()
+                    filler.backgroundColor = UIKitChassis.bezelHi
+                    filler.isAccessibilityElement = false
+                    return filler
+                }
+                return controls[index]
             }
-
-            let row = UIStackView(arrangedSubviews: [first, second])
+            let row = UIStackView(arrangedSubviews: cells)
             row.axis = .horizontal
             row.alignment = .fill
             row.distribution = .fillEqually
@@ -307,12 +335,13 @@ final class ShortcutPanelViewController: UIViewController {
         }
     }
 
-    /// A row that leaves the panel up may have moved the very window the
-    /// switch list marks ACTIVE (Next / Previous / Last Window). The binding
+    /// Next / Previous / Last Window may have moved the very window the
+    /// switch list marks ACTIVE while the panel stays up. The binding
     /// travels through the terminal, so re-read the list once it has landed
-    /// rather than guess the destination.
+    /// rather than guess the destination. Rows that stay put (pane hops,
+    /// zoom, resize) never pay the round trip.
     private func scheduleChoiceRefreshIfPanelStays(_ item: ShortcutPanelItem) {
-        guard item.keepsPanelOpen, let loadChoices else { return }
+        guard item.invalidatesSwitchChoices, let loadChoices else { return }
         choiceRefreshTask?.cancel()
         choiceRefreshTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: Self.choiceRefreshDelay)
@@ -353,6 +382,57 @@ final class ShortcutPanelViewController: UIViewController {
 /// pressed — the fade starts from the colour the touch already set, which is
 /// what makes a quick tap visible.
 private let shortcutPressFadeDuration: TimeInterval = 0.25
+
+/// Shared press chassis for every control in the panel: the square hover
+/// shape, the press wiring, and the fade above. Subclasses supply only their
+/// content and, where state changes it, the resting ground.
+@MainActor
+private class ShortcutPressControl: UIControl {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
+        addTarget(
+            self,
+            action: #selector(beginPress),
+            for: [.touchDown, .touchDragEnter]
+        )
+        addTarget(
+            self,
+            action: #selector(endPress),
+            for: [.touchCancel, .touchDragExit, .touchUpInside, .touchUpOutside]
+        )
+        refreshBackground()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    // PROTOTYPE(GLASS): rest on strata over the popover's smoke, never
+    // opaque chassis.
+    var restingBackgroundColor: UIColor { GlassPrototype.strataChassis }
+
+    override var isHighlighted: Bool {
+        didSet { refreshBackground(animated: !isHighlighted) }
+    }
+
+    override func accessibilityActivate() -> Bool {
+        sendActions(for: .touchUpInside)
+        return true
+    }
+
+    func refreshBackground(animated: Bool = false) {
+        let ground = isHighlighted ? UIKitChassis.bezelHi : restingBackgroundColor
+        guard animated else { return backgroundColor = ground }
+        UIView.animate(withDuration: shortcutPressFadeDuration) {
+            self.backgroundColor = ground
+        }
+    }
+
+    @objc private func beginPress() { isHighlighted = true }
+    @objc private func endPress() { isHighlighted = false }
+}
 
 @MainActor
 private final class ShortcutPanelRootView: UIKitTallyBorderedView {
@@ -414,7 +494,7 @@ private final class ShortcutPanelRootView: UIKitTallyBorderedView {
 }
 
 @MainActor
-private final class ShortcutItemButton: UIControl {
+private final class ShortcutItemButton: ShortcutPressControl {
     let item: ShortcutPanelItem
 
     private let titleLabel = ShortcutPanelLabel()
@@ -428,9 +508,6 @@ private final class ShortcutItemButton: UIControl {
         super.init(frame: .zero)
         minimumHeight(48)
         accessibilityIdentifier = item.accessibilityIdentifier
-        isAccessibilityElement = true
-        accessibilityTraits = .button
-        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
 
         titleLabel.configure(
             item.title.uppercased(),
@@ -480,21 +557,8 @@ private final class ShortcutItemButton: UIControl {
             row.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 
-        addTarget(
-            self,
-            action: #selector(beginPress),
-            for: [.touchDown, .touchDragEnter]
-        )
-        addTarget(
-            self,
-            action: #selector(endPress),
-            for: [.touchCancel, .touchDragExit, .touchUpInside, .touchUpOutside]
-        )
         setArmed(false)
     }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
 
     func setArmed(_ armed: Bool) {
         isArmed = armed
@@ -510,15 +574,9 @@ private final class ShortcutItemButton: UIControl {
         refreshBackground()
     }
 
-    override var isHighlighted: Bool {
-        // Fading out of the pressed ground, rather than dropping it, is what
-        // makes a quick tap visible — see `shortcutPressFadeDuration`.
-        didSet { refreshBackground(animated: !isHighlighted) }
-    }
-
-    override func accessibilityActivate() -> Bool {
-        sendActions(for: .touchUpInside)
-        return true
+    // Arming swaps the strata resting ground for the raised bezel.
+    override var restingBackgroundColor: UIColor {
+        isArmed ? UIKitChassis.bezelHi : super.restingBackgroundColor
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -541,35 +599,105 @@ private final class ShortcutItemButton: UIControl {
         return "\(item.title), \(item.command), \(item.bindingLabel)"
     }
 
-    @objc private func beginPress() {
-        isHighlighted = true
-    }
-
-    @objc private func endPress() {
-        isHighlighted = false
-    }
-
-    // PROTOTYPE(GLASS): rest on strata over the popover's smoke, never
-    // opaque chassis.
-    private var restingBackgroundColor: UIColor {
-        isArmed ? UIKitChassis.bezelHi : GlassPrototype.strataChassis
-    }
-
-    private func refreshBackground(animated: Bool = false) {
-        let ground = isHighlighted ? UIKitChassis.bezelHi : restingBackgroundColor
-        guard animated else { return backgroundColor = ground }
-        UIView.animate(withDuration: shortcutPressFadeDuration) {
-            self.backgroundColor = ground
-        }
-    }
-
     private func refreshBorder() {
         layer.borderColor = UIKitChassis.signal2.resolvedColor(with: traitCollection).cgColor
     }
 }
 
+/// A square compact-row button showing just its item's symbol face; the
+/// title, command, and stock chord travel through the accessibility label
+/// the way the full rows compose theirs.
+///
+/// A tap fires `onTap`; keeping the press down goes coarse — `onHoldStep`
+/// after the hold delay, then again every repeat interval until release —
+/// so a big resize is one held press, not twenty taps. A press that held
+/// swallows its release: the finger lifting off a repeat must not append
+/// one more fine step.
 @MainActor
-private final class ShortcutChoiceButton: UIControl {
+private final class ShortcutCompactItemButton: ShortcutPressControl {
+    nonisolated static let holdDelay: UInt64 = 500_000_000
+    nonisolated static let holdRepeatInterval: UInt64 = 1_000_000_000
+
+    var onTap: () -> Void = {}
+    var onHoldStep: () -> Void = {}
+
+    private var holdTask: Task<Void, Never>?
+    private var didHold = false
+
+    init(item: ShortcutPanelItem) {
+        super.init(frame: .zero)
+        minimumHeight(40)
+        accessibilityIdentifier = item.accessibilityIdentifier
+        accessibilityLabel = "\(item.title), \(item.command), \(item.bindingLabel)"
+        accessibilityHint =
+            "Hold for \(TmuxShortcut.coarseResizeCells)-cell steps, repeating until release."
+
+        let face = UIImageView(
+            image: item.symbolName.flatMap(UIImage.init(systemName:))
+        )
+        face.preferredSymbolConfiguration = UIImage.SymbolConfiguration(
+            pointSize: 13 * Theme.typeScale, weight: .semibold
+        )
+        face.tintColor = UIKitChassis.signal
+        face.isAccessibilityElement = false
+        addSubview(face)
+        face.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            face.centerXAnchor.constraint(equalTo: centerXAnchor),
+            face.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
+        // Mirrors the base press events: a drag back in re-arms the hold the
+        // way it re-lights the pressed ground.
+        addTarget(
+            self,
+            action: #selector(beginHold),
+            for: [.touchDown, .touchDragEnter]
+        )
+        addTarget(self, action: #selector(lift), for: .touchUpInside)
+        addTarget(
+            self,
+            action: #selector(cancelHold),
+            for: [.touchUpOutside, .touchCancel, .touchDragExit]
+        )
+    }
+
+    @objc private func beginHold() {
+        didHold = false
+        holdTask?.cancel()
+        holdTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.holdDelay)
+            while !Task.isCancelled {
+                guard let self else { return }
+                didHold = true
+                onHoldStep()
+                try? await Task.sleep(nanoseconds: Self.holdRepeatInterval)
+            }
+        }
+    }
+
+    @objc private func lift() {
+        cancelHoldTask()
+        if didHold {
+            didHold = false
+        } else {
+            onTap()
+        }
+    }
+
+    @objc private func cancelHold() {
+        cancelHoldTask()
+        didHold = false
+    }
+
+    private func cancelHoldTask() {
+        holdTask?.cancel()
+        holdTask = nil
+    }
+}
+
+@MainActor
+private final class ShortcutChoiceButton: ShortcutPressControl {
     private(set) var choice: TmuxWindowChoice
 
     private let noun: String
@@ -588,9 +716,6 @@ private final class ShortcutChoiceButton: UIControl {
         super.init(frame: .zero)
         minimumHeight(40)
         accessibilityIdentifier = accessibilityPrefix + choice.tmuxID
-        isAccessibilityElement = true
-        accessibilityTraits = .button
-        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
 
         let index = ShortcutPanelLabel(
             "\(choice.index)",
@@ -625,22 +750,8 @@ private final class ShortcutChoiceButton: UIControl {
             row.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 
-        addTarget(
-            self,
-            action: #selector(beginPress),
-            for: [.touchDown, .touchDragEnter]
-        )
-        addTarget(
-            self,
-            action: #selector(endPress),
-            for: [.touchCancel, .touchDragExit, .touchUpInside, .touchUpOutside]
-        )
         setActive(choice.isActive)
-        refreshBackground()
     }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
 
     func setActive(_ active: Bool) {
         choice.isActive = active
@@ -648,36 +759,6 @@ private final class ShortcutChoiceButton: UIControl {
         accessibilityLabel = active
             ? "\(noun.capitalized) \(choice.index), \(choice.name), current \(noun)"
             : "Switch to \(noun) \(choice.index), \(choice.name)"
-    }
-
-    override var isHighlighted: Bool {
-        // Fading out of the pressed ground, rather than dropping it, is what
-        // makes a quick tap visible — see `shortcutPressFadeDuration`.
-        didSet { refreshBackground(animated: !isHighlighted) }
-    }
-
-    override func accessibilityActivate() -> Bool {
-        sendActions(for: .touchUpInside)
-        return true
-    }
-
-    @objc private func beginPress() {
-        isHighlighted = true
-    }
-
-    @objc private func endPress() {
-        isHighlighted = false
-    }
-
-    // PROTOTYPE(GLASS): rest on strata over the popover's smoke.
-    private var restingBackgroundColor: UIColor { GlassPrototype.strataChassis }
-
-    private func refreshBackground(animated: Bool = false) {
-        let ground = isHighlighted ? UIKitChassis.bezelHi : restingBackgroundColor
-        guard animated else { return backgroundColor = ground }
-        UIView.animate(withDuration: shortcutPressFadeDuration) {
-            self.backgroundColor = ground
-        }
     }
 }
 

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -948,6 +948,12 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
                 }
                 self?.press(.shortcut(item))
             },
+            // A held resize row repeats coarse steps — clicked like a press,
+            // dispatched straight to the controller (no dismissal decision).
+            selectCoarse: { [weak self] item in
+                self?.click()
+                self?.controller?.performPanelShortcutCoarse(item)
+            },
             loadChoices: { [weak self] in
                 await self?.controller?.loadShortcutSwitchChoices()
             },

--- a/Multiplex/Views/Terminal/UMDBarUIKit.swift
+++ b/Multiplex/Views/Terminal/UMDBarUIKit.swift
@@ -988,6 +988,11 @@ final class UMDBarViewController: UIViewController,
                 }
                 self.configuration.controller?.performPanelShortcut(item)
             },
+            // A held resize row repeats coarse steps; the panel stays up
+            // throughout, so no dismissal decision rides along.
+            selectCoarse: { [weak self] item in
+                self?.configuration.controller?.performPanelShortcutCoarse(item)
+            },
             loadChoices: { [weak controller = configuration.controller] in
                 await controller?.loadShortcutSwitchChoices()
             },

--- a/MultiplexTests/ShortcutPanelUIKitTests.swift
+++ b/MultiplexTests/ShortcutPanelUIKitTests.swift
@@ -15,7 +15,7 @@ final class ShortcutPanelUIKitTests: XCTestCase {
         let headers = descendants(of: UIKitChassisLabel.self, in: controller.view)
             .filter { $0.accessibilityTraits.contains(.header) }
             .compactMap(\.accessibilityLabel)
-        XCTAssertEqual(headers, ["TMUX SHORTCUTS", "Panes", "Windows"])
+        XCTAssertEqual(headers, ["TMUX SHORTCUTS", "Panes", "Resize Pane", "Windows"])
 
         let size = controller.fittingContentSize()
         XCTAssertEqual(size.width, ShortcutPanelViewController.preferredWidth)
@@ -34,6 +34,20 @@ final class ShortcutPanelUIKitTests: XCTestCase {
             closePane.accessibilityLabel,
             "Close Pane, kill-pane, press twice to confirm"
         )
+
+        // Resize is a compact row: an arrow-to-bar SF Symbol face, with the
+        // full story left to assistive tech.
+        let resizeLeft = try XCTUnwrap(
+            control("tmuxShortcut.resizeLeft", in: controller.view)
+        )
+        XCTAssertEqual(
+            resizeLeft.accessibilityLabel,
+            "Resize Left, resize-pane -L, ⌃B ⌃←"
+        )
+        XCTAssertEqual(
+            descendants(of: UIImageView.self, in: resizeLeft).first?.image,
+            UIImage(systemName: "arrow.left.to.line")
+        )
     }
 
     func testSafeShortcutSelectsImmediatelyAndDestructiveShortcutRequiresSecondPress() throws {
@@ -47,11 +61,17 @@ final class ShortcutPanelUIKitTests: XCTestCase {
         copyMode.sendActions(for: .touchUpInside)
         XCTAssertEqual(selected.map(\.payload), [.tmux(.copyMode)])
 
+        // A resize press selects immediately — repeated taps keep nudging.
+        let resizeUp = try XCTUnwrap(control("tmuxShortcut.resizeUp", in: controller.view))
+        resizeUp.sendActions(for: .touchUpInside)
+        XCTAssertEqual(selected.map(\.payload), [.tmux(.copyMode), .tmux(.resizeUp)])
+        selected = []
+
         let closeWindow = try XCTUnwrap(
             control("tmuxShortcut.closeWindow", in: controller.view)
         )
         closeWindow.sendActions(for: .touchUpInside)
-        XCTAssertEqual(selected.map(\.payload), [.tmux(.copyMode)])
+        XCTAssertEqual(selected, [])
         XCTAssertEqual(
             closeWindow.accessibilityLabel,
             "Close Window, press again to close"
@@ -60,11 +80,39 @@ final class ShortcutPanelUIKitTests: XCTestCase {
         XCTAssertTrue(renderedText(in: closeWindow).contains("AGAIN"))
 
         closeWindow.sendActions(for: .touchUpInside)
-        XCTAssertEqual(selected.map(\.payload), [.tmux(.copyMode), .tmux(.closeWindow)])
+        XCTAssertEqual(selected.map(\.payload), [.tmux(.closeWindow)])
         XCTAssertEqual(
             closeWindow.accessibilityLabel,
             "Close Window, kill-window, press twice to confirm"
         )
+    }
+
+    func testHoldingAResizeRowRepeatsCoarseStepsAndSwallowsItsRelease() async throws {
+        var selected: [ShortcutPanelItem] = []
+        var coarse: [ShortcutPanelItem] = []
+        let controller = ShortcutPanelViewController(
+            content: .tmux,
+            select: { selected.append($0) },
+            selectCoarse: { coarse.append($0) }
+        )
+        controller.loadViewIfNeeded()
+        let resizeUp = try XCTUnwrap(control("tmuxShortcut.resizeUp", in: controller.view))
+
+        // Hold: one coarse step after the delay, another after the repeat
+        // interval, and the release adds no fine step on top.
+        resizeUp.sendActions(for: .touchDown)
+        try await Task.sleep(nanoseconds: 750_000_000)
+        XCTAssertEqual(coarse.map(\.payload), [.tmux(.resizeUp)])
+        try await Task.sleep(nanoseconds: 1_250_000_000)
+        XCTAssertEqual(coarse.count, 2)
+        resizeUp.sendActions(for: .touchUpInside)
+        XCTAssertEqual(selected, [])
+
+        // A quick tap still nudges one fine cell and never goes coarse.
+        resizeUp.sendActions(for: .touchDown)
+        resizeUp.sendActions(for: .touchUpInside)
+        XCTAssertEqual(selected.map(\.payload), [.tmux(.resizeUp)])
+        XCTAssertEqual(coarse.count, 2)
     }
 
     func testHerdrCloseRowsCarryTheirPayloadThroughTheSameConfirmation() throws {

--- a/MultiplexTests/TmuxShortcutTests.swift
+++ b/MultiplexTests/TmuxShortcutTests.swift
@@ -17,12 +17,43 @@ final class TmuxShortcutTests: XCTestCase {
             .renameWindow: Character(",").asciiValue!,
         ]
 
-        let safeShortcuts = TmuxShortcut.allCases.filter { !$0.requiresDoubleActivation }
+        let safeShortcuts = TmuxShortcut.allCases.filter {
+            !$0.requiresDoubleActivation && $0.group != .resize
+        }
         XCTAssertEqual(safeShortcuts.count, expected.count)
         for shortcut in safeShortcuts {
             XCTAssertEqual(shortcut.bindingInput, [0x02, expected[shortcut]!])
             XCTAssertFalse(shortcut.command.isEmpty)
         }
+    }
+
+    func testResizeRowsNudgeOneCellThroughTheControlPlaneOnly() throws {
+        // No count suffix: resize-pane's default adjustment is one cell.
+        XCTAssertEqual(
+            TmuxShortcut.shortcuts(in: .resize).map(\.command),
+            ["resize-pane -L", "resize-pane -D", "resize-pane -U", "resize-pane -R"]
+        )
+        // The stock chord is prefix + a multi-byte ⌃-arrow, so resize never
+        // travels as terminal input — only the active-pane control command.
+        XCTAssertNil(TmuxShortcut.resizeLeft.bindingInput)
+        XCTAssertEqual(TmuxShortcut.resizeLeft.bindingLabel, "⌃B ⌃←")
+        let delivery = try XCTUnwrap(TmuxProbe.shortcutDelivery(
+            .resizeLeft, sessionName: "my project"
+        ))
+        guard case .controlCommand(let command) = delivery else {
+            return XCTFail("Panel resize must use its control command")
+        }
+        XCTAssertTrue(command.contains("tmux -u list-panes -t '=my project'"))
+        XCTAssertTrue(command.contains("tmux -u resize-pane -L -t \"$target\""))
+        XCTAssertFalse(command.contains("$target\" 1"))
+
+        // The held press goes coarse: tmux's own M-arrow step, as the
+        // trailing positional adjustment.
+        XCTAssertEqual(TmuxShortcut.coarseResizeCells, 5)
+        let coarse = try XCTUnwrap(TmuxProbe.directShortcutCommand(
+            .resizeLeft, sessionName: "my project", resizeCells: 5
+        ))
+        XCTAssertTrue(coarse.contains("tmux -u resize-pane -L -t \"$target\" 5"))
     }
 
     func testCloseActionsHaveNoTerminalInputAfterUIConfirmation() {
@@ -73,9 +104,10 @@ final class TmuxShortcutTests: XCTestCase {
         XCTAssertEqual(deliveredTopBottom, topBottom)
     }
 
-    func testOnlySplitsAndConfirmedClosesHaveDirectControlCommands() {
+    func testOnlySplitsResizesAndConfirmedClosesHaveDirectControlCommands() {
         let expected: Set<TmuxShortcut> = [
             .splitLeftRight, .splitTopBottom, .closePane, .closeWindow,
+            .resizeLeft, .resizeDown, .resizeUp, .resizeRight,
         ]
         let actual = Set(TmuxShortcut.allCases.filter {
             TmuxProbe.directShortcutCommand($0, sessionName: "main") != nil
@@ -112,7 +144,10 @@ final class TmuxShortcutTests: XCTestCase {
     func testOnlyMovementRowsLeaveThePanelOpen() {
         XCTAssertEqual(
             Set(TmuxShortcut.allCases.filter(\.keepsPanelOpen)),
-            [.nextPane, .togglePaneZoom, .nextWindow, .previousWindow, .lastWindow]
+            [
+                .nextPane, .togglePaneZoom, .nextWindow, .previousWindow, .lastWindow,
+                .resizeLeft, .resizeDown, .resizeUp, .resizeRight,
+            ]
         )
         // Anything that leaves you looking at the terminal — a new pane, a
         // prompt, a mode, a close — must uncover it.
@@ -132,7 +167,7 @@ final class TmuxShortcutTests: XCTestCase {
     func testEveryShortcutAppearsInExactlyOneMenuGroup() {
         let grouped = TmuxShortcut.Group.allCases.flatMap(TmuxShortcut.shortcuts(in:))
 
-        XCTAssertEqual(TmuxShortcut.Group.allCases, [.panes, .windows])
+        XCTAssertEqual(TmuxShortcut.Group.allCases, [.panes, .resize, .windows])
         XCTAssertEqual(grouped.count, TmuxShortcut.allCases.count)
         XCTAssertEqual(Set(grouped), Set(TmuxShortcut.allCases))
         XCTAssertEqual(TmuxShortcut.copyMode.group, .panes)

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -1,5 +1,6 @@
 NEW SINCE 1.3.1
 • THE SHORTCUT PANEL STAYS OPEN WHILE YOU MOVE — in the TMUX / HRDR panel, the window/workspace switch list and the movement rows keep the panel up, with ACTIVE following where you land. Splits, new/rename/close and Copy Mode still close it.
+• RESIZE PANES FROM THE TMUX PANEL — a RESIZE PANE row of four arrow buttons nudges the focused pane's border one cell per tap, and the panel stays open so you can tap until it fits. Keep a button pressed to go faster: five cells per step, repeating every second until you let go.
 • DICTATE IN YOUR OWN LANGUAGES — while dictating, the LISTENING bar shows your language next to a globe. Tap it to switch among the preferred languages from your device's Language Settings, like the system keyboard's dictation; the take restarts in the language you pick and it sticks for next time. With one language the mic works exactly as before.
 
 PLEASE TRY


### PR DESCRIPTION
## What

A **RESIZE PANE** row in the TMUX shortcut panel: four arrow-to-bar direction buttons between PANES and WINDOWS.

- **Tap** nudges the focused pane's border **one cell** (tmux's stock `⌃-arrow` step).
- **Hold** goes coarse: **five cells** (the stock `M-arrow` step) after 0.5 s, **repeating every 1 s** until release. A press that held swallows its release, so lifting off a repeat never appends a stray fine step; drag-out cancels and drag-back-in re-arms, matching the pressed-ground highlight.
- The row **keeps the panel open** like the window-hop switchboard rows, so you tap/hold until it fits.
- Faces are SF Symbols (`arrow.*.to.line`) rather than Unicode arrow-to-bar text: the text glyphs come from different blocks and the horizontal pair draws visibly smaller. Symbol size tracks `Theme.typeScale`. VoiceOver rows carry the full story (`"Resize Left, resize-pane -L, ⌃B ⌃←"`) plus a hold hint.

## How

- **Model** — four `TmuxShortcut` cases in their own `Resize Pane` group, all derived from one exhaustive `resizeDirection` switch; `coarseResizeCells = 5` documents the M-arrow parity. `binding` became `Character?`, matching `HerdrShortcut`'s existing idiom.
- **Probe** — delivery rides the control plane like the splits: the stock chord is prefix + a multi-byte `⌃-arrow` sequence, even more burst-fragile than the splits' shifted `%`. The rows resolve the active pane id and run `resize-pane` against it, with the trailing positional adjustment when coarse (`resize-pane -L -t "$target" 5`). `shortcutDelivery`/`directShortcutCommand` gained `resizeCells: Int = 1`, so every existing command stays byte-identical.
- **Panel** — the compact button owns the hold (task with 0.5 s delay / 1 s repeat) and dispatches coarse steps through a new optional `selectCoarse` closure; both presenters (visionOS UMD, iPad key rail) pass it, the rail clicking per step.

## Cleanups that rode along (from the /simplify pass)

- The panel's three buttons share one `ShortcutPressControl` press chassis (hover shape, press fade, resting glass ground) instead of three verbatim copies.
- The two-column grid and the compact row share one `makeGrid(_:columns:)` builder.
- The switch-list refresh is now gated on `invalidatesSwitchChoices` (only Next/Previous/Last Window) instead of every keeps-panel-open row — resize taps, pane hops, and zoom no longer schedule a window-list exec they can never invalidate; on herdr no row does.
- The active-pane lookup in `TmuxProbe.directShortcutCommand` is bound once instead of pasted four times.

## Verification

- Full unit suite green (1295 tests), including a hold-timing test (coarse at ~0.5 s, again at ~1.5 s, release adds no fine step; quick tap still fires one) and command assertions. SwiftLint `--strict` at zero violations.
- Rendered live on the visionOS simulator via `debug.tmuxshortcuts` (screenshot-verified, both glyph iterations).
- The exact generated commands were exercised against real tmux on the dev-sshd harness: coarse moved a pane border exactly 5 cells, fine exactly 1, in a throwaway session.
- `fastlane/testflight-whats-new.txt` updated; `Tools/check-metadata.rb` passes.