### PR TITLE
Open PDFs and play sound files in the File Viewer

### DIFF
--- a/Multiplex/Design/Chassis.swift
+++ b/Multiplex/Design/Chassis.swift
@@ -238,6 +238,7 @@ final class UIKitChassisChip: UIKitTallyBorderedView {
     private let contentStack = UIStackView()
     private let action: () -> Void
     private var caption = ""
+    private var symbolName: String?
     var isProminent: Bool {
         didSet {
             tallyBorderColor = isProminent ? UIKitChassis.signal2 : UIKitChassis.bezelHi
@@ -306,14 +307,23 @@ final class UIKitChassisChip: UIKitTallyBorderedView {
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(pressed))
         addGestureRecognizer(tap)
-        setContent(caption: caption, systemImage: systemImage)
+        applyContent(caption: caption, systemImage: systemImage)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
 
+    /// Unchanged content is a no-op — a restyle invalidates the intrinsic
+    /// size and costs the row a layout, so readouts may set this from a
+    /// timer or a layout pass without gating it themselves.
     func setContent(caption: String, systemImage: String?) {
+        guard caption != self.caption || systemImage != symbolName else { return }
+        applyContent(caption: caption, systemImage: systemImage)
+    }
+
+    private func applyContent(caption: String, systemImage: String?) {
         self.caption = caption
+        symbolName = systemImage
         symbolView.isHidden = systemImage == nil
         symbolView.image = systemImage.flatMap {
             UIImage(

--- a/Multiplex/Models/FileViewer/FileKind.swift
+++ b/Multiplex/Models/FileViewer/FileKind.swift
@@ -45,6 +45,13 @@ enum FileRenderKind: Equatable {
     case markdown
     /// Fit-to-screen image.
     case image
+    /// Paged document on the PDFKit screen.
+    case pdf
+    /// A sound file behind the transport panel (play/pause, scrub, clock).
+    /// Membership is by extension only — whether THIS device can decode it
+    /// is the player's verdict, and an honest CAN'T PLAY beats a BINARY
+    /// panel for a format that is plainly audio.
+    case audio
     /// Known-opaque formats (archives, databases, executables): never read
     /// as text, the header says BINARY and the size.
     case binary
@@ -69,6 +76,8 @@ enum FileKind {
         if let language = languageByExtension[ext] { return .code(language) }
         if markdownExtensions.contains(ext) { return .markdown }
         if imageExtensions.contains(ext) { return .image }
+        if ext == "pdf" { return .pdf }
+        if audioExtensions.contains(ext) { return .audio }
         if binaryExtensions.contains(ext) { return .binary }
         return .code(nil)
     }
@@ -170,12 +179,21 @@ enum FileKind {
         "png", "jpg", "jpeg", "gif", "heic", "heif", "webp", "bmp", "tiff", "tif", "ico",
     ]
 
+    /// What Core Audio reads on these devices, plus the Ogg family — the
+    /// player decides Vorbis vs Opus at decode time and says CAN'T PLAY
+    /// rather than pretending a `.ogg` is opaque bytes. Video containers
+    /// stay binary: this is a sound panel, not a media player.
+    private static let audioExtensions: Set<String> = [
+        "mp3", "m4a", "m4b", "aac", "wav", "wave", "aif", "aiff", "aifc",
+        "caf", "flac", "alac", "au", "amr", "ogg", "oga", "opus",
+    ]
+
     private static let binaryExtensions: Set<String> = [
         "zip", "gz", "tgz", "bz2", "xz", "zst", "7z", "rar", "tar",
-        "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx",
+        "doc", "docx", "xls", "xlsx", "ppt", "pptx",
         "sqlite", "sqlite3", "db", "realm",
         "a", "o", "so", "dylib", "dll", "exe", "bin", "wasm", "class", "jar",
-        "mp3", "mp4", "mov", "m4a", "m4v", "avi", "mkv", "wav", "flac", "ogg",
+        "mp4", "mov", "m4v", "avi", "mkv", "webm", "wma",
         "ttf", "otf", "woff", "woff2",
         "car", "ipa", "apk", "dmg", "iso",
         "psd", "sketch", "fig", "afdesign",

--- a/Multiplex/Models/FileViewer/FileViewerAudioClock.swift
+++ b/Multiplex/Models/FileViewer/FileViewerAudioClock.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// The sound screen's clock: `m:ss`, `h:mm:ss` past an hour — the transport's
+/// readouts and the header's length. Fractions floor: a clock that rounds
+/// shows 0:01 for a clip half a second in.
+enum FileViewerAudioClock {
+    static func label(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "0:00" }
+        let total = Int(seconds)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let secs = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, secs)
+        }
+        return String(format: "%d:%02d", minutes, secs)
+    }
+}

--- a/Multiplex/Models/FileViewer/FileViewerAudioVolume.swift
+++ b/Multiplex/Models/FileViewer/FileViewerAudioVolume.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// The listener's level for the file viewer's sound screen — a plain 0…1
+/// gain under the device volume, so a loud sample can be turned down without
+/// reaching for the hardware. Pure: the clamp and the readout.
+enum FileViewerAudioVolume {
+    static let `default`: Float = 1
+
+    static func clamped(_ value: Float) -> Float {
+        guard value.isFinite else { return `default` }
+        return min(1, max(0, value))
+    }
+
+    /// Panel readout: `100%`, `35%`, `0%`.
+    static func percentLabel(_ value: Float) -> String {
+        "\(Int((clamped(value) * 100).rounded()))%"
+    }
+}

--- a/Multiplex/Services/FileViewerAudioClip.swift
+++ b/Multiplex/Services/FileViewerAudioClip.swift
@@ -1,0 +1,164 @@
+import AVFoundation
+import Foundation
+import Observation
+import UniformTypeIdentifiers
+
+/// One sound file the viewer has read whole over SFTP, decoded by
+/// `AVAudioPlayer`. Owned by the `Document` that named it, not by the screen
+/// showing it: the screen is a remote (PLAY/PAUSE, scrub, clock), so a tab
+/// moving between windows on merge/split keeps its position, a quiet watch
+/// reload can hand the position to the replacement, and closing the tab
+/// releases the player — the audio stops with the document, never later.
+///
+/// Playback is deliberately whole-file: streaming would need a resource
+/// loader over SFTP, and every file the size cap admits fits in memory.
+/// Nothing here is observable — the position moves several times a second,
+/// and repainting the pane's rail and header at that rate would be waste.
+/// The screen polls while the clip plays. The one thing the clip follows is
+/// the listener's volume store, so every clip is at the chosen level whether
+/// or not a panel is currently looking at it.
+@MainActor
+final class FileViewerAudioClip: Equatable {
+    /// Transport skips ride the same ±15 s the system players use.
+    static let skipInterval: TimeInterval = 15
+
+    private let player: AVAudioPlayer
+    private let volumeStore: FileViewerAudioVolumeStore
+    private let finishBridge = FinishBridge()
+
+    var duration: TimeInterval { player.duration }
+    var currentTime: TimeInterval { player.currentTime }
+    var isPlaying: Bool { player.isPlaying }
+    /// The gain under the device volume, 0…1 — always the store's reading.
+    var volume: Float { player.volume }
+
+    /// Throws when Core Audio can't read the bytes — an Ogg Vorbis file, a
+    /// text file wearing `.mp3`, or a truncated header all land here, and
+    /// the screen says CAN'T PLAY. The extension is offered as a hint only
+    /// when it names a known audio type: a `dyn.` UTI for a stray extension
+    /// would steer the decoder wrong where no hint lets it sniff the bytes.
+    /// ⚠ Built ON the main actor on purpose: the same call from
+    /// `Task.detached` measured 100–400× slower on the visionOS sim (and
+    /// ~9 s for a mismatched hint) — Core Audio's open path wants a run
+    /// loop; here it is sub-millisecond, header-deep, whatever the file size.
+    init(data: Data, fileName: String, volumeStore: FileViewerAudioVolumeStore) throws {
+        let hint = fileName.split(separator: ".").dropFirst().last
+            .flatMap { UTType(filenameExtension: String($0)) }
+            .flatMap { $0.conforms(to: .audio) ? $0.identifier : nil }
+        player = try AVAudioPlayer(data: data, fileTypeHint: hint)
+        self.volumeStore = volumeStore
+        player.delegate = finishBridge
+        finishBridge.clip = self
+        followVolume()
+    }
+
+    deinit {
+        // A released clip may have been mid-play (the tab closed): hand the
+        // session back so audio interrupted elsewhere resumes.
+        if player.isPlaying {
+            player.stop()
+            Self.releaseSession()
+        }
+    }
+
+    nonisolated static func == (lhs: FileViewerAudioClip, rhs: FileViewerAudioClip) -> Bool {
+        lhs === rhs
+    }
+
+    // MARK: Transport
+
+    func play() {
+        guard !player.isPlaying else { return }
+        // Playback category so a muted iPad still plays what the person
+        // pressed PLAY on; claimed only now, never at load, so opening a
+        // sound file in the tree does not interrupt music.
+        let session = AVAudioSession.sharedInstance()
+        try? session.setCategory(.playback, mode: .default)
+        try? session.setActive(true)
+        player.play()
+    }
+
+    func pause() {
+        guard player.isPlaying else { return }
+        player.pause()
+        Self.releaseSession()
+    }
+
+    /// Stop and rewind — the tab is closing or the document is being
+    /// replaced; a paused clip at position zero is what a fresh screen shows.
+    func stop() {
+        let wasPlaying = player.isPlaying
+        player.stop()
+        player.currentTime = 0
+        if wasPlaying { Self.releaseSession() }
+    }
+
+    func togglePlayback() {
+        if player.isPlaying { pause() } else { play() }
+    }
+
+    func seek(to time: TimeInterval) {
+        // A seek at the very end makes AVAudioPlayer stop on the next tick;
+        // hold a hair short so PLAY from a full scrub still plays.
+        let ceiling = max(0, player.duration - 0.05)
+        player.currentTime = min(max(0, time), ceiling)
+    }
+
+    func skip(by delta: TimeInterval) {
+        seek(to: player.currentTime + delta)
+    }
+
+    /// A quiet watch reload swapped the bytes underneath a listener: carry
+    /// the position and the playing state over so the screen does not jump
+    /// to zero, and silence the clip being replaced.
+    func adoptPosition(from previous: FileViewerAudioClip) {
+        let wasPlaying = previous.isPlaying
+        let time = previous.currentTime
+        previous.stop()
+        seek(to: time)
+        if wasPlaying { play() }
+    }
+
+    // MARK: Volume
+
+    /// Observation's change hook fires BEFORE the store's write lands, so
+    /// the re-read happens one main-actor hop later; the panel's slider only
+    /// ever writes the store.
+    private func followVolume() {
+        withObservationTracking {
+            player.volume = volumeStore.volume
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in self?.followVolume() }
+        }
+    }
+
+    // MARK: Session + finish
+
+    /// Handing the session back can block briefly, so it happens off the main
+    /// actor. A play that begins meanwhile keeps its own I/O running, and a
+    /// deactivate under a running player is refused by the system — never a
+    /// stop.
+    nonisolated private static func releaseSession() {
+        Task.detached {
+            try? AVAudioSession.sharedInstance().setActive(
+                false, options: .notifyOthersOnDeactivation
+            )
+        }
+    }
+
+    private func playbackFinished() {
+        // AVAudioPlayer has already stopped and rewound itself; the session
+        // is what still needs handing back.
+        Self.releaseSession()
+    }
+
+    /// The delegate lives on a retained NSObject so the clip stays a plain
+    /// class; AVAudioPlayer holds its delegate weakly.
+    private final class FinishBridge: NSObject, AVAudioPlayerDelegate {
+        weak var clip: FileViewerAudioClip?
+
+        nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+            Task { @MainActor [weak self] in self?.clip?.playbackFinished() }
+        }
+    }
+}

--- a/Multiplex/Services/FileViewerAudioVolumeStore.swift
+++ b/Multiplex/Services/FileViewerAudioVolumeStore.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Observation
+
+/// The sound screen's volume, app-wide and device-local — the text-size
+/// store's shape for the same reasons: a level chosen while listening to one
+/// file is the level the next should open at, in any window, and it answers
+/// to the ears in front of the device, not to a host record. Applied to a
+/// clip when it is made and followed by every open panel while it plays.
+@MainActor
+@Observable
+final class FileViewerAudioVolumeStore {
+    static let shared = FileViewerAudioVolumeStore()
+
+    private static let key = "MultiplexFileViewerAudioVolume"
+    private let defaults: UserDefaults
+
+    private(set) var volume: Float
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let stored = defaults.object(forKey: Self.key) as? Double
+        volume = stored.map { FileViewerAudioVolume.clamped(Float($0)) }
+            ?? FileViewerAudioVolume.default
+    }
+
+    func set(_ value: Float) {
+        let clamped = FileViewerAudioVolume.clamped(value)
+        guard clamped != volume else { return }
+        volume = clamped
+        defaults.set(Double(clamped), forKey: Self.key)
+    }
+}

--- a/Multiplex/Services/FileViewerController.swift
+++ b/Multiplex/Services/FileViewerController.swift
@@ -2,6 +2,7 @@ import Citadel
 import Foundation
 import ImageIO
 import Observation
+import PDFKit
 import UIKit
 
 /// One file-viewer tab's state: its own SSH connection (dialed lazily,
@@ -24,6 +25,11 @@ final class FileViewerController: AuxiliaryPaneController {
     /// that highlighting stays interactive.
     static let textByteLimit = 1_500_000
     static let imageByteLimit = 12_000_000
+    /// PDFs and sound files are read whole (PDFKit wants random access, the
+    /// player has no streaming road over SFTP), so the cap is what a
+    /// listener will wait through and what a tab may hold in memory: a
+    /// scanned book or an hour of MP3, not a lossless album.
+    static let mediaByteLimit = 60_000_000
     /// The longest edge the viewer decodes to. Encoded bytes bound nothing
     /// about a bitmap's size, and the screen this renders on is smaller than
     /// this in every dimension.
@@ -133,6 +139,14 @@ final class FileViewerController: AuxiliaryPaneController {
         /// Decoded once at load — re-decoding megabytes per body
         /// evaluation is what image views must never do.
         var image: UIImage?
+        /// Parsed once at load (PDFKit compares by identity, so a reload is
+        /// a new value). A locked document (`isLocked`) is still a PDF — the
+        /// screen offers UNLOCK.
+        var pdf: PDFDocument?
+        /// The player behind an audio file, owned here so the position
+        /// survives the screen (merge/split rebuilds the pane, not the
+        /// document). nil under `.audio` means this device can't decode it.
+        var audio: FileViewerAudioClip?
         /// The text behind a markdown render, kept so the RAW toggle
         /// re-renders locally instead of re-downloading the file.
         var sourceText: String?
@@ -158,7 +172,19 @@ final class FileViewerController: AuxiliaryPaneController {
         case failure(title: String, message: String)
     }
 
-    private(set) var content: Content = .idle
+    /// The document leaving the screen takes its sound with it — sound with
+    /// no controls in sight is a dead end. The same clip re-published (an
+    /// unlock, a quiet reload that adopted it) keeps playing; a moved tab
+    /// never changes `content`, so merge/split plays through.
+    private(set) var content: Content = .idle {
+        didSet {
+            guard case .document(let previous) = oldValue,
+                  let clip = previous.audio
+            else { return }
+            if case .document(let next) = content, next.audio === clip { return }
+            clip.pause()
+        }
+    }
     /// Back/forward trail of the content screens this tab visited. Written
     /// only where content lands (a failed load is never a destination);
     /// `visit`'s equality gate keeps refresh and quiet watch swaps out.
@@ -366,6 +392,10 @@ final class FileViewerController: AuxiliaryPaneController {
     }
 
     func shutdown() {
+        // A closing tab silences its player now rather than whenever the
+        // last reference lets go (`lastDocument` holds every clip `content`
+        // can, and the one a failed load left behind).
+        lastDocument?.audio?.stop()
         let dying = connection
         connection = nil
         Task { await dying?.close() }
@@ -699,6 +729,13 @@ final class FileViewerController: AuxiliaryPaneController {
         }
     }
 
+    /// Carries the off-main parse home. `PDFDocument` is not `Sendable`, but a
+    /// freshly built one is referenced by nobody else — the hop back to the
+    /// main actor is the only crossing it makes.
+    private struct ParsedPDF: @unchecked Sendable {
+        let document: PDFDocument?
+    }
+
     /// A refusal the pipeline can title itself (the size cap) — one error
     /// channel: `makeDocument` throws, callers catch into the panel.
     private struct LoadRefusal: Error {
@@ -723,16 +760,32 @@ final class FileViewerController: AuxiliaryPaneController {
         switch document.kind {
         case .binary:
             break
+        case .pdf:
+            let data = try await readWhole(
+                path: path, name: name, size: size, limit: Self.mediaByteLimit, noun: "PDFs"
+            )
+            // The xref walk of a scanned book is real work — off the main
+            // actor like the highlighter; pages then render lazily on screen.
+            let parsed = await Task.detached { ParsedPDF(document: PDFDocument(data: data)) }.value
+            if let pdf = parsed.document {
+                document.pdf = pdf
+            } else {
+                // Not a PDF by any honest reading — the image verdict again.
+                document.kind = .binary
+            }
+        case .audio:
+            let data = try await readWhole(
+                path: path, name: name, size: size, limit: Self.mediaByteLimit, noun: "sound files"
+            )
+            // A decode failure keeps the AUDIO verdict: the screen says
+            // CAN'T PLAY and why, where BINARY would only say "not text".
+            document.audio = try? FileViewerAudioClip(
+                data: data, fileName: name, volumeStore: .shared
+            )
         case .image:
-            guard size <= UInt64(Self.imageByteLimit) else {
-                throw LoadRefusal(
-                    title: "TOO LARGE",
-                    message: "\(name) is \(Self.formatBytes(size)) — the viewer renders images up to \(Self.formatBytes(UInt64(Self.imageByteLimit)))."
-                )
-            }
-            let (data, _) = try await withConnection {
-                try await $0.readFile(atPath: path, limit: Self.imageByteLimit)
-            }
+            let data = try await readWhole(
+                path: path, name: name, size: size, limit: Self.imageByteLimit, noun: "images"
+            )
             // Undecodable "image" bytes are binary content by any honest
             // reading — same verdict as the NUL sniff below. Decoding goes
             // through a bounded downsample: the byte limit above says nothing
@@ -768,6 +821,38 @@ final class FileViewerController: AuxiliaryPaneController {
             }
         }
         return document
+    }
+
+    /// The whole-file read behind the media screens: the size gate names its
+    /// cap in the refusal, and the bytes come back in one piece (a document
+    /// or a sound file has no useful "head").
+    private func readWhole(
+        path: String, name: String, size: UInt64, limit: Int, noun: String
+    ) async throws -> Data {
+        guard size <= UInt64(limit) else {
+            throw LoadRefusal(
+                title: "TOO LARGE",
+                message: "\(name) is \(Self.formatBytes(size)) — the viewer opens \(noun) up to \(Self.formatBytes(UInt64(limit)))."
+            )
+        }
+        let (data, _) = try await withConnection {
+            try await $0.readFile(atPath: path, limit: limit)
+        }
+        return data
+    }
+
+    /// The LOCKED panel's UNLOCK: PDFKit unlocks the document in place, so
+    /// the same `Document` is re-published for the screen to rebuild against
+    /// the now-readable pages. Returns false when the password is wrong; the
+    /// password itself is never kept.
+    func unlockPDF(password: String) -> Bool {
+        guard case .document(let document) = content,
+              let pdf = document.pdf, pdf.isLocked,
+              pdf.unlock(withPassword: password)
+        else { return false }
+        contentGeneration += 1
+        content = .document(document)
+        return true
     }
 
     /// Markdown renders both ways from the same held text: blocks when
@@ -1033,6 +1118,11 @@ final class FileViewerController: AuxiliaryPaneController {
                   generation == contentGeneration,
                   case .document(let still) = content, still.path == current.path
             else { return }
+            // New bytes, same listener: the replacement clip picks up where
+            // the old one was and the old one goes quiet.
+            if let previous = still.audio, let replacement = document.audio {
+                replacement.adoptPosition(from: previous)
+            }
             lastDocument = document
             content = .document(document)
         case .diff:

--- a/Multiplex/Services/SSHConnection.swift
+++ b/Multiplex/Services/SSHConnection.swift
@@ -687,8 +687,13 @@ actor SSHConnection {
                     if next < offsets.count { addNext() }
                 }
             }
-            for (index, chunk) in chunks.enumerated() {
-                guard let chunk else { break }
+            // Assemble into one reserved buffer, releasing each chunk as it
+            // lands: at the media cap the pieces are 60 MB on their own, and
+            // holding them beside the growing whole doubled the peak.
+            data.reserveCapacity(total)
+            for index in chunks.indices {
+                guard let chunk = chunks[index] else { break }
+                chunks[index] = nil
                 data.append(chunk)
                 let planned = min(readChunkSize, total - offsets[index])
                 if chunk.count < planned { break }

--- a/Multiplex/Views/Terminal/FileViewerPane.swift
+++ b/Multiplex/Views/Terminal/FileViewerPane.swift
@@ -1,4 +1,5 @@
 import Observation
+import PDFKit
 import UIKit
 
 /// Equatable projection of the controller's content enum. Observation can
@@ -162,8 +163,7 @@ final class FileViewerPaneViewController: UIViewController {
     private var watchTask: Task<Void, Never>?
 
     #if DEBUG
-    private var debugSelectObserver: NSObjectProtocol?
-    private var debugImageObserver: NSObjectProtocol?
+    private var debugObservers: [NSObjectProtocol] = []
     #endif
 
     init(
@@ -199,12 +199,7 @@ final class FileViewerPaneViewController: UIViewController {
         startTask?.cancel()
         watchTask?.cancel()
         #if DEBUG
-        if let debugSelectObserver {
-            NotificationCenter.default.removeObserver(debugSelectObserver)
-        }
-        if let debugImageObserver {
-            NotificationCenter.default.removeObserver(debugImageObserver)
-        }
+        for observer in debugObservers { NotificationCenter.default.removeObserver(observer) }
         #endif
     }
 
@@ -233,20 +228,29 @@ final class FileViewerPaneViewController: UIViewController {
         }
 
         #if DEBUG
-        debugSelectObserver = NotificationCenter.default.addObserver(
-            forName: .multiplexDebugFileViewerSelect,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.toggleMarkdownSelection() }
-        }
-        debugImageObserver = NotificationCenter.default.addObserver(
-            forName: .multiplexDebugFileViewerImage,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.pressFirstMarkdownImage() }
-        }
+        let center = NotificationCenter.default
+        debugObservers = [
+            center.addObserver(
+                forName: .multiplexDebugFileViewerSelect, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in self?.toggleMarkdownSelection() }
+            },
+            center.addObserver(
+                forName: .multiplexDebugFileViewerImage, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in self?.pressFirstMarkdownImage() }
+            },
+            center.addObserver(
+                forName: .multiplexDebugFileViewerPlay, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    guard let self, isActive,
+                          let audio = currentBodyView as? FileViewerAudioContentView
+                    else { return }
+                    _ = audio.playChip.accessibilityActivate()
+                }
+            },
+        ]
         #endif
     }
 
@@ -695,21 +699,22 @@ final class FileViewerPaneViewController: UIViewController {
     private func headerMeta(_ state: FileViewerPaneObservedState) -> String {
         switch state.body {
         case .document(let document):
-            var parts: [String] = []
-            if case .code(let language) = document.kind {
-                parts.append(language?.rawValue ?? "TEXT")
-            } else if document.kind == .markdown {
-                parts.append(
-                    state.markdownRaw
-                        ? "MARKDOWN · RAW"
-                        : (selectingMarkdownSource ? "MARKDOWN · SOURCE" : "MARKDOWN")
-                )
-            } else if document.kind == .image {
-                parts.append("IMAGE")
-            } else {
-                parts.append("BINARY")
+            let kind: String = switch document.kind {
+            case .code(let language): language?.rawValue ?? "TEXT"
+            case .markdown where state.markdownRaw: "MARKDOWN · RAW"
+            case .markdown: selectingMarkdownSource ? "MARKDOWN · SOURCE" : "MARKDOWN"
+            case .image: "IMAGE"
+            case .pdf:
+                switch document.pdf {
+                case nil: "PDF"
+                case let pdf? where pdf.isLocked: "PDF · LOCKED"
+                case let pdf?: "PDF · \(pdf.pageCount) PAGE\(pdf.pageCount == 1 ? "" : "S")"
+                }
+            case .audio:
+                document.audio.map { "AUDIO · \(FileViewerAudioClock.label($0.duration))" } ?? "AUDIO"
+            case .binary: "BINARY"
             }
-            parts.append(FileViewerController.formatBytes(document.size))
+            var parts = [kind, FileViewerController.formatBytes(document.size)]
             if document.truncated { parts.append("TRUNCATED") }
             return parts.joined(separator: " · ")
         case .diff(let diff, .repo):
@@ -995,6 +1000,10 @@ final class FileViewerPaneViewController: UIViewController {
         case loading(String)
         case binary(String)
         case image(String)
+        case pdf(String)
+        case pdfLocked(String)
+        case audio(String)
+        case audioUnplayable(String)
         case code(String)
         case markdown(String)
         case markdownSource(String)
@@ -1013,6 +1022,11 @@ final class FileViewerPaneViewController: UIViewController {
             case .binary: return .binary(document.path)
             case .image: return document.image == nil
                 ? .binary(document.path) : .image(document.path)
+            case .pdf:
+                guard let pdf = document.pdf else { return .binary(document.path) }
+                return pdf.isLocked ? .pdfLocked(document.path) : .pdf(document.path)
+            case .audio: return document.audio == nil
+                ? .audioUnplayable(document.path) : .audio(document.path)
             case .markdown where !document.markdown.isEmpty:
                 return selectingMarkdownSource && document.sourceText != nil
                     ? .markdownSource(document.path) : .markdown(document.path)
@@ -1097,6 +1111,37 @@ final class FileViewerPaneViewController: UIViewController {
             let view = FileViewerImageContentView()
             view.apply(image: image)
             return view
+        case .pdf:
+            guard let pdf = document.pdf else { return binaryBody(document) }
+            if pdf.isLocked {
+                // Still the file that was asked for: the panel says so and
+                // offers the one action that changes it.
+                return verdictPanel(
+                    document,
+                    caption: "LOCKED",
+                    message: "Password-protected. Unlocking opens it on this screen only — the password is not kept.",
+                    action: ("UNLOCK…", { [weak self] in self?.presentPDFUnlock(retrying: false) })
+                )
+            }
+            let view = FileViewerPDFContentView()
+            view.openLink = { [weak self] in self?.openMarkdownLink($0) }
+            view.apply(document: pdf)
+            return view
+        case .audio:
+            guard let clip = document.audio else {
+                // The bytes came down and Core Audio declined them; the
+                // verdict stays AUDIO — a sound file this device can't play,
+                // not "binary".
+                return verdictPanel(
+                    document,
+                    caption: "CAN'T PLAY",
+                    message: "This device can't decode it — a format Core Audio doesn't read "
+                        + "(Ogg Vorbis, for one), or not audio at all."
+                )
+            }
+            let view = FileViewerAudioContentView(volumeStore: .shared)
+            view.apply(clip: clip, name: document.name)
+            return view
         case .markdown where !document.markdown.isEmpty:
             if selectingMarkdownSource, let text = document.sourceText {
                 let view = FileViewerMarkdownSourceContentView()
@@ -1125,21 +1170,63 @@ final class FileViewerPaneViewController: UIViewController {
     }
 
     private func binaryBody(_ document: FileViewerController.Document) -> UIView {
+        verdictPanel(
+            document, caption: "BINARY", message: "Not text — Multiplex won't render it as code."
+        )
+    }
+
+    /// The chassis verdict panels — BINARY, LOCKED, CAN'T PLAY: the file
+    /// named with its size, one sentence, at most one action.
+    private func verdictPanel(
+        _ document: FileViewerController.Document,
+        caption: String,
+        message: String,
+        action: (caption: String, handler: () -> Void)? = nil
+    ) -> UIView {
         FileViewerPanelHostView(panel: FileViewerPanelView(
-            caption: "BINARY",
+            caption: caption,
             details: [
                 (
                     "\(document.name) · \(FileViewerController.formatBytes(document.size))",
                     UIKitChassis.monoFont(12),
                     UIKitChassis.signal2
                 ),
-                (
-                    "Not text — Multiplex won't render it as code.",
-                    UIFont.preferredFont(forTextStyle: .footnote),
-                    UIKitChassis.signal3
-                ),
-            ]
+                (message, UIFont.preferredFont(forTextStyle: .footnote), UIKitChassis.signal3),
+            ],
+            action: action
         ))
+    }
+
+    /// UNLOCK asks in an alert (the only host a system secure field gets
+    /// here) whose text is cleared in every button action — the key-unlock
+    /// alert's rule.
+    private func presentPDFUnlock(retrying: Bool) {
+        guard presentedViewController == nil else { return }
+        let alert = UIAlertController(
+            title: "Unlock PDF",
+            message: retrying
+                ? "That password didn't unlock it. Try again."
+                : "Enter the document's password.",
+            preferredStyle: .alert
+        )
+        alert.addTextField { field in
+            field.isSecureTextEntry = true
+            field.placeholder = "Password"
+            field.returnKeyType = .go
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { [weak alert] _ in
+            alert?.textFields?.first?.text = ""
+        })
+        alert.addAction(UIAlertAction(title: "Unlock", style: .default) { [weak self, weak alert] _ in
+            let password = alert?.textFields?.first?.text ?? ""
+            alert?.textFields?.first?.text = ""
+            guard let self else { return }
+            if !controller.unlockPDF(password: password) {
+                // The alert is dismissing itself; re-ask on the next turn.
+                Task { @MainActor [weak self] in self?.presentPDFUnlock(retrying: true) }
+            }
+        })
+        present(alert, animated: true)
     }
 
     private func applyTextScale(_ scale: CGFloat, to view: UIView?) {
@@ -1149,8 +1236,9 @@ final class FileViewerPaneViewController: UIViewController {
         case let source as FileViewerMarkdownSourceContentView: source.setTextScale(scale)
         case let diff as FileViewerDiffContentView: diff.setTextScale(scale)
         default:
-            // Image screens carry their own zoom and the state panels are
-            // chassis chrome — neither answers to the reading size.
+            // Image and PDF screens carry their own zoom, the sound panel and
+            // the state panels are chassis chrome — none answers to the
+            // reading size.
             break
         }
     }
@@ -1173,6 +1261,10 @@ final class FileViewerPaneViewController: UIViewController {
             source.apply(text: document.sourceText ?? "")
         case (.document(let document), let image as FileViewerImageContentView):
             if let uiImage = document.image { image.apply(image: uiImage) }
+        case (.document(let document), let pdf as FileViewerPDFContentView):
+            if let pdfDocument = document.pdf { pdf.apply(document: pdfDocument) }
+        case (.document(let document), let audio as FileViewerAudioContentView):
+            if let clip = document.audio { audio.apply(clip: clip, name: document.name) }
         case (.diff(let diff, let scope), let diffView as FileViewerDiffContentView):
             diffView.apply(diff: diff, scope: scope)
         default:
@@ -1280,14 +1372,7 @@ final class FileViewerBadgeView: UIKitTallyBorderedView {
         super.init(frame: .zero)
         backgroundColor = GlassPrototype.strataChassis
         isAccessibilityElement = true
-        label.attributedText = NSAttributedString(
-            string: text,
-            attributes: [
-                .font: UIKitChassis.monoFont(9, weight: .semibold),
-                .kern: 1.1,
-                .foregroundColor: UIKitChassis.signal2,
-            ]
-        )
+        setText(text)
         addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -1300,6 +1385,21 @@ final class FileViewerBadgeView: UIKitTallyBorderedView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
+
+    /// Readouts that move (a PDF's page) restyle the same badge in place; an
+    /// unchanged text is a no-op, so callers can set it from layout.
+    func setText(_ text: String) {
+        guard text != accessibilityLabel else { return }
+        accessibilityLabel = text
+        label.attributedText = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: UIKitChassis.monoFont(9, weight: .semibold),
+                .kern: 1.1,
+                .foregroundColor: UIKitChassis.signal2,
+            ]
+        )
+    }
 }
 
 // MARK: - Syntax + diff palette (screen content, not chrome)
@@ -1463,7 +1563,7 @@ final class FileViewerPanelView: UIKitTallyBorderedView {
 }
 
 @MainActor
-final class FileViewerPanelHostView: UIView {
+class FileViewerPanelHostView: UIView {
     init(panel: UIView, outerInset: CGFloat = 0) {
         super.init(frame: .zero)
         backgroundColor = UIKitChassis.screen
@@ -1481,6 +1581,43 @@ final class FileViewerPanelHostView: UIView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
+}
+
+// MARK: - Shared screen furniture
+
+/// The image and PDF screens' zoom-reset chip: `133% · FIT`, hidden at fit,
+/// one caption and one accessibility phrasing for both.
+@MainActor
+enum FileViewerZoomReadout {
+    static func makeChip(action: @escaping () -> Void) -> UIKitChassisChip {
+        let chip = UIKitChassisChip(
+            "100% · FIT", accessibilityLabel: "Zoom 100 percent; resets to fit", action: action
+        )
+        chip.isHidden = true
+        return chip
+    }
+
+    /// `ratio` is the current scale over the fit scale.
+    static func show(ratio: CGFloat, on chip: UIKitChassisChip) {
+        let percent = Int((ratio * 100).rounded())
+        chip.setContent(caption: "\(percent)% · FIT", systemImage: nil)
+        chip.accessibilityLabel = "Zoom \(percent) percent; resets to fit"
+        chip.isHidden = abs(ratio - 1) < 0.01
+    }
+}
+
+/// The sound panel's sliders — scrubber and volume — in one chassis dress.
+@MainActor
+private func makeChassisSlider(accessibilityLabel: String) -> UISlider {
+    let slider = UISlider()
+    slider.minimumValue = 0
+    slider.maximumValue = 1
+    slider.isContinuous = true
+    slider.minimumTrackTintColor = UIKitChassis.signal2
+    slider.maximumTrackTintColor = UIKitChassis.bezelHi
+    slider.thumbTintColor = UIKitChassis.signal
+    slider.accessibilityLabel = accessibilityLabel
+    return slider
 }
 
 // MARK: - Native selectable code and diff screens
@@ -1771,12 +1908,7 @@ final class FileViewerImageContentView: UIView, UIScrollViewDelegate {
         doubleTap.numberOfTapsRequired = 2
         scrollView.addGestureRecognizer(doubleTap)
 
-        zoomChip = UIKitChassisChip(
-            "100% · FIT",
-            accessibilityLabel: "Zoom 100 percent; resets to fit",
-            action: { [weak self] in self?.resetZoom(animated: true) }
-        )
-        zoomChip.isHidden = true
+        zoomChip = FileViewerZoomReadout.makeChip { [weak self] in self?.resetZoom(animated: true) }
         addSubview(zoomChip)
         zoomChip.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -1838,10 +1970,7 @@ final class FileViewerImageContentView: UIView, UIScrollViewDelegate {
     }
 
     private func updateZoomChip() {
-        let percent = Int((scrollView.zoomScale * 100).rounded())
-        zoomChip.setContent(caption: "\(percent)% · FIT", systemImage: nil)
-        zoomChip.accessibilityLabel = "Zoom \(percent) percent; resets to fit"
-        zoomChip.isHidden = abs(scrollView.zoomScale - 1) < 0.01
+        FileViewerZoomReadout.show(ratio: scrollView.zoomScale, on: zoomChip)
     }
 
     private func fittedSize(in container: CGSize) -> CGSize {
@@ -1864,6 +1993,412 @@ final class FileViewerImageContentView: UIView, UIScrollViewDelegate {
 private extension Comparable {
     func clamped(to range: ClosedRange<Self>) -> Self {
         min(max(self, range.lowerBound), range.upperBound)
+    }
+}
+
+// MARK: - Native PDF screen
+
+/// PDFKit's view on the chassis screen: continuous vertical pages, pinch
+/// zoom, native text selection, with a page readout and the image screen's
+/// zoom-reset chip in the corner. A URL link inside the document is untrusted
+/// document text exactly like a markdown link — it goes to the app's link
+/// sheet through `openLink`, never straight to the system (PDFKit's default
+/// when no delegate answers). A quiet watch swap keeps the reader's page.
+///
+/// Zoom is left to `autoScales`: while it is on, PDFKit fits the page width
+/// and refits on every resize, and it sets its own absolute bounds (0.25–5×,
+/// measured 2026-08-15). A pinch — or ANY write to `minScaleFactor` /
+/// `maxScaleFactor` / `scaleFactor` — switches it off, after which a resize
+/// leaves the page where it was; the FIT chip re-arms it rather than
+/// assigning the fit scale, which is what keeps resizes fitting again.
+@MainActor
+final class FileViewerPDFContentView: UIView {
+    private(set) var pdfView = PDFView()
+    private(set) var pageBadge = FileViewerBadgeView("")
+    private(set) var zoomChip: UIKitChassisChip!
+    private var observers: [NSObjectProtocol] = []
+    /// `PDFDocument.index(for:)` walks the pages; the page changes only when
+    /// PDFKit says so, so the index is looked up once per page, not per layout.
+    private var readPage: PDFPage?
+    private var readIndex = 0
+    private var readoutSize = CGSize.zero
+    var openLink: ((String) -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = UIKitChassis.screen
+        pdfView.backgroundColor = UIKitChassis.screen
+        pdfView.autoScales = true
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displayDirection = .vertical
+        pdfView.displaysPageBreaks = true
+        pdfView.delegate = self
+        pdfView.isAccessibilityElement = false
+        addSubview(pdfView)
+        pdfView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            pdfView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pdfView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            pdfView.topAnchor.constraint(equalTo: topAnchor),
+            pdfView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        zoomChip = FileViewerZoomReadout.makeChip { [weak self] in self?.resetZoom() }
+        pageBadge.isHidden = true
+        let corner = UIStackView(arrangedSubviews: [pageBadge, zoomChip])
+        corner.axis = .horizontal
+        corner.alignment = .center
+        corner.spacing = 6
+        addSubview(corner)
+        corner.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            corner.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            corner.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+        ])
+
+        let center = NotificationCenter.default
+        for name in [Notification.Name.PDFViewPageChanged, .PDFViewScaleChanged] {
+            observers.append(center.addObserver(
+                forName: name, object: pdfView, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.updateReadouts() }
+            })
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    deinit {
+        for observer in observers { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    /// The document on screen. A replacement (the watch saw new bytes — a
+    /// LaTeX rebuild, say) lands on the page the reader was on when that page
+    /// still exists, so a document being rebuilt can be read as it grows; a
+    /// zoom the reader chose survives too (autoScales is already off then).
+    func apply(document: PDFDocument) {
+        guard pdfView.document !== document else { return }
+        let keptPage = pdfView.currentPage.flatMap { pdfView.document?.index(for: $0) }
+        pdfView.document = document
+        if let keptPage, keptPage < document.pageCount, let page = document.page(at: keptPage) {
+            pdfView.go(to: page)
+        }
+        updateReadouts()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // A new width is a new fit — the zoom readout must say so even when
+        // PDFKit posts no scale change for it; an unchanged size costs nothing.
+        guard pdfView.bounds.size != readoutSize else { return }
+        readoutSize = pdfView.bounds.size
+        updateReadouts()
+    }
+
+    /// PDFKit calls this INSTEAD of opening the URL itself, which is the
+    /// point: the app confirms links, it never follows them.
+    func linkPressed(_ url: URL) {
+        openLink?(url.absoluteString)
+    }
+
+    private func resetZoom() {
+        // Re-arm rather than assign: an assigned fit is stale after the next
+        // resize, an armed one follows it.
+        pdfView.autoScales = true
+        updateReadouts()
+    }
+
+    /// Runs from layout as well as from PDFKit's notifications; the widgets
+    /// gate their own restyles, so an unchanged readout costs a comparison.
+    private func updateReadouts() {
+        guard let document = pdfView.document else {
+            pageBadge.isHidden = true
+            zoomChip.isHidden = true
+            return
+        }
+        if let page = pdfView.currentPage, page !== readPage {
+            readPage = page
+            readIndex = document.index(for: page)
+        }
+        let count = document.pageCount
+        pageBadge.setText("PAGE \(readIndex + 1) / \(count)")
+        pageBadge.isHidden = count <= 1
+        let fit = pdfView.scaleFactorForSizeToFit
+        FileViewerZoomReadout.show(ratio: fit > 0 ? pdfView.scaleFactor / fit : 1, on: zoomChip)
+    }
+}
+
+extension FileViewerPDFContentView: PDFViewDelegate {
+    /// PDFKit reports the press from the main thread; the hop keeps the
+    /// compiler's word for it without isolating the whole conformance.
+    nonisolated func pdfViewWillClick(onLink sender: PDFView, with url: URL) {
+        Task { @MainActor in self.linkPressed(url) }
+    }
+}
+
+// MARK: - Native audio screen
+
+/// The transport for a sound file: a centered chassis panel with the state
+/// lamp (PLAYING wears tally red — it is live state, and captioned), the
+/// file's name, PLAY/PAUSE with ±15 s either side, a scrubber, the clock,
+/// and a volume row. The clip belongs to the document; this view is its
+/// remote and polls it a few times a second only while it plays — nothing
+/// about the position is observable state, and a paused panel costs no
+/// wakeups. The controller pauses a clip whose document leaves the screen;
+/// a tab merely hidden behind another keeps playing — listening while typing
+/// is the point of a sound file beside a session. Volume is the listener's
+/// app-wide level (`FileViewerAudioVolumeStore`): the slider writes it, the
+/// clip follows it on its own, and this panel mirrors it by observation.
+@MainActor
+final class FileViewerAudioContentView: FileViewerPanelHostView {
+    private(set) var clip: FileViewerAudioClip?
+    private let volumeStore: FileViewerAudioVolumeStore
+    private let panel = UIKitTallyBorderedView()
+    private let lampSlot = UIStackView()
+    private var lampState: LampState?
+    private let nameLabel = UILabel()
+    private(set) var playChip: UIKitChassisChip!
+    private(set) var backChip: UIKitChassisChip!
+    private(set) var forwardChip: UIKitChassisChip!
+    private(set) var slider: UISlider
+    private(set) var elapsedLabel = UILabel()
+    private(set) var remainingLabel = UILabel()
+    private(set) var volumeSlider: UISlider
+    private(set) var volumeLabel = UILabel()
+    private var timer: Timer?
+
+    enum LampState: Equatable {
+        case ready, playing, paused
+    }
+
+    init(volumeStore: FileViewerAudioVolumeStore) {
+        self.volumeStore = volumeStore
+        slider = makeChassisSlider(accessibilityLabel: "Playback position")
+        volumeSlider = makeChassisSlider(accessibilityLabel: "Volume")
+        super.init(panel: panel, outerInset: 20)
+
+        panel.backgroundColor = UIKitChassis.bezel
+        panel.layer.cornerRadius = 12
+        panel.layer.cornerCurve = .continuous
+        panel.clipsToBounds = true
+
+        nameLabel.font = UIKitChassis.monoFont(12)
+        nameLabel.textColor = UIKitChassis.signal2
+        nameLabel.numberOfLines = 1
+        nameLabel.lineBreakMode = .byTruncatingMiddle
+        nameLabel.textAlignment = .center
+
+        backChip = UIKitChassisChip(
+            "15",
+            systemImage: "gobackward",
+            accessibilityLabel: "Back 15 seconds",
+            action: { [weak self] in
+                self?.clip?.skip(by: -FileViewerAudioClip.skipInterval)
+                self?.refresh()
+            }
+        )
+        playChip = UIKitChassisChip(
+            "PLAY",
+            systemImage: "play.fill",
+            prominent: true,
+            accessibilityLabel: "Play",
+            action: { [weak self] in
+                self?.clip?.togglePlayback()
+                self?.refresh()
+            }
+        )
+        forwardChip = UIKitChassisChip(
+            "15",
+            systemImage: "goforward",
+            accessibilityLabel: "Forward 15 seconds",
+            action: { [weak self] in
+                self?.clip?.skip(by: FileViewerAudioClip.skipInterval)
+                self?.refresh()
+            }
+        )
+        let transport = UIStackView(arrangedSubviews: [backChip, playChip, forwardChip])
+        transport.axis = .horizontal
+        transport.alignment = .center
+        transport.spacing = 8
+
+        slider.addTarget(self, action: #selector(scrubbed), for: .valueChanged)
+        for label in [elapsedLabel, remainingLabel, volumeLabel] {
+            label.font = UIKitChassis.monoFont(10)
+            label.textColor = UIKitChassis.signal2
+        }
+        remainingLabel.textAlignment = .right
+        let clock = UIStackView(arrangedSubviews: [elapsedLabel, remainingLabel])
+        clock.axis = .horizontal
+        clock.distribution = .fillEqually
+
+        // Volume: a glyph, the level, and its readout.
+        let volumeGlyph = UIImageView(image: UIImage(
+            systemName: "speaker.wave.2.fill",
+            withConfiguration: UIImage.SymbolConfiguration(
+                pointSize: 10 * Theme.typeScale, weight: .semibold
+            )
+        ))
+        volumeGlyph.tintColor = UIKitChassis.signal3
+        volumeGlyph.contentMode = .scaleAspectFit
+        volumeGlyph.setContentHuggingPriority(.required, for: .horizontal)
+        volumeGlyph.isAccessibilityElement = false
+        volumeSlider.addTarget(self, action: #selector(volumeChanged), for: .valueChanged)
+        volumeLabel.textAlignment = .right
+        volumeLabel.setContentHuggingPriority(.required, for: .horizontal)
+        volumeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        volumeLabel.isAccessibilityElement = false
+        let volumeRow = UIStackView(arrangedSubviews: [volumeGlyph, volumeSlider, volumeLabel])
+        volumeRow.axis = .horizontal
+        volumeRow.alignment = .center
+        volumeRow.spacing = 10
+
+        let stack = UIStackView(
+            arrangedSubviews: [lampSlot, nameLabel, transport, slider, clock, volumeRow]
+        )
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 14
+        stack.setCustomSpacing(8, after: slider)
+        panel.addSubview(stack)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        let preferredWidth = panel.widthAnchor.constraint(equalToConstant: 440)
+        preferredWidth.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            panel.widthAnchor.constraint(lessThanOrEqualToConstant: 440),
+            preferredWidth,
+            stack.leadingAnchor.constraint(equalTo: panel.leadingAnchor, constant: 26),
+            stack.trailingAnchor.constraint(equalTo: panel.trailingAnchor, constant: -26),
+            stack.topAnchor.constraint(equalTo: panel.topAnchor, constant: 24),
+            stack.bottomAnchor.constraint(equalTo: panel.bottomAnchor, constant: -24),
+            slider.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            clock.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            volumeRow.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            // A fixed readout width keeps the slider from breathing as the
+            // digits change count.
+            volumeLabel.widthAnchor.constraint(equalToConstant: 38 * Theme.typeScale),
+            nameLabel.widthAnchor.constraint(lessThanOrEqualTo: stack.widthAnchor),
+        ])
+        setLamp(.ready)
+        mirrorVolume()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    /// Bind the screen to a clip. Rebinding (a quiet watch swap handed the
+    /// position to a replacement clip) restyles in place; the panel keeps
+    /// its identity.
+    func apply(clip: FileViewerAudioClip, name: String) {
+        self.clip = clip
+        nameLabel.text = name
+        nameLabel.accessibilityLabel = name
+        remainingLabel.text = FileViewerAudioClock.label(clip.duration)
+        refresh()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil {
+            stopTimer()
+        } else {
+            refresh()
+        }
+    }
+
+    /// The remote's one repaint: transport caption, lamp, scrubber, clock.
+    /// Every write is change-gated — this runs four times a second while the
+    /// clip plays, and a restyle costs the panel a layout pass.
+    func refresh() {
+        guard let clip else { return }
+        let playing = clip.isPlaying
+        playChip.setContent(
+            caption: playing ? "PAUSE" : "PLAY",
+            systemImage: playing ? "pause.fill" : "play.fill"
+        )
+        playChip.accessibilityLabel = playing ? "Pause" : "Play"
+        setLamp(playing ? .playing : (clip.currentTime > 0 ? .paused : .ready))
+        let duration = clip.duration
+        let position = duration > 0 ? Float(clip.currentTime / duration) : 0
+        if !slider.isTracking, slider.value != position {
+            slider.setValue(position, animated: false)
+        }
+        let elapsed = FileViewerAudioClock.label(clip.currentTime)
+        if elapsedLabel.text != elapsed {
+            elapsedLabel.text = elapsed
+            slider.accessibilityValue = "\(elapsed) of \(FileViewerAudioClock.label(duration))"
+        }
+        // The clock only moves while the clip plays; a paused panel needs no
+        // wakeups, and the tick that sees playback end stops itself.
+        if playing, window != nil {
+            startTimerIfNeeded()
+        } else {
+            stopTimer()
+        }
+    }
+
+    private func startTimerIfNeeded() {
+        guard timer == nil else { return }
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refresh() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func setLamp(_ state: LampState) {
+        guard state != lampState else { return }
+        lampState = state
+        for old in lampSlot.arrangedSubviews { old.removeFromSuperview() }
+        let lamp: UIKitTallyLamp = switch state {
+        case .ready: UIKitTallyLamp(caption: "READY", color: UIKitChassis.signal3)
+        case .playing: UIKitTallyLamp(caption: "PLAYING", color: TallyPalette.tally)
+        case .paused: UIKitTallyLamp(caption: "PAUSED", color: UIKitChassis.signal3)
+        }
+        lampSlot.addArrangedSubview(lamp)
+    }
+
+    /// The store is the level's owner; this panel mirrors it — the hop past
+    /// Observation's before-the-write hook is what makes the re-read current.
+    private func mirrorVolume() {
+        withObservationTracking {
+            showVolume(volumeStore.volume)
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in self?.mirrorVolume() }
+        }
+    }
+
+    private func showVolume(_ level: Float) {
+        if !volumeSlider.isTracking, volumeSlider.value != level {
+            volumeSlider.setValue(level, animated: false)
+        }
+        let readout = FileViewerAudioVolume.percentLabel(level)
+        if volumeLabel.text != readout {
+            volumeLabel.text = readout
+            volumeSlider.accessibilityValue = readout
+        }
+    }
+
+    @objc private func scrubbed() {
+        guard let clip else { return }
+        clip.seek(to: Double(slider.value) * clip.duration)
+        refresh()
+    }
+
+    /// Whole percents: the readout shows nothing finer, and it makes the
+    /// store's equality guard coalesce a drag's frames into a few writes.
+    @objc private func volumeChanged() {
+        volumeStore.set((volumeSlider.value * 100).rounded() / 100)
+        showVolume(volumeStore.volume)
     }
 }
 

--- a/Multiplex/Views/Terminal/TerminalWindow.swift
+++ b/Multiplex/Views/Terminal/TerminalWindow.swift
@@ -26,6 +26,9 @@ extension Notification.Name {
     static let multiplexDebugFileViewerImage = Notification.Name(
         "MultiplexDebugFileViewerImage"
     )
+    static let multiplexDebugFileViewerPlay = Notification.Name(
+        "MultiplexDebugFileViewerPlay"
+    )
 }
 
 /// `….debug.fileviewer` runs the focused window's + TAB ▸ File Viewer
@@ -37,6 +40,9 @@ extension Notification.Name {
 /// simulator can't tap). `….debug.fvimage` presses the first image
 /// placeholder on the rendered markdown screen — the same destination →
 /// resolve → open path a finger takes, which no sim tap can drive.
+/// `….debug.fvplay` presses PLAY/PAUSE on the active viewer's sound screen
+/// (the panel's own chip action; proof is the PLAYING lamp and a moving
+/// clock in the next screenshot).
 @MainActor
 enum FileViewerDebugHook {
     private static var installed = false
@@ -78,6 +84,14 @@ enum FileViewerDebugHook {
         ) { _ in
             NotificationCenter.default.post(
                 name: .multiplexDebugFileViewerImage, object: nil
+            )
+        }
+        var playToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.fvplay", &playToken, .main
+        ) { _ in
+            NotificationCenter.default.post(
+                name: .multiplexDebugFileViewerPlay, object: nil
             )
         }
     }

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -2612,6 +2612,9 @@ extension TerminalWindowViewController {
         else { return }
         controller.dismissPendingLink()
         openViewport(offer)
+        // The chip's own road ends with the sheet going away; the model
+        // clear above leaves the presented sheet standing otherwise.
+        dismissPresentedFeature()
     }
 
     private func debugOpenFileViewer() {
@@ -2626,6 +2629,7 @@ extension TerminalWindowViewController {
         else { return }
         controller.dismissPendingPath()
         openFileViewer(target: target)
+        dismissPresentedFeature()
     }
 
     private func debugLogLinkRegions() {

--- a/MultiplexTests/FileKindTests.swift
+++ b/MultiplexTests/FileKindTests.swift
@@ -26,6 +26,23 @@ final class FileKindTests: XCTestCase {
         XCTAssertEqual(FileKind.classify(fileName: "release.tar.gz"), .binary)
     }
 
+    /// PDFs and sound files have screens of their own now; video containers
+    /// and the formats no device here decodes stay opaque bytes.
+    func testDocumentsAndSoundFilesHaveTheirOwnScreens() {
+        XCTAssertEqual(FileKind.classify(fileName: "paper.pdf"), .pdf)
+        XCTAssertEqual(FileKind.classify(fileName: "Scan.PDF"), .pdf)
+        for name in [
+            "take.mp3", "voice.m4a", "book.m4b", "raw.aac", "hit.wav", "hit.WAVE",
+            "loop.aiff", "loop.aif", "cue.caf", "master.flac", "note.amr", "bell.au",
+            "song.ogg", "song.oga", "talk.opus",
+        ] {
+            XCTAssertEqual(FileKind.classify(fileName: name), .audio, name)
+        }
+        for name in ["clip.mp4", "clip.mov", "clip.m4v", "clip.mkv", "clip.webm", "old.wma"] {
+            XCTAssertEqual(FileKind.classify(fileName: name), .binary, name)
+        }
+    }
+
     func testDotfileIsNotAnExtension() {
         // ".zshrc" — the leading dot is a hidden-file marker, not an
         // extension separator.

--- a/MultiplexTests/FileViewerMediaTests.swift
+++ b/MultiplexTests/FileViewerMediaTests.swift
@@ -1,0 +1,351 @@
+import PDFKit
+import UIKit
+import XCTest
+@testable import Multiplex
+
+/// The ▤ viewer's PDF and sound screens: the clip's transport contract, the
+/// remote that drives it, and PDFKit's screen with its readouts. Fixtures are
+/// built in memory — a PCM WAV header over silence, a `UIGraphicsPDFRenderer`
+/// document — so nothing here reaches disk or a host.
+@MainActor
+final class FileViewerMediaTests: XCTestCase {
+    // MARK: Audio clip
+
+    func testAudioClipReadsTheLengthAndKeepsSeeksInsideIt() throws {
+        let clip = try Self.clip(seconds: 2)
+        XCTAssertEqual(clip.duration, 2, accuracy: 0.05)
+        XCTAssertFalse(clip.isPlaying)
+        XCTAssertEqual(clip.currentTime, 0, accuracy: 0.01)
+
+        clip.seek(to: 1)
+        XCTAssertEqual(clip.currentTime, 1, accuracy: 0.05)
+        // Past the end holds a hair short of it, so PLAY after a full scrub
+        // still plays; before the start clamps to zero.
+        clip.seek(to: 99)
+        XCTAssertLessThan(clip.currentTime, clip.duration)
+        XCTAssertGreaterThan(clip.currentTime, clip.duration - 0.2)
+        clip.seek(to: -5)
+        XCTAssertEqual(clip.currentTime, 0, accuracy: 0.01)
+        clip.skip(by: FileViewerAudioClip.skipInterval)
+        XCTAssertLessThan(clip.currentTime, clip.duration)
+    }
+
+    func testAudioClipRefusesBytesCoreAudioCannotRead() {
+        XCTAssertThrowsError(try FileViewerAudioClip(
+            data: Data("not a sound file".utf8), fileName: "x.mp3", volumeStore: .shared
+        ))
+        XCTAssertThrowsError(try FileViewerAudioClip(
+            data: Data(), fileName: "empty.wav", volumeStore: .shared
+        ))
+    }
+
+    /// The name is only a hint: sound bytes under a stray or missing
+    /// extension are still sniffed and read.
+    func testAudioClipReadsSoundBytesWhateverTheNameSays() {
+        let wav = Self.wavData(seconds: 1)
+        for name in ["mystery.bin", "noext", "renamed.mp3"] {
+            XCTAssertNoThrow(try FileViewerAudioClip(data: wav, fileName: name, volumeStore: .shared))
+        }
+    }
+
+    func testClockLabelFloorsAndGrowsAnHourField() {
+        XCTAssertEqual(FileViewerAudioClock.label(0), "0:00")
+        XCTAssertEqual(FileViewerAudioClock.label(0.9), "0:00")
+        XCTAssertEqual(FileViewerAudioClock.label(59.9), "0:59")
+        XCTAssertEqual(FileViewerAudioClock.label(61), "1:01")
+        XCTAssertEqual(FileViewerAudioClock.label(3725), "1:02:05")
+        XCTAssertEqual(FileViewerAudioClock.label(.nan), "0:00")
+        XCTAssertEqual(FileViewerAudioClock.label(.infinity), "0:00")
+    }
+
+    // MARK: Audio screen
+
+    func testAudioScreenIsARemoteForTheClip() throws {
+        let clip = try Self.clip(seconds: 2)
+        let screen = FileViewerAudioContentView(volumeStore: .shared)
+        screen.frame = CGRect(x: 0, y: 0, width: 600, height: 400)
+        screen.apply(clip: clip, name: "tone.wav")
+        screen.layoutIfNeeded()
+
+        XCTAssertEqual(screen.playChip.accessibilityLabel, "Play")
+        XCTAssertEqual(screen.backChip.accessibilityLabel, "Back 15 seconds")
+        XCTAssertEqual(screen.forwardChip.accessibilityLabel, "Forward 15 seconds")
+        XCTAssertEqual(screen.elapsedLabel.text, "0:00")
+        XCTAssertEqual(screen.remainingLabel.text, "0:02")
+        XCTAssertEqual(screen.lampCaption, "ready")
+
+        clip.seek(to: 1)
+        screen.refresh()
+        XCTAssertEqual(screen.elapsedLabel.text, "0:01")
+        XCTAssertEqual(screen.slider.value, 0.5, accuracy: 0.03)
+        XCTAssertEqual(screen.slider.accessibilityValue, "0:01 of 0:02")
+        XCTAssertEqual(screen.lampCaption, "paused")
+
+        // The scrubber drives the clip; the skip chips ride the same seek.
+        screen.slider.value = 0.25
+        screen.slider.sendActions(for: .valueChanged)
+        XCTAssertEqual(clip.currentTime, 0.5, accuracy: 0.05)
+        XCTAssertTrue(screen.backChip.accessibilityActivate())
+        XCTAssertEqual(clip.currentTime, 0, accuracy: 0.01)
+        XCTAssertEqual(screen.lampCaption, "ready")
+        XCTAssertTrue(screen.forwardChip.accessibilityActivate())
+        XCTAssertLessThan(clip.currentTime, clip.duration)
+        XCTAssertGreaterThan(clip.currentTime, 0)
+    }
+
+    /// The panel names the file: a moved tab rebuilds the pane, and the new
+    /// remote binds to the same clip at the same position.
+    func testAudioScreenRebindsWithoutLosingThePosition() throws {
+        let clip = try Self.clip(seconds: 3)
+        clip.seek(to: 2)
+        let screen = FileViewerAudioContentView(volumeStore: .shared)
+        screen.apply(clip: clip, name: "tone.wav")
+        XCTAssertEqual(screen.elapsedLabel.text, "0:02")
+        XCTAssertEqual(screen.remainingLabel.text, "0:03")
+
+        // A quiet watch reload hands the position to the replacement clip.
+        let replacement = try Self.clip(seconds: 3)
+        replacement.adoptPosition(from: clip)
+        XCTAssertEqual(replacement.currentTime, 2, accuracy: 0.05)
+        XCTAssertEqual(clip.currentTime, 0, accuracy: 0.01, "the replaced clip is rewound")
+        screen.apply(clip: replacement, name: "tone.wav")
+        XCTAssertEqual(screen.elapsedLabel.text, "0:02")
+        XCTAssertTrue(screen.clip === replacement)
+    }
+
+    // MARK: Volume
+
+    func testAudioVolumeClampsAndReadsOut() {
+        XCTAssertEqual(FileViewerAudioVolume.clamped(1.5), 1)
+        XCTAssertEqual(FileViewerAudioVolume.clamped(-0.2), 0)
+        XCTAssertEqual(FileViewerAudioVolume.clamped(.nan), 1)
+        XCTAssertEqual(FileViewerAudioVolume.clamped(0.35), 0.35)
+        XCTAssertEqual(FileViewerAudioVolume.percentLabel(0.354), "35%")
+        XCTAssertEqual(FileViewerAudioVolume.percentLabel(1), "100%")
+        XCTAssertEqual(FileViewerAudioVolume.percentLabel(0), "0%")
+    }
+
+    func testVolumeStorePersistsTheLevelDeviceLocally() throws {
+        let suite = "FileViewerMediaTests.volume.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let store = FileViewerAudioVolumeStore(defaults: defaults)
+        XCTAssertEqual(store.volume, 1, "a fresh install listens at full level")
+        store.set(0.4)
+        XCTAssertEqual(store.volume, 0.4)
+        store.set(2)
+        XCTAssertEqual(store.volume, 1, "the store clamps like the model")
+        store.set(0.25)
+        XCTAssertEqual(FileViewerAudioVolumeStore(defaults: defaults).volume, 0.25)
+    }
+
+    /// The slider writes the app-wide level; every clip follows the store on
+    /// its own, and a second panel (another tab, another window) mirrors it —
+    /// neither needs the panel that moved it.
+    func testVolumeSliderDrivesTheStoreAndEveryClipAndPanelFollow() async throws {
+        let suite = "FileViewerMediaTests.volume.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = FileViewerAudioVolumeStore(defaults: defaults)
+
+        let clip = try Self.clip(seconds: 1, volumeStore: store)
+        let screen = FileViewerAudioContentView(volumeStore: store)
+        screen.apply(clip: clip, name: "a.wav")
+        XCTAssertEqual(screen.volumeLabel.text, "100%")
+        XCTAssertEqual(screen.volumeSlider.accessibilityLabel, "Volume")
+
+        screen.volumeSlider.value = 0.4
+        screen.volumeSlider.sendActions(for: .valueChanged)
+        XCTAssertEqual(store.volume, 0.4, accuracy: 0.001)
+        XCTAssertEqual(screen.volumeLabel.text, "40%")
+        XCTAssertEqual(screen.volumeSlider.accessibilityValue, "40%")
+        await Self.settle { clip.volume == 0.4 }
+        XCTAssertEqual(clip.volume, 0.4, accuracy: 0.001)
+
+        // A clip made after the change is born at the listener's level, and
+        // its panel opens on it.
+        let later = try Self.clip(seconds: 1, volumeStore: store)
+        XCTAssertEqual(later.volume, 0.4, accuracy: 0.001)
+        let other = FileViewerAudioContentView(volumeStore: store)
+        other.apply(clip: later, name: "b.wav")
+        XCTAssertEqual(other.volumeSlider.value, 0.4, accuracy: 0.001)
+
+        // Moving the level in one panel reaches the other clip and panel
+        // through the store — no refresh of theirs involved.
+        screen.volumeSlider.value = 0.7
+        screen.volumeSlider.sendActions(for: .valueChanged)
+        await Self.settle { later.volume == 0.7 && other.volumeLabel.text == "70%" }
+        XCTAssertEqual(later.volume, 0.7, accuracy: 0.001)
+        XCTAssertEqual(other.volumeSlider.value, 0.7, accuracy: 0.001)
+        XCTAssertEqual(other.volumeLabel.text, "70%")
+
+        // A drag's frames coalesce to whole percents before the store writes.
+        screen.volumeSlider.value = 0.70004
+        screen.volumeSlider.sendActions(for: .valueChanged)
+        XCTAssertEqual(store.volume, 0.7, accuracy: 0.0001)
+    }
+
+    // MARK: PDF screen
+
+    func testPDFScreenReportsPagesAndKeepsThePageAcrossAReload() throws {
+        let document = try XCTUnwrap(PDFDocument(data: Self.pdfData(pages: 3)))
+        let screen = FileViewerPDFContentView()
+        screen.frame = CGRect(x: 0, y: 0, width: 400, height: 600)
+        screen.apply(document: document)
+        screen.layoutIfNeeded()
+
+        XCTAssertEqual(screen.pdfView.document?.pageCount, 3)
+        XCTAssertFalse(screen.pageBadge.isHidden)
+        XCTAssertEqual(screen.pageBadge.accessibilityLabel, "PAGE 1 / 3")
+        XCTAssertTrue(screen.zoomChip.isHidden, "at fit there is nothing to reset")
+        XCTAssertEqual(screen.pdfView.displayMode, .singlePageContinuous)
+        XCTAssertTrue(screen.pdfView.autoScales)
+
+        // Zooming in (which switches PDFKit's autoScales off, as a pinch
+        // does) surfaces the reset chip with the multiple of fit; the chip
+        // re-arms the fit, so the next resize fits again instead of holding
+        // the old scale.
+        screen.pdfView.scaleFactor = screen.pdfView.scaleFactorForSizeToFit * 2
+        screen.setNeedsLayout()
+        screen.layoutIfNeeded()
+        XCTAssertFalse(screen.pdfView.autoScales)
+        XCTAssertFalse(screen.zoomChip.isHidden)
+        XCTAssertEqual(screen.zoomChip.accessibilityLabel, "Zoom 200 percent; resets to fit")
+        XCTAssertTrue(screen.zoomChip.accessibilityActivate())
+        XCTAssertTrue(screen.pdfView.autoScales)
+        XCTAssertEqual(
+            screen.pdfView.scaleFactor, screen.pdfView.scaleFactorForSizeToFit, accuracy: 0.001
+        )
+        XCTAssertTrue(screen.zoomChip.isHidden)
+        screen.frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        screen.layoutIfNeeded()
+        XCTAssertEqual(
+            screen.pdfView.scaleFactor, screen.pdfView.scaleFactorForSizeToFit, accuracy: 0.001,
+            "an armed fit follows the width"
+        )
+        XCTAssertTrue(screen.zoomChip.isHidden)
+
+        // A reader on page 3 sees the rebuilt document open on page 3.
+        screen.pdfView.go(to: try XCTUnwrap(document.page(at: 2)))
+        screen.setNeedsLayout()
+        screen.layoutIfNeeded()
+        XCTAssertEqual(screen.pdfView.currentPage.map { document.index(for: $0) }, 2)
+        let rebuilt = try XCTUnwrap(PDFDocument(data: Self.pdfData(pages: 4)))
+        screen.apply(document: rebuilt)
+        screen.layoutIfNeeded()
+        XCTAssertTrue(screen.pdfView.document === rebuilt)
+        XCTAssertEqual(screen.pdfView.currentPage.map { rebuilt.index(for: $0) }, 2)
+        XCTAssertEqual(screen.pageBadge.accessibilityLabel, "PAGE 3 / 4")
+    }
+
+    func testSinglePagePDFShowsNoPageReadoutAndLinksGoToTheApp() throws {
+        let document = try XCTUnwrap(PDFDocument(data: Self.pdfData(pages: 1)))
+        let screen = FileViewerPDFContentView()
+        var pressed: [String] = []
+        screen.openLink = { pressed.append($0) }
+        screen.frame = CGRect(x: 0, y: 0, width: 400, height: 600)
+        screen.apply(document: document)
+        screen.layoutIfNeeded()
+
+        XCTAssertTrue(screen.pageBadge.isHidden)
+        // PDFKit hands a pressed URL to the app instead of opening it; the
+        // pane routes it through the same link sheet a markdown link meets.
+        screen.linkPressed(try XCTUnwrap(URL(string: "https://example.com/spec")))
+        XCTAssertEqual(pressed, ["https://example.com/spec"])
+    }
+
+    /// PDFKit locks the document behind the user password; the pane's LOCKED
+    /// panel unlocks the same object in place, which is what lets the
+    /// controller re-publish the document rather than re-read the file.
+    func testPasswordProtectedPDFUnlocksInPlace() throws {
+        let plain = try XCTUnwrap(PDFDocument(data: Self.pdfData(pages: 2)))
+        let sealed = try XCTUnwrap(plain.dataRepresentation(options: [
+            PDFDocumentWriteOption.userPasswordOption: "s3cret",
+            PDFDocumentWriteOption.ownerPasswordOption: "s3cret",
+        ]))
+        let locked = try XCTUnwrap(PDFDocument(data: sealed))
+        XCTAssertTrue(locked.isLocked)
+        XCTAssertFalse(locked.unlock(withPassword: "wrong"))
+        XCTAssertTrue(locked.isLocked)
+        XCTAssertTrue(locked.unlock(withPassword: "s3cret"))
+        XCTAssertFalse(locked.isLocked)
+        XCTAssertEqual(locked.pageCount, 2)
+    }
+
+    // MARK: Fixtures
+
+    static func clip(
+        seconds: Double, volumeStore: FileViewerAudioVolumeStore = .shared
+    ) throws -> FileViewerAudioClip {
+        try FileViewerAudioClip(
+            data: wavData(seconds: seconds), fileName: "tone.wav", volumeStore: volumeStore
+        )
+    }
+
+    /// Store changes reach clips and panels one main-actor hop later
+    /// (Observation's hook fires before the write lands); yield until the
+    /// hop has landed, bounded so a regression fails instead of hanging.
+    static func settle(until done: @escaping @MainActor () -> Bool) async {
+        var attempts = 0
+        while attempts < 50, !done() {
+            attempts += 1
+            await Task.yield()
+        }
+    }
+
+    /// 16-bit mono PCM silence under a canonical RIFF/WAVE header — the
+    /// smallest thing Core Audio reads with an exact duration.
+    static func wavData(seconds: Double, sampleRate: Int = 8000) -> Data {
+        let frames = Int(Double(sampleRate) * seconds)
+        let payload = frames * 2
+        var data = Data()
+        func append(_ value: UInt32) {
+            withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+        }
+        func append(_ value: UInt16) {
+            withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+        }
+        data.append(contentsOf: Array("RIFF".utf8))
+        append(UInt32(36 + payload))
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        append(UInt32(16))
+        append(UInt16(1))
+        append(UInt16(1))
+        append(UInt32(sampleRate))
+        append(UInt32(sampleRate * 2))
+        append(UInt16(2))
+        append(UInt16(16))
+        data.append(contentsOf: Array("data".utf8))
+        append(UInt32(payload))
+        data.append(Data(count: payload))
+        return data
+    }
+
+    static func pdfData(pages: Int) -> Data {
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(x: 0, y: 0, width: 200, height: 300))
+        return renderer.pdfData { context in
+            for index in 0..<pages {
+                context.beginPage()
+                ("Page \(index + 1)" as NSString).draw(
+                    at: CGPoint(x: 20, y: 20),
+                    withAttributes: [.font: UIFont.systemFont(ofSize: 14)]
+                )
+            }
+        }
+    }
+}
+
+private extension FileViewerAudioContentView {
+    /// The lamp's caption, as VoiceOver reads it.
+    var lampCaption: String? {
+        descendants.compactMap { $0 as? UIKitTallyLamp }.first?.accessibilityLabel
+    }
+}
+
+private extension UIView {
+    var descendants: [UIView] {
+        subviews + subviews.flatMap(\.descendants)
+    }
+}

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -68,7 +68,9 @@ UIKit scene runtime (MultiplexSceneDelegate + UIKitSceneRootViewController;
                      moves re-parent the live page; in-memory only
     FileViewerController one per ▤ file-viewer tab; dials its OWN lazy
                      SSHConnection; in-memory only (shares the
-                     isAuxiliaryPane rules with the viewport)
+                     isAuxiliaryPane rules with the viewport); its
+                     Document owns the PDF / audio clip, so a moved tab
+                     keeps page and position
   TerminalSessionController  one per tab; input pump + TerminalView
     TerminalTransport    the tab's byte pipe; picked by host.useMosh
                          (exec + SFTP stay SSH-only capabilities)

--- a/docs/agents/e2e-headless.md
+++ b/docs/agents/e2e-headless.md
@@ -204,6 +204,12 @@ app.multiplexterm.multiplex.<name>`:
 - `debug.fvselect` — the file viewer's markdown SELECT mode.
 - `debug.fvimage` — press the first image placeholder on the rendered
   markdown screen (destination → resolve → open, the finger's own path).
+- `debug.fvplay` — press PLAY/PAUSE on the active viewer's sound screen;
+  proof is the PLAYING lamp and a moving clock. Reach the screen via
+  `debug.link` + `debug.pathview` on a printed `.wav` path, or launch with
+  `MULTIPLEX_AUTO_ACTION_URL='multiplex://open?host=devbox&action=file&path=/abs/x.wav'`
+  (works for `.pdf` too; the load can trail launch by ~25 s on a sim with
+  hundreds of synced hosts).
 - `debug.dictation` — press the dictation action. Grant mic with `simctl
   privacy <UDID> grant microphone …`; speech recognition has no simctl
   service — with the device SHUT DOWN insert `kTCCServiceSpeechRecognition`

--- a/docs/agents/links-and-viewers.md
+++ b/docs/agents/links-and-viewers.md
@@ -230,3 +230,46 @@ link/path resolution, the ⌗ viewport, or the ▤ file viewer.
   ⚠ `mountBlocksIfNeeded` must `setNeedsLayout` the scroll view before
   reading `contentSize`, or a teardown's stale tall height reads as a full
   viewport and the screen stays BLANK until the reader scrolls.
+- **PDFs and sound files are screens, not BINARY** (2026-08-15;
+  `FileRenderKind.pdf` / `.audio`, `FileViewerPDFContentView`,
+  `FileViewerAudioContentView`, `FileViewerAudioClip`). Both are read WHOLE
+  over SFTP under one 60 MB `mediaByteLimit` (`readWhole`, shared with
+  images; TOO LARGE names the cap) — PDFKit wants random access and there is
+  no streaming road over SFTP. Video containers stay `.binary`.
+  - **PDF = PDFKit's `PDFView`** with a PAGE n / m badge and the image
+    screen's `%·FIT` chip (`FileViewerZoomReadout`). ⚠ ANY write to
+    `minScaleFactor` / `maxScaleFactor` / `scaleFactor` (a pinch included)
+    switches `autoScales` OFF, after which a resize no longer refits
+    (measured on the visionOS sim); so nothing sets the bounds and FIT
+    re-arms `autoScales` instead of assigning a scale. **A URL link inside a
+    PDF is untrusted document text**: `pdfViewWillClick(onLink:with:)` is
+    implemented because PDFKit otherwise opens the URL itself — it rides
+    `openMarkdownLink` into the link sheet. A quiet watch swap keeps the
+    reader's page (LaTeX build loops). Locked PDFs get a LOCKED panel with
+    UNLOCK… (system secure field, cleared in every button action, password
+    never kept); PDFKit unlocks IN PLACE, so `unlockPDF` re-publishes the
+    same `Document` and the pane rebuilds only because `BodyKey` flips
+    `pdfLocked → pdf`.
+  - **The audio clip belongs to the `Document`, the screen is its remote**
+    (`Document.audio`, an `AVAudioPlayer` over the bytes): merge/split
+    rebuilds the pane, not the document, so the position survives; a quiet
+    reload hands position + playing state to the replacement
+    (`adoptPosition`); `shutdown()` silences it. ⚠ Build the player ON the
+    main actor: `AVAudioPlayer(data:)` inside `Task.detached` measured
+    100–400× slower on the visionOS sim (~9 s for a mismatched hint). The
+    screen polls at 4 Hz only while playing; `UIKitChassisChip.setContent`
+    and `FileViewerBadgeView.setText` gate themselves, so readouts may be
+    set from timers and layout. **The document leaving the screen pauses,
+    hiding it does not**: `FileViewerController.content`'s `didSet` pauses a
+    clip whose document left (another file, a diff, a failure); a hidden tab
+    keeps playing, and merge/split never touches `content`. The `.playback`
+    session is claimed only at PLAY and handed back on pause / finish /
+    release. A decode failure keeps the AUDIO verdict (CAN'T PLAY panel; the
+    Ogg family is admitted on purpose so `.opus` plays and Vorbis fails
+    honestly). **Volume is the listener's, not the file's**
+    (`FileViewerAudioVolume` + `FileViewerAudioVolumeStore`, the text-size
+    store's shape: device-local, never synced): every clip and every panel
+    follow the store through `withObservationTracking` (its hook fires
+    before the write lands — hence the main-actor hop before re-reading),
+    and the slider only writes the store, in whole percents. No
+    background-audio mode is claimed.

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -221,7 +221,8 @@ Current product split:
   free file attachment on SSH-backed tmux and herdr tabs from Files/Photos
   (plus camera
   on iPad) and drag-and-drop through the same SSH upload path, a read-only
-  File Viewer (code, rendered Markdown, images, and git diffs) summoned from
+  File Viewer (code, rendered Markdown, images, PDFs, sound files, and git
+  diffs) summoned from
   + TAB or a confirmed path in terminal output (a percent-decoded,
   local-authority `file:` URI naming that SSH host takes the same road); a
   tree-file long press opens that file in another viewer tab, per-file

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -5,10 +5,13 @@ NEW SINCE 1.3.1
 • DICTATE IN YOUR OWN LANGUAGES — tap the globe in the LISTENING bar to switch among your device's preferred languages.
 • LEANER PANELS — pane/tab/window cycling rows are gone; those are directly selectable already.
 • THEME EDITS SHOW LIVE in your open terminal windows — Save keeps them, Back puts the old theme back.
+• FILE VIEWER OPENS PDFs — continuous pages, pinch to zoom, page readout; locked PDFs offer UNLOCK.
+• FILE VIEWER PLAYS SOUND FILES — MP3, M4A, WAV, FLAC, AIFF, CAF: PLAY/PAUSE, scrubber, 15 s skips, a volume slider that is remembered; keeps playing while you type in another tab.
 
 PLEASE TRY
 1. Hop through windows from the TMUX panel — it should stay up, with ACTIVE following.
 2. If your device lists several languages, tap the globe while dictating and speak in the language you pick.
 3. Confirm split, resize, create, rename and close still work in both panels.
+4. Long-press a .pdf or .mp3 path in terminal output and open it with VIEW; try a link inside the PDF (it should ask first) and scrub the sound file.
 
 Feedback: screenshot in TestFlight


### PR DESCRIPTION
## What

The ▤ File Viewer gains two screens beside code / markdown / images / git diffs:

- **PDF** — PDFKit's `PDFView`: continuous vertical pages, pinch zoom, native text selection, a `PAGE n / m` badge and the image screen's `% · FIT` reset chip. Links inside a PDF go through the app's link sheet (PDFKit would otherwise open the URL itself). A password-protected PDF shows a **LOCKED** panel with **UNLOCK…** (system secure field, password never kept). A quiet watch swap keeps the reader's page — a LaTeX build loop reads as it grows.
- **Sound files** — MP3, M4A/AAC, WAV, AIFF, CAF, FLAC, ALAC, AU, AMR (+ the Ogg family, tried honestly): a centered chassis panel with the state lamp (PLAYING in tally red), the file's name, `↺15 · PLAY/PAUSE · ↻15`, a scrubber, the clock, and a **volume row** whose level is remembered app-wide. Bytes Core Audio can't decode (Ogg Vorbis, or not audio) get a **CAN'T PLAY** panel — the verdict stays AUDIO, not BINARY.

Both are read whole over SFTP under one 60 MB `mediaByteLimit` (TOO LARGE names the cap); video containers stay binary.

## How

- **Model** — `FileRenderKind.pdf` / `.audio`; `pdf` and the sound extensions leave the BINARY set. Pure `FileViewerAudioClock` (m:ss / h:mm:ss) and `FileViewerAudioVolume` (clamp + percent readout).
- **Services** — `FileViewerController.makeDocument` reads via one `readWhole` (images too now), parses `PDFDocument` off the main actor, and builds a `FileViewerAudioClip` (an `AVAudioPlayer` wrapper). **The clip belongs to the `Document`, the screen is its remote**: merge/split rebuilds the pane, not the document, so position survives; a quiet reload hands position + playing state to the replacement (`adoptPosition`); `shutdown()` silences it. `content`'s `didSet` pauses a clip whose document left the screen (another file, a diff, a failure) — a hidden tab keeps playing, merge/split never touches `content`. `.playback` session claimed only at PLAY, handed back on pause/finish/release. `unlockPDF` re-publishes the same document (PDFKit unlocks in place). `FileViewerAudioVolumeStore` is the text-size store's shape (device-local `UserDefaults`); every clip and every panel follow it through `withObservationTracking`, the slider only writes it (whole percents).
- **Views** — `FileViewerPDFContentView` (page index cached per page, layout early-returns on unchanged size), `FileViewerAudioContentView` (subclass of `FileViewerPanelHostView`; polls the clip at 4 Hz **only while playing**, all writes change-gated). BINARY / LOCKED / CAN'T PLAY are one `verdictPanel`; the zoom chip and slider dress are shared furniture. Header meta: `PDF · 5 PAGES · 6.9 KB`, `AUDIO · 0:24 · 1.1 MB`.

Two measured traps, recorded in `docs/agents/links-and-viewers.md`: any write to `PDFView`'s min/max/scaleFactor disarms `autoScales` (so FIT re-arms it rather than assigning a scale), and `AVAudioPlayer(data:)` inside `Task.detached` is 100–400× slower on the visionOS sim than on the main actor (built on main on purpose).

## Cleanups that rode along (from the /simplify pass)

- `UIKitChassisChip.setContent` and `FileViewerBadgeView.setText` gate themselves on unchanged content, so readouts can be set from timers/layout without caches.
- `SSHConnection.readChunks` reserves the assembly buffer and releases chunks as they land (the 60 MB cap doubled the old peak).
- `debug.fvplay` hook (press PLAY headlessly); `debug.pathview` / `debug.viewportopen` now dismiss the sheet like the chip does.

## Verification

- Full visionOS unit suite green (1253 tests); new `FileViewerMediaTests` cover the clip contract, the panel remote, PDF readouts and page-keeping across a reload, link routing, PDFKit unlock-in-place, and volume store/propagation. iPad target builds; SwiftLint `--strict` at zero.
- E2E on the visionOS simulator against the dev-sshd harness: PDF page render + badge, sound panel READY → PLAYING with a moving clock (via `debug.fvplay`), `.m4a` loads, fake `.ogg` → CAN'T PLAY, sealed PDF → LOCKED / UNLOCK…, volume row.
- `fastlane/testflight-whats-new.txt` updated; `Tools/check-metadata.rb` passes.
