### PR TITLE
Hold CTRL for saved Key Commands

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,7 +163,11 @@ straddle otherwise), then the UMD title row: `DECK` chip, source label
 `+ TAB · FILE · TMUX · MERGE · DETACH`, then a key row: `ESC · CTRL · TAB`,
 the DECCKM-aware autorepeat arrows, `RET`, and the keyboard toggle (the
 floating visionOS keyboard has none of these — arrows + `RET` drive a CLI
-agent's option picker without summoning it). The iPad toolbar keeps the
+agent's option picker without summoning it). Holding `CTRL` opens **KEY
+COMMANDS**, a two-tab TALLY popover on the shortcut panel's grammar:
+COMMANDS is a hairline grid of keycap chords (⇧↩ · ⌃C ×2 · ⌥⌫, and the user's
+own, in custom ink), CUSTOM SETUP is the agent editor's numbered list with an
+inline composer — bake-off record in `local-plan/key-commands-bakeoff/`. The iPad toolbar keeps the
 full chip set: `DECK`,
 source label, lamp, then
 `A− · A+ · + TAB · FILE · TMUX · MERGE · DETACH` chips; the keyboard

--- a/Multiplex/App/AppRuntime.swift
+++ b/Multiplex/App/AppRuntime.swift
@@ -79,6 +79,12 @@ final class AppRuntime {
         backgroundRefresh.installDebugHook()
         #endif
 
+        // The hold-CTRL Key Commands set is read once here, not inside the
+        // first hold: its file load and Keychain-mirror check stay off the
+        // gesture path.
+        _ = KeyCommandStore.shared
+        Task { await KeyCommandStore.shared.refreshFromCloud() }
+
         // Mint the widget-link token once per install: the widget process
         // reads it from the App Group to mark its own deep links, and
         // `receive(_ url:)` confirms anything that arrives without it.

--- a/Multiplex/Design/Chassis.swift
+++ b/Multiplex/Design/Chassis.swift
@@ -153,6 +153,7 @@ final class UIKitChassisLabel: UILabel {
     required init?(coder: NSCoder) { fatalError("unused") }
 
     func setText(_ text: String) {
+        guard text != sourceText else { return }
         sourceText = text
         accessibilityLabel = text
         refreshAttributedText()
@@ -162,6 +163,7 @@ final class UIKitChassisLabel: UILabel {
     /// layout subtree. Interactive controls use this instead of replacing a
     /// label that may still be participating in the current touch/layout pass.
     func setInk(_ color: UIColor) {
+        guard color != ink else { return }
         ink = color
         refreshAttributedText()
     }
@@ -195,6 +197,82 @@ final class UIKitChassisLabel: UILabel {
                 .foregroundColor: ink.resolvedColor(with: traitCollection),
             ]
         )
+    }
+}
+
+/// A one-line panel label in a caller-chosen font — the mono readouts,
+/// bindings, and hints of the shortcut / Key Commands panels — whose
+/// RESOLVED ink is baked into its attributed string and re-resolved on every
+/// trait change and on window attach (the retained-ink defect, see
+/// `UIKitChassisLabel.didMoveToWindow`). Not an accessibility element by
+/// default: the control it decorates speaks for it.
+@MainActor
+final class UIKitChassisMonoLabel: UILabel {
+    private var sourceText = ""
+    private var sourceFont = UIFont.systemFont(ofSize: 10)
+    private var sourceColor = UIKitChassis.signal
+    private var kern: CGFloat?
+
+    convenience init(_ text: String, font: UIFont, color: UIColor, kern: CGFloat? = nil) {
+        self.init(frame: .zero)
+        configure(text, font: font, color: color, kern: kern)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        numberOfLines = 1
+        lineBreakMode = .byClipping
+        isAccessibilityElement = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    func configure(_ text: String, font: UIFont, color: UIColor, kern: CGFloat? = nil) {
+        sourceText = text
+        sourceFont = font
+        sourceColor = color
+        self.kern = kern
+        refreshAttributedText()
+    }
+
+    /// Text and ink together, one refresh; unchanged values are a no-op so a
+    /// per-keystroke re-render costs nothing.
+    func setText(_ text: String, ink: UIColor? = nil) {
+        let nextColor = ink ?? sourceColor
+        guard text != sourceText || nextColor != sourceColor else { return }
+        sourceText = text
+        sourceColor = nextColor
+        refreshAttributedText()
+    }
+
+    func setInk(_ color: UIColor) {
+        guard color != sourceColor else { return }
+        sourceColor = color
+        refreshAttributedText()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        refreshAttributedText()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil else { return }
+        refreshAttributedText()
+    }
+
+    private func refreshAttributedText() {
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: sourceFont,
+            .foregroundColor: sourceColor.resolvedColor(with: traitCollection),
+        ]
+        if let kern { attributes[.kern] = kern }
+        attributedText = NSAttributedString(string: sourceText, attributes: attributes)
+        accessibilityLabel = sourceText
     }
 }
 

--- a/Multiplex/Design/TallyEditorControls.swift
+++ b/Multiplex/Design/TallyEditorControls.swift
@@ -1,0 +1,368 @@
+import UIKit
+
+// MARK: - Shared TALLY editor controls
+//
+// The pieces every TALLY editor popover shares — COMMAND SETUP (agent custom
+// commands) introduced them and KEY COMMANDS' CUSTOM SETUP reuses them: the
+// compact captioned switch (26×14 monochrome — never the system green pill),
+// the square row-action button, the ↑ ↓ 🗑 row-action trio, the legend rows,
+// and the ADD · CANCEL · DONE footer.
+
+/// Metrics the shared controls agree on.
+enum TallyEditorMetrics {
+    /// The one selection/thumb slide duration every editor control uses.
+    static let selectionAnimationDuration: TimeInterval = 0.14
+}
+
+@MainActor
+final class TallyEditorSwitch: UIControl {
+    private let track: TallyEditorSwitchTrack
+    private let caption: UIKitChassisLabel
+    private var isOn: Bool
+    private let changed: (Bool) -> Void
+
+    /// `identifierPrefix` namespaces the accessibility identifier per editor
+    /// (`customCommands` / `keyCommands`). `scale` grows the track and thumb
+    /// (Key Commands passes `Theme.typeScale` so the switch keeps pace with
+    /// its keycaps on the Mac); the agent editor keeps the authored 26×14.
+    init(
+        label: String,
+        accessibilityLabel: String,
+        isOn: Bool,
+        identifierPrefix: String,
+        scale: CGFloat = 1,
+        changed: @escaping (Bool) -> Void
+    ) {
+        self.isOn = isOn
+        self.changed = changed
+        track = TallyEditorSwitchTrack(scale: scale)
+        caption = UIKitChassisLabel(
+            label,
+            size: 8,
+            color: isOn ? UIKitChassis.signal : UIKitChassis.signal2
+        )
+        super.init(frame: .zero)
+        isAccessibilityElement = true
+        // The SwiftUI row was a real `Toggle`; `.toggleButton` is UIKit's
+        // equivalent identity, so the switch rotor and the spoken On/Off
+        // state survive the port.
+        accessibilityTraits = [.button, .toggleButton]
+        self.accessibilityLabel = accessibilityLabel
+        accessibilityIdentifier = "\(identifierPrefix).switch.\(label.lowercased())"
+        addTarget(self, action: #selector(pressed), for: .touchUpInside)
+        #if os(visionOS)
+        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
+        #endif
+
+        let row = UIStackView(arrangedSubviews: [track, caption])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 7
+        row.isUserInteractionEnabled = false
+        addSubview(row)
+        row.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: trailingAnchor),
+            row.topAnchor.constraint(equalTo: topAnchor),
+            row.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        render()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    @objc private func pressed() {
+        isOn.toggle()
+        render(animated: true)
+        changed(isOn)
+    }
+
+    /// Reflect a value set elsewhere (a row re-rendered from its model)
+    /// without firing `changed`.
+    func setOn(_ on: Bool, animated: Bool = false) {
+        guard on != isOn else { return }
+        isOn = on
+        render(animated: animated)
+    }
+
+    private func render(animated: Bool = false) {
+        track.setOn(isOn, animated: animated)
+        caption.setInk(isOn ? UIKitChassis.signal : UIKitChassis.signal2)
+        accessibilityValue = isOn ? "On" : "Off"
+        if isOn {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
+    }
+}
+
+@MainActor
+final class TallyEditorSwitchTrack: UIKitTallyBorderedView {
+    private let thumb = UIView()
+    private var leading: NSLayoutConstraint!
+    private var trailing: NSLayoutConstraint!
+
+    init(scale: CGFloat = 1) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: ceil(26 * scale)),
+            heightAnchor.constraint(equalToConstant: ceil(14 * scale)),
+        ])
+        thumb.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(thumb)
+        let inset = ceil(3 * scale)
+        leading = thumb.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset)
+        trailing = thumb.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset)
+        NSLayoutConstraint.activate([
+            thumb.widthAnchor.constraint(equalToConstant: ceil(8 * scale)),
+            thumb.heightAnchor.constraint(equalToConstant: ceil(8 * scale)),
+            thumb.centerYAnchor.constraint(equalTo: centerYAnchor),
+            leading,
+        ])
+        isAccessibilityElement = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    func setOn(_ on: Bool, animated: Bool = false) {
+        leading.isActive = false
+        trailing.isActive = false
+        (on ? trailing : leading).isActive = true
+        let apply = {
+            self.backgroundColor = on ? UIKitChassis.bezelHi : UIKitChassis.screen
+            self.thumb.backgroundColor = on ? UIKitChassis.signal : UIKitChassis.signal3
+            self.tallyBorderColor = on ? UIKitChassis.signal2 : UIKitChassis.bezelHi
+            // The swapped constraint only moves the thumb inside an animation
+            // transaction if the layout pass runs there too.
+            self.layoutIfNeeded()
+        }
+        guard animated, window != nil, !UIAccessibility.isReduceMotionEnabled else {
+            apply()
+            return
+        }
+        UIView.animate(
+            withDuration: TallyEditorMetrics.selectionAnimationDuration,
+            delay: 0,
+            options: [.curveEaseOut, .beginFromCurrentState],
+            animations: apply
+        )
+    }
+}
+
+@MainActor
+final class TallyEditorRowActionButton: UIButton {
+    private let action: () -> Void
+
+    /// `scale` grows the 25×23 square (Key Commands passes `Theme.typeScale`).
+    /// The glyph inside always rides `Theme.typeScale` on its own — chrome
+    /// type is scaled app-wide, geometry only where a control opts in — so
+    /// the agent editor's default-scale button keeps its Mac-legible symbol.
+    init(
+        systemImage: String,
+        accessibilityLabel: String,
+        enabled: Bool,
+        scale: CGFloat = 1,
+        action: @escaping () -> Void
+    ) {
+        self.action = action
+        super.init(frame: .zero)
+        backgroundColor = GlassPrototype.strataChassis
+        layer.borderWidth = 1
+        layer.borderColor = UIKitChassis.bezelHi
+            .resolvedColor(with: traitCollection).cgColor
+        setImage(
+            UIImage(
+                systemName: systemImage,
+                withConfiguration: UIImage.SymbolConfiguration(
+                    pointSize: 9 * Theme.typeScale,
+                    weight: .semibold
+                )
+            ),
+            for: .normal
+        )
+        tintColor = enabled ? UIKitChassis.signal2 : UIKitChassis.signal3
+        isEnabled = enabled
+        self.accessibilityLabel = accessibilityLabel
+        addTarget(self, action: #selector(pressed), for: .touchUpInside)
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: ceil(25 * scale)),
+            heightAnchor.constraint(equalToConstant: ceil(23 * scale)),
+        ])
+        #if os(visionOS)
+        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
+        #endif
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    @objc private func pressed() {
+        action()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        layer.borderColor = UIKitChassis.bezelHi
+            .resolvedColor(with: traitCollection).cgColor
+    }
+}
+
+/// The ↑ ↓ 🗑 trio every numbered editor row wears: enablement from the
+/// row's position, identifiers namespaced per editor and keyed by the row's
+/// ID.
+@MainActor
+enum TallyEditorRowActions {
+    struct Trio {
+        let stack: UIStackView
+        let up: TallyEditorRowActionButton
+        let down: TallyEditorRowActionButton
+        let delete: TallyEditorRowActionButton
+    }
+
+    static func make(
+        index: Int,
+        count: Int,
+        identifierPrefix: String,
+        rowID: UUID,
+        scale: CGFloat = 1,
+        move: @escaping (Int) -> Void,
+        delete: @escaping () -> Void
+    ) -> Trio {
+        let up = TallyEditorRowActionButton(
+            systemImage: "arrow.up",
+            accessibilityLabel: "Move command up",
+            enabled: index > 0,
+            scale: scale,
+            action: { move(-1) }
+        )
+        up.accessibilityIdentifier = "\(identifierPrefix).moveUp.\(rowID.uuidString)"
+        let down = TallyEditorRowActionButton(
+            systemImage: "arrow.down",
+            accessibilityLabel: "Move command down",
+            enabled: index < count - 1,
+            scale: scale,
+            action: { move(1) }
+        )
+        down.accessibilityIdentifier = "\(identifierPrefix).moveDown.\(rowID.uuidString)"
+        let trash = TallyEditorRowActionButton(
+            systemImage: "trash",
+            accessibilityLabel: "Delete command",
+            enabled: true,
+            scale: scale,
+            action: delete
+        )
+        trash.accessibilityIdentifier = "\(identifierPrefix).delete.\(rowID.uuidString)"
+        let stack = UIStackView(arrangedSubviews: [up, down, trash])
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 8
+        stack.setContentHuggingPriority(.required, for: .horizontal)
+        stack.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return Trio(stack: stack, up: up, down: down, delete: trash)
+    }
+}
+
+/// A legend row: a 6-pt dot in the ink it explains, then one wrapping line
+/// of mono copy. Stacked at 6 pt by the editors' footers.
+@MainActor
+enum TallyEditorLegend {
+    static func row(color: UIColor, text: String) -> UIView {
+        let dot = UIView()
+        dot.backgroundColor = color
+        dot.layer.cornerRadius = 3
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dot.widthAnchor.constraint(equalToConstant: 6),
+            dot.heightAnchor.constraint(equalToConstant: 6),
+        ])
+        dot.isAccessibilityElement = false
+
+        let label = UILabel()
+        label.text = text
+        label.font = UIKitChassis.monoFont(8, weight: .medium)
+        label.textColor = UIKitChassis.signal2
+        label.numberOfLines = 0
+        // Above the list viewport's resting height, below required: the legend
+        // is the last thing in the panel to give way, and a required floor here
+        // would make a popover shorter than the whole panel unsatisfiable.
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+
+        let row = UIStackView(arrangedSubviews: [dot, label])
+        row.axis = .horizontal
+        row.alignment = .firstBaseline
+        row.spacing = 8
+        return row
+    }
+
+    static func stack(_ rows: [UIView]) -> UIStackView {
+        let legend = UIStackView(arrangedSubviews: rows)
+        legend.axis = .vertical
+        legend.alignment = .fill
+        legend.spacing = 6
+        return legend
+    }
+}
+
+/// ADD COMMAND · spacer · CANCEL · DONE — the editors' one action row.
+@MainActor
+enum TallyEditorFooter {
+    /// The ADD chip's state: live; dimmed at the list's hard cap; or the
+    /// tier's route past its own cap — still live, prominent, marked PRO,
+    /// and `add` opens the paywall.
+    enum AddState {
+        case available
+        case capped
+        case upgrade
+    }
+
+    static func actions(
+        identifierPrefix: String,
+        addState: AddState = .available,
+        add: @escaping () -> Void,
+        cancel: @escaping () -> Void,
+        done: @escaping () -> Void
+    ) -> UIStackView {
+        let addChip = UIKitChassisChip(
+            addState == .upgrade ? "ADD COMMAND · PRO" : "ADD COMMAND",
+            systemImage: "plus",
+            prominent: addState == .upgrade,
+            accessibilityLabel: addState == .upgrade ? "Add command with Multiplex Pro" : "Add command",
+            action: add
+        )
+        addChip.accessibilityIdentifier = "\(identifierPrefix).add"
+        addChip.alpha = addState == .capped ? 0.45 : 1
+        addChip.isUserInteractionEnabled = addState != .capped
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        let cancelChip = UIKitChassisChip(
+            "CANCEL",
+            accessibilityLabel: "Cancel",
+            action: cancel
+        )
+        cancelChip.accessibilityIdentifier = "\(identifierPrefix).cancel"
+        let doneChip = UIKitChassisChip(
+            "DONE",
+            prominent: true,
+            accessibilityLabel: "Done",
+            action: done
+        )
+        doneChip.accessibilityIdentifier = "\(identifierPrefix).done"
+        for chip in [addChip, cancelChip, doneChip] {
+            chip.setContentHuggingPriority(.required, for: .horizontal)
+            chip.setContentCompressionResistancePriority(.required, for: .horizontal)
+        }
+        let row = UIStackView(arrangedSubviews: [addChip, spacer, cancelChip, doneChip])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 8
+        return row
+    }
+}

--- a/Multiplex/Models/KeyCommand.swift
+++ b/Multiplex/Models/KeyCommand.swift
@@ -1,0 +1,458 @@
+import Foundation
+
+/// One saved Key Command — what the CTRL key's hold panel can send in a
+/// press: a key chord (modifiers + one key) or a text snippet, repeated
+/// under a fixed guard, with a rule for whether the panel closes on press.
+///
+/// Pure model: no encoding lives here. A chord is encoded by the terminal
+/// view at press time (`TerminalView.bytes(for:)`), so it always matches what
+/// a hardware keyboard would send in the terminal's current mode.
+struct KeyCommand: Identifiable, Codable, Hashable {
+    enum Kind: Codable, Hashable {
+        case chord(KeyChord)
+        case text(KeyTextSnippet)
+    }
+
+    var id: UUID
+    var kind: Kind
+    /// How many times one press sends the command. Clamped by
+    /// `KeyCommandRepeatGuard`.
+    var repeatCount: Int
+    /// The gap between repeated sends. Meaningless at `repeatCount == 1` but
+    /// kept so a row remembers its setting when the count comes back.
+    var repeatGapMilliseconds: Int
+    /// CLOSE ON PRESS: the panel drops with the send. Off keeps it up so a
+    /// key like Option+Backspace can be pressed again without reopening.
+    var closesPanel: Bool
+    /// One of the three shipped defaults (never wears the custom ink).
+    var isShipped: Bool
+
+    init(
+        id: UUID = UUID(),
+        kind: Kind,
+        repeatCount: Int = 1,
+        repeatGapMilliseconds: Int = KeyCommandRepeatGuard.defaultGapMilliseconds,
+        closesPanel: Bool = true,
+        isShipped: Bool = false
+    ) {
+        self.id = id
+        self.kind = kind
+        self.repeatCount = repeatCount
+        self.repeatGapMilliseconds = repeatGapMilliseconds
+        self.closesPanel = closesPanel
+        self.isShipped = isShipped
+    }
+
+    var isRepeating: Bool { repeatCount > 1 }
+
+    var chord: KeyChord? {
+        if case .chord(let chord) = kind { return chord }
+        return nil
+    }
+
+    var textSnippet: KeyTextSnippet? {
+        if case .text(let snippet) = kind { return snippet }
+        return nil
+    }
+
+    /// The derived label — there is no name field. Chords spell their keys
+    /// (SHIFT ENTER · CTRL C); text rows are their own text, one line,
+    /// truncated like an agent bar label.
+    var name: String {
+        switch kind {
+        case .chord(let chord): chord.name
+        case .text(let snippet): snippet.label
+        }
+    }
+
+    /// The keycap faces the COMMANDS grid and setup rows draw.
+    var faces: [KeyCapFace] {
+        switch kind {
+        case .chord(let chord): chord.faces
+        case .text(let snippet): [.text(snippet.label)]
+        }
+    }
+
+    /// The three voices of "everything the face doesn't say" — the setup
+    /// row's caps readout, the grid cell's quieter hint (defaults omitted),
+    /// and the spoken form — from one walk over the same fields.
+    enum ReadoutStyle {
+        case row
+        case cellHint
+        case spoken
+    }
+
+    /// The row's readout of everything the face doesn't say.
+    var readout: String { readout(.row) }
+
+    func readout(_ style: ReadoutStyle) -> String {
+        let submits = textSnippet?.submits == true
+        switch style {
+        case .row:
+            var parts: [String] = []
+            if submits { parts.append("SUBMITS") }
+            parts.append(isRepeating ? "×\(repeatCount) · \(repeatGapMilliseconds) MS" : "×1")
+            parts.append(closesPanel ? "CLOSES" : "STAYS")
+            return parts.joined(separator: " · ")
+        case .cellHint:
+            var parts: [String] = []
+            if submits { parts.append("submits") }
+            if isRepeating { parts.append("×\(repeatCount) · \(repeatGapMilliseconds) ms") }
+            if !closesPanel { parts.append("stays open") }
+            return parts.joined(separator: " · ")
+        case .spoken:
+            var text: String
+            switch kind {
+            case .chord(let chord): text = chord.accessibilityName
+            case .text(let snippet): text = "Type \(snippet.normalizedText)"
+            }
+            if submits { text += ", then Enter" }
+            if isRepeating { text += ", \(repeatCount) times" }
+            text += closesPanel ? ", closes the panel" : ", panel stays open"
+            return text
+        }
+    }
+
+    /// True when the command can be sent: a chord always can; a text row
+    /// needs text.
+    var isSendable: Bool {
+        switch kind {
+        case .chord: true
+        case .text(let snippet): !snippet.normalizedText.isEmpty
+        }
+    }
+
+    /// The command with its repeat under the guard and its text normalized.
+    var normalized: KeyCommand {
+        var command = self
+        let clamped = KeyCommandRepeatGuard.clamp(
+            count: repeatCount,
+            gapMilliseconds: repeatGapMilliseconds
+        )
+        command.repeatCount = clamped.count
+        command.repeatGapMilliseconds = clamped.gapMilliseconds
+        if case .text(var snippet) = kind {
+            snippet.text = snippet.normalizedText
+            command.kind = .text(snippet)
+        }
+        return command
+    }
+}
+
+/// Modifiers plus one key. Letters and digits arrive as one character; the
+/// terminal view lowercases the base and reports the shifted form itself.
+struct KeyChord: Codable, Hashable {
+    struct Modifiers: OptionSet, Codable, Hashable {
+        let rawValue: Int
+
+        static let control = Modifiers(rawValue: 1 << 0)
+        static let shift = Modifiers(rawValue: 1 << 1)
+        static let option = Modifiers(rawValue: 1 << 2)
+
+        /// Canonical keycap order — ⌃ ⇧ ⌥ — the order macOS prints chords.
+        static let ordered: [Modifiers] = [.control, .shift, .option]
+    }
+
+    enum Key: Codable, Hashable {
+        case enter, tab, escape, delete, space
+        case up, down, left, right
+        /// One printable character (a letter, digit, or symbol).
+        case character(String)
+
+        /// The composer's fixed key set: the editing keys, then the direction
+        /// keys (a phone popover puts the two on separate lines).
+        static let composerEditingSet: [Key] = [.enter, .tab, .escape, .delete, .space]
+        static let composerArrowSet: [Key] = [.up, .down, .left, .right]
+
+        var face: KeyCapFace {
+            switch self {
+            case .enter: .symbol("return", glyph: "↩")
+            case .tab: .symbol("arrow.right.to.line", glyph: "⇥")
+            case .escape: .symbol("escape", glyph: "⎋")
+            case .delete: .symbol("delete.left", glyph: "⌫")
+            case .space: .symbol("space", glyph: "␣")
+            case .up: .symbol("arrow.up", glyph: "↑")
+            case .down: .symbol("arrow.down", glyph: "↓")
+            case .left: .symbol("arrow.left", glyph: "←")
+            case .right: .symbol("arrow.right", glyph: "→")
+            case .character(let character): .text(character.uppercased())
+            }
+        }
+
+        var word: String {
+            switch self {
+            case .enter: "ENTER"
+            case .tab: "TAB"
+            case .escape: "ESC"
+            case .delete: "DELETE"
+            case .space: "SPACE"
+            case .up: "UP"
+            case .down: "DOWN"
+            case .left: "LEFT"
+            case .right: "RIGHT"
+            case .character(let character): character.uppercased()
+            }
+        }
+
+        var accessibilityWord: String {
+            switch self {
+            case .escape: "Escape"
+            case .character(let character): character.uppercased()
+            default: word.capitalized
+            }
+        }
+
+        /// A composer field accepts exactly one printable character; anything
+        /// else (paste, control bytes, an emoji cluster) is refused. Letters
+        /// are kept lowercase — the base key — so a chord without ⇧ types
+        /// the lowercase letter; the face and name uppercase for display.
+        static func fromFieldText(_ text: String) -> Key? {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.count == 1,
+                  let scalar = trimmed.unicodeScalars.first,
+                  trimmed.unicodeScalars.count == 1,
+                  scalar.isASCII,
+                  !CharacterSet.controlCharacters.contains(scalar)
+            else { return nil }
+            return .character(trimmed.lowercased())
+        }
+    }
+
+    var modifiers: Modifiers
+    var key: Key
+
+    init(modifiers: Modifiers = [], key: Key) {
+        self.modifiers = modifiers
+        self.key = key
+    }
+
+    var faces: [KeyCapFace] {
+        Modifiers.ordered.filter { modifiers.contains($0) }.map(\.face) + [key.face]
+    }
+
+    /// SHIFT ENTER · CTRL C · OPTION UP — modifiers in keycap order, then the
+    /// key.
+    var name: String {
+        (Modifiers.ordered.filter { modifiers.contains($0) }.map(\.word) + [key.word])
+            .joined(separator: " ")
+    }
+
+    var accessibilityName: String {
+        (Modifiers.ordered.filter { modifiers.contains($0) }.map(\.accessibilityWord)
+            + [key.accessibilityWord])
+            .joined(separator: " ")
+    }
+}
+
+extension KeyChord.Modifiers {
+    var face: KeyCapFace {
+        switch self {
+        case .control: .symbol("control", glyph: "⌃")
+        case .shift: .symbol("shift", glyph: "⇧")
+        case .option: .symbol("option", glyph: "⌥")
+        default: .text("?")
+        }
+    }
+
+    var word: String {
+        switch self {
+        case .control: "CTRL"
+        case .shift: "SHIFT"
+        case .option: "OPTION"
+        default: ""
+        }
+    }
+
+    var accessibilityWord: String {
+        switch self {
+        case .control: "Control"
+        case .shift: "Shift"
+        case .option: "Option"
+        default: ""
+        }
+    }
+}
+
+/// One line of text the panel types, optionally followed by Enter (a CR
+/// sent ~160 ms after the text — the slash-chip shape).
+struct KeyTextSnippet: Codable, Hashable {
+    static let maximumLabelLength = 12
+
+    var text: String
+    var submits: Bool
+
+    init(text: String, submits: Bool = true) {
+        self.text = text
+        self.submits = submits
+    }
+
+    /// One line, no terminal control bytes (a pasted Ctrl-B would arm the
+    /// remote prefix), trimmed at both ends.
+    var normalizedText: String {
+        let flattened = text
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+        let safe = flattened.unicodeScalars.reduce(into: "") { result, scalar in
+            if scalar == "\t" || !CharacterSet.controlCharacters.contains(scalar) {
+                result.append(Character(scalar))
+            }
+        }
+        return safe.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The face and name: the first characters of the text, `...` when cut.
+    var label: String {
+        let text = normalizedText.replacingOccurrences(of: "\t", with: "⇥")
+        guard text.count > Self.maximumLabelLength else { return text }
+        return String(text.prefix(Self.maximumLabelLength)) + "..."
+    }
+}
+
+/// What a keycap draws: an SF Symbol with a plain-text fallback, or text.
+struct KeyCapFace: Hashable {
+    var symbolName: String?
+    var text: String
+
+    static func symbol(_ name: String, glyph: String) -> KeyCapFace {
+        KeyCapFace(symbolName: name, text: glyph)
+    }
+
+    static func text(_ text: String) -> KeyCapFace {
+        KeyCapFace(symbolName: nil, text: text)
+    }
+}
+
+/// The fixed ceiling on repeats. Values clamp; the composer says so instead
+/// of erroring.
+enum KeyCommandRepeatGuard {
+    static let maximumCount = 5
+    static let gapRange = 50...500
+    static let defaultGapMilliseconds = 150
+    /// Whole burst — the last send lands within this of the first.
+    static let burstLimitMilliseconds = 2000
+    static let gapStep = 50
+
+    struct Clamped: Equatable {
+        var count: Int
+        var gapMilliseconds: Int
+        var wasClamped: Bool
+    }
+
+    static func burstMilliseconds(count: Int, gapMilliseconds: Int) -> Int {
+        max(0, count - 1) * gapMilliseconds
+    }
+
+    static func clamp(count: Int, gapMilliseconds: Int) -> Clamped {
+        var clampedCount = min(max(1, count), maximumCount)
+        var clampedGap = min(max(gapRange.lowerBound, gapMilliseconds), gapRange.upperBound)
+        var wasClamped = clampedCount != count || clampedGap != gapMilliseconds
+        // The burst limit gives way on the gap first (a repeat you asked for
+        // is worth more than the exact spacing), then on the count.
+        while burstMilliseconds(count: clampedCount, gapMilliseconds: clampedGap)
+            > burstLimitMilliseconds {
+            wasClamped = true
+            if clampedGap - gapStep >= gapRange.lowerBound {
+                clampedGap -= gapStep
+            } else if clampedCount > 1 {
+                clampedCount -= 1
+            } else {
+                break
+            }
+        }
+        return Clamped(count: clampedCount, gapMilliseconds: clampedGap, wasClamped: wasClamped)
+    }
+}
+
+/// The whole persisted set, ordered as the grid shows it.
+struct KeyCommandSet: Codable, Equatable {
+    static let maximumCount = 12
+
+    var commands: [KeyCommand]
+    var updatedAt: Date
+
+    /// Stable IDs so a device that never edited the set and one that did
+    /// merge to the same three rows.
+    static let shiftEnterID = UUID(uuidString: "5B2E4C1A-0001-4E6B-9F52-9A5C0F0E0001")!
+    static let doubleControlCID = UUID(uuidString: "5B2E4C1A-0002-4E6B-9F52-9A5C0F0E0002")!
+    static let optionDeleteID = UUID(uuidString: "5B2E4C1A-0003-4E6B-9F52-9A5C0F0E0003")!
+
+    /// ⇧↩ (closes) · ⌃C ×2 at 150 ms (closes) · ⌥⌫ delete-word (stays —
+    /// the point of a staying key is pressing it a few times without
+    /// reopening).
+    static let shipped: [KeyCommand] = [
+        KeyCommand(
+            id: shiftEnterID,
+            kind: .chord(KeyChord(modifiers: [.shift], key: .enter)),
+            isShipped: true
+        ),
+        KeyCommand(
+            id: doubleControlCID,
+            kind: .chord(KeyChord(modifiers: [.control], key: .character("c"))),
+            repeatCount: 2,
+            repeatGapMilliseconds: 150,
+            isShipped: true
+        ),
+        KeyCommand(
+            id: optionDeleteID,
+            kind: .chord(KeyChord(modifiers: [.option], key: .delete)),
+            closesPanel: false,
+            isShipped: true
+        ),
+    ]
+
+    static var initial: KeyCommandSet {
+        KeyCommandSet(commands: shipped, updatedAt: .distantPast)
+    }
+
+    /// Repeats under the guard, text trimmed, empty text rows dropped,
+    /// duplicate IDs made unique, and the cap applied.
+    static func normalized(_ commands: [KeyCommand]) -> [KeyCommand] {
+        var seen = Set<UUID>()
+        var result: [KeyCommand] = []
+        for command in commands {
+            var normalized = command.normalized
+            guard normalized.isSendable else { continue }
+            if seen.contains(normalized.id) { normalized.id = UUID() }
+            seen.insert(normalized.id)
+            result.append(normalized)
+            if result.count == maximumCount { break }
+        }
+        return result
+    }
+}
+
+/// Plain-words spelling of a byte sequence for the composer's SENDS readout:
+/// control bytes by name, escapes as `ESC`, everything printable as itself.
+enum KeyBytesNotation {
+    static func describe(_ bytes: [UInt8]) -> String {
+        var words: [String] = []
+        var run: [UInt8] = []
+        func flush() {
+            guard !run.isEmpty else { return }
+            words.append(String(decoding: run, as: UTF8.self))
+            run.removeAll()
+        }
+        for byte in bytes {
+            let named: String? = switch byte {
+            case 0x1B: "ESC"
+            case 0x0D: "CR"
+            case 0x0A: "LF"
+            case 0x09: "TAB"
+            case 0x7F: "DEL"
+            case 0x00: "NUL"
+            case 0x20: "SPACE"
+            case 0x01...0x1F: "^" + String(UnicodeScalar(byte + 0x40))
+            default: nil
+            }
+            if let named {
+                flush()
+                words.append(named)
+            } else {
+                run.append(byte)
+            }
+        }
+        flush()
+        return words.joined(separator: " ")
+    }
+}

--- a/Multiplex/Models/KeyCommandSync.swift
+++ b/Multiplex/Models/KeyCommandSync.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The Key Commands mirror's merge rule, pure so it is assertable without a
+/// store: last writer wins by `updatedAt`, ties keep the local set, and a
+/// mirror that is older (or missing while a local set exists) is republished
+/// from here. `HostSync` is the same idea for the host list.
+enum KeyCommandSync {
+    struct Resolution: Equatable {
+        /// The set the device should hold after the merge.
+        var set: KeyCommandSet
+        /// The local file must be rewritten (a peer's newer set was adopted).
+        var shouldPersist: Bool
+        /// The mirror must be rewritten (it is older than, or missing behind,
+        /// a local set that has been edited).
+        var shouldPush: Bool
+    }
+
+    static func merge(local: KeyCommandSet, cloud: KeyCommandSet?) -> Resolution {
+        guard let cloud else {
+            return Resolution(
+                set: local,
+                shouldPersist: false,
+                shouldPush: local.updatedAt != .distantPast
+            )
+        }
+        if cloud.updatedAt > local.updatedAt {
+            return Resolution(
+                set: KeyCommandSet(
+                    commands: KeyCommandSet.normalized(cloud.commands),
+                    updatedAt: cloud.updatedAt
+                ),
+                shouldPersist: true,
+                shouldPush: false
+            )
+        }
+        return Resolution(
+            set: local,
+            shouldPersist: false,
+            shouldPush: cloud.updatedAt < local.updatedAt
+        )
+    }
+}

--- a/Multiplex/Models/TerminalGuide.swift
+++ b/Multiplex/Models/TerminalGuide.swift
@@ -191,8 +191,27 @@ enum TerminalGuide {
             ]
         ),
         TerminalGuideEntry(
-            id: "resize",
+            id: "keycommands",
             figure: 12,
+            bank: .keyboard,
+            title: "HOLD CTRL",
+            tag: nil,
+            body: [
+                .text("A tap latches "),
+                .key("CTRL"),
+                .text("; a hold opens KEY COMMANDS — "),
+                .key("⇧⏎"),
+                .text(" newline, a double "),
+                .key("⌃C"),
+                .text(", "),
+                .key("⌥⌫"),
+                .text(" delete-word, and your own chords or one-line text macros "
+                    + "from CUSTOM SETUP, on every device."),
+            ]
+        ),
+        TerminalGuideEntry(
+            id: "resize",
+            figure: 13,
             bank: .herdrPanes,
             title: "RESIZE PANES",
             tag: "herdr",
@@ -202,7 +221,7 @@ enum TerminalGuide {
         ),
         TerminalGuideEntry(
             id: "panemenu",
-            figure: 13,
+            figure: 14,
             bank: .herdrPanes,
             title: "PANE MENU",
             tag: "herdr",

--- a/Multiplex/Services/EntitlementStore.swift
+++ b/Multiplex/Services/EntitlementStore.swift
@@ -232,6 +232,7 @@ final class EntitlementStore {
     static let proProductID = "app.multiplexterm.multiplex.pro"
     static let freeHostLimit = 2
     static let dailySlashChipLimit = 10
+    static let freeKeyCommandLimit = 5
 
     enum CommerceState: Equatable {
         case idle
@@ -339,6 +340,14 @@ final class EntitlementStore {
     /// removed or disconnected; callers enforce this only before an add.
     func canAddHost(existingHostCount: Int) -> Bool {
         isPro || existingHostCount < Self.freeHostLimit
+    }
+
+    /// The free tier keeps five Key Commands; Pro lifts the set to its full
+    /// cap. Like hosts, a set that already holds more (synced from a Pro
+    /// device, or after an entitlement lapse) is never trimmed or disabled —
+    /// the panel enforces this only before an add.
+    var keyCommandLimit: Int {
+        isPro ? KeyCommandSet.maximumCount : Self.freeKeyCommandLimit
     }
 
     /// Turning on mosh is Pro intent; a record that already has it remains

--- a/Multiplex/Services/KeyCommandDispatcher.swift
+++ b/Multiplex/Services/KeyCommandDispatcher.swift
@@ -1,0 +1,95 @@
+import Foundation
+import SwiftTerm
+
+/// Sends a Key Command through a terminal view. Every byte goes through
+/// `TerminalView.send` — the same delegate → ordered-pump path a rail key
+/// takes — and every chord is encoded by the view at send time
+/// (`TerminalView.bytes(for:)`), so it matches what a hardware press of the
+/// same chord would send in the terminal's current mode.
+@MainActor
+enum KeyCommandDispatcher {
+    /// The slash-chip shape: a text row's Enter is a separate write this long
+    /// after the text (Codex treats a same-burst CR as a pasted newline).
+    static let submitDelay: Duration = .milliseconds(160)
+
+    /// Starts the send (or the repeat burst) and returns its task; nil when
+    /// the command has nothing to send in this terminal's mode. The burst
+    /// runs to its guard-bounded end even if the panel that pressed it has
+    /// already dropped; a terminal that goes away ends it.
+    @discardableResult
+    static func perform(_ command: KeyCommand, on terminal: TerminalView) -> Task<Void, Never>? {
+        let command = command.normalized
+        let step: (TerminalView) -> Bool
+        switch command.kind {
+        case .chord(let chord):
+            let terminalChord = chord.terminalChord
+            guard terminal.bytes(for: terminalChord) != nil else { return nil }
+            step = { $0.send(chord: terminalChord) }
+        case .text(let snippet):
+            let text = snippet.normalizedText
+            guard !text.isEmpty else { return nil }
+            step = { view in
+                view.send(txt: text)
+                return true
+            }
+        }
+        let submits = command.textSnippet?.submits ?? false
+        let repeats = command.repeatCount
+        let gap = Duration.milliseconds(command.repeatGapMilliseconds)
+        return Task { @MainActor [weak terminal] in
+            for index in 0..<repeats {
+                guard let live = terminal, !Task.isCancelled else { return }
+                guard step(live) else { return }
+                if submits {
+                    try? await Task.sleep(for: submitDelay)
+                    guard let live = terminal, !Task.isCancelled else { return }
+                    live.send([0x0D])
+                }
+                if index < repeats - 1 {
+                    try? await Task.sleep(for: gap)
+                }
+            }
+        }
+    }
+
+    /// The composer's SENDS readout for the terminal's current mode: the
+    /// chord's bytes in plain words, or the text row's shape.
+    static func describe(_ command: KeyCommand, on terminal: TerminalView?) -> String {
+        switch command.kind {
+        case .chord(let chord):
+            guard let terminal, let bytes = terminal.bytes(for: chord.terminalChord) else {
+                return "NO ENCODING"
+            }
+            var text = KeyBytesNotation.describe(bytes)
+            if !terminal.getTerminal().keyboardEnhancementFlags.isEmpty {
+                text += " · KITTY KEYS ON"
+            }
+            return text
+        case .text(let snippet):
+            return snippet.submits ? "TEXT · THEN CR 160 MS LATER" : "TEXT · NO ENTER"
+        }
+    }
+}
+
+extension KeyChord {
+    /// The fork's spelling of this chord.
+    var terminalChord: TerminalKeyChord {
+        var modifiers: TerminalKeyChord.Modifiers = []
+        if self.modifiers.contains(.control) { modifiers.insert(.control) }
+        if self.modifiers.contains(.shift) { modifiers.insert(.shift) }
+        if self.modifiers.contains(.option) { modifiers.insert(.option) }
+        let key: TerminalKeyChord.Key = switch self.key {
+        case .enter: .enter
+        case .tab: .tab
+        case .escape: .escape
+        case .delete: .backspace
+        case .space: .space
+        case .up: .up
+        case .down: .down
+        case .left: .left
+        case .right: .right
+        case .character(let character): .character(character.first ?? " ")
+        }
+        return TerminalKeyChord(key: key, modifiers: modifiers)
+    }
+}

--- a/Multiplex/Services/KeyCommandStore.swift
+++ b/Multiplex/Services/KeyCommandStore.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Observation
+
+/// The app-wide Key Commands set — one list for every host and every
+/// terminal, since a chord is keyboard-level, not host-level.
+///
+/// The set persists to `keycommands.json` beside `hosts.json` and mirrors to
+/// one synchronizable Keychain item so iCloud Keychain carries it to the
+/// user's other devices (the host list's channel; no CloudKit container).
+/// The merge is `KeyCommandSync` — last writer wins by `updatedAt`.
+@MainActor
+@Observable
+final class KeyCommandStore {
+    static let shared = KeyCommandStore()
+
+    /// A cloud refresh costs a synchronizable Keychain read; the set changes
+    /// rarely, so panel opens inside this window reuse the last answer.
+    nonisolated static let cloudRefreshInterval: TimeInterval = 60
+
+    private(set) var commands: [KeyCommand]
+    private(set) var updatedAt: Date
+
+    private let fileURL: URL?
+    private let usesKeychainMirror: Bool
+    private var isRefreshingFromCloud = false
+    private var lastCloudRefresh: Date?
+
+    /// - Parameters:
+    ///   - directory: where `keycommands.json` lives; nil keeps the set in
+    ///     memory only (tests).
+    ///   - usesKeychainMirror: whether saves publish to the synchronizable
+    ///     Keychain item and `refreshFromCloud()` reads it. Tests keep the
+    ///     device's real mirror out of the run.
+    init(directory: URL? = nil, usesKeychainMirror: Bool = false) {
+        fileURL = directory?.appendingPathComponent("keycommands.json")
+        self.usesKeychainMirror = usesKeychainMirror
+        let loaded = Self.load(from: fileURL) ?? .initial
+        commands = KeyCommandSet.normalized(loaded.commands)
+        updatedAt = loaded.updatedAt
+    }
+
+    private convenience init() {
+        let directory = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Multiplex", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        self.init(directory: directory, usesKeychainMirror: true)
+    }
+
+    var set: KeyCommandSet {
+        KeyCommandSet(commands: commands, updatedAt: updatedAt)
+    }
+
+    /// The editor's DONE: normalize once, stamp, persist, publish.
+    func replace(_ commands: [KeyCommand], now: Date = Date()) {
+        self.commands = KeyCommandSet.normalized(commands)
+        updatedAt = now
+        guard let data = encoded() else { return }
+        persist(data)
+        mirror(data)
+    }
+
+    /// Reconcile with the Keychain mirror. Synchronizable Keychain queries
+    /// can involve securityd/iCloud, so the read leaves the main actor, and
+    /// repeats inside `cloudRefreshInterval` are skipped unless `force`d.
+    func refreshFromCloud(force: Bool = false, now: Date = Date()) async {
+        guard usesKeychainMirror, !isRefreshingFromCloud else { return }
+        if !force, let last = lastCloudRefresh,
+           now.timeIntervalSince(last) < Self.cloudRefreshInterval {
+            return
+        }
+        isRefreshingFromCloud = true
+        defer { isRefreshingFromCloud = false }
+        let record = await Task.detached(priority: .utility) {
+            KeychainStore.keyCommandRecord()
+        }.value
+        lastCloudRefresh = now
+        adopt(cloudRecord: record)
+    }
+
+    /// Apply the mirror's record through `KeyCommandSync`.
+    func adopt(cloudRecord: Data?) {
+        let cloud = cloudRecord.flatMap { try? Self.decoder.decode(KeyCommandSet.self, from: $0) }
+        let resolution = KeyCommandSync.merge(local: set, cloud: cloud)
+        if resolution.shouldPersist {
+            commands = resolution.set.commands
+            updatedAt = resolution.set.updatedAt
+            if let data = encoded() { persist(data) }
+        }
+        if resolution.shouldPush, let data = encoded() {
+            mirror(data)
+        }
+    }
+
+    // MARK: - Persistence
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private static func load(from url: URL?) -> KeyCommandSet? {
+        guard let url, let data = try? Data(contentsOf: url) else { return nil }
+        return try? decoder.decode(KeyCommandSet.self, from: data)
+    }
+
+    private func encoded() -> Data? {
+        try? Self.encoder.encode(set)
+    }
+
+    private func persist(_ data: Data) {
+        guard let fileURL else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    /// The mirror is fire-and-forget: two securityd round-trips that need
+    /// not hold the DONE press on the main actor.
+    private func mirror(_ data: Data) {
+        guard usesKeychainMirror else { return }
+        Task.detached(priority: .utility) {
+            KeychainStore.setKeyCommandRecord(data)
+        }
+    }
+}

--- a/Multiplex/Services/KeychainStore.swift
+++ b/Multiplex/Services/KeychainStore.swift
@@ -3,11 +3,12 @@ import Security
 
 /// Minimal Keychain wrapper. Every item is written as *synchronizable*, so
 /// iCloud Keychain carries it to the user's other devices — end-to-end
-/// encrypted, no entitlement or CloudKit container required. Two item
+/// encrypted, no entitlement or CloudKit container required. Three item
 /// families share the same primitives:
 ///   - per-host secrets (password / private key / passphrase)
 ///   - mirrored host records: the non-secret `Host` JSON, one item per host,
 ///     which is how the host list itself crosses devices
+///   - the Key Commands set: one item, last writer wins by `updatedAt`
 ///
 /// Every query MUST include `kSecAttrSynchronizable` (we use `…Any`): a query
 /// without the key matches only device-local items, so synced secrets would
@@ -15,6 +16,11 @@ import Security
 enum KeychainStore {
     private static let secretService = "app.multiplexterm.multiplex"
     private static let hostRecordService = "app.multiplexterm.multiplex.hosts"
+    /// The one app-wide Key Commands set (`KeyCommandSet` JSON) — the same
+    /// synchronizable channel the host list rides, so a chord added on the
+    /// iPad reaches the Vision Pro without a CloudKit container.
+    private static let keyCommandService = "app.multiplexterm.multiplex.keycommands"
+    private static let keyCommandAccount = "set"
 
     enum Kind: String {
         case password
@@ -71,6 +77,17 @@ enum KeychainStore {
 
     static func deleteHostRecord(for hostID: UUID) {
         deleteItem(service: hostRecordService, account: hostID.uuidString)
+    }
+
+    // MARK: - Key command mirror
+
+    @discardableResult
+    static func setKeyCommandRecord(_ record: Data) -> Bool {
+        setItem(record, service: keyCommandService, account: keyCommandAccount)
+    }
+
+    static func keyCommandRecord() -> Data? {
+        getItem(service: keyCommandService, account: keyCommandAccount)
     }
 
     // MARK: - Migration

--- a/Multiplex/Views/Settings/ProPaywallView.swift
+++ b/Multiplex/Views/Settings/ProPaywallView.swift
@@ -162,7 +162,8 @@ final class ProPaywallViewController: UIViewController, AppAppearanceFollowing {
         )
         let freeTier = makeLabel(
             "The free tier stays useful: two hosts, spatial SSH terminals, "
-                + "live agent detection, built-in themes and "
+                + "live agent detection, built-in themes, "
+                + "\(EntitlementStore.freeKeyCommandLimit) saved Key Commands and "
                 + "\(EntitlementStore.dailySlashChipLimit) built-in or custom "
                 + "agent-command taps each day.",
             style: .subheadline,
@@ -196,6 +197,12 @@ final class ProPaywallViewController: UIViewController, AppAppearanceFollowing {
             makeFeature(
                 "CUSTOM THEMES",
                 "Build and edit terminal palettes while the Tally chassis stays consistent."
+            ),
+            makeFeature(
+                "\(KeyCommandSet.maximumCount) KEY COMMANDS",
+                "Grow the hold-CTRL set of saved chords and text macros from "
+                    + "\(EntitlementStore.freeKeyCommandLimit) to \(KeyCommandSet.maximumCount), "
+                    + "synced to every device."
             ),
         ])
         stack.axis = .vertical

--- a/Multiplex/Views/Settings/SettingsView.swift
+++ b/Multiplex/Views/Settings/SettingsView.swift
@@ -540,6 +540,11 @@ final class SettingsViewController: UIViewController {
         ))
         rows.append(proRow("Agent Alerts", state: state))
         rows.append(proRow("Custom Themes", state: state))
+        rows.append(proRow(
+            "Key Commands",
+            freeStatus: "UP TO \(EntitlementStore.freeKeyCommandLimit)",
+            state: state
+        ))
         rows.append(SettingsInsetRow(contentView: settingsLeadingView(UIKitChassisChip(
             state.isPro ? "PRO DETAILS" : "UNLOCK MULTIPLEX PRO",
             prominent: true,
@@ -561,8 +566,9 @@ final class SettingsViewController: UIViewController {
         return SettingsSectionView(
             title: "Multiplex Pro",
             detail: "Pro adds unlimited hosts, mosh, unlimited agent-helper commands, "
-                + "alerts, and custom themes. SSH terminals, agent detection, and the "
-                + "wall's live state stay free.",
+                + "alerts, custom themes, and a \(KeyCommandSet.maximumCount)-command Key Commands set "
+                + "(free keeps \(EntitlementStore.freeKeyCommandLimit)). SSH terminals, agent "
+                + "detection, and the wall's live state stay free.",
             rows: rows
         )
     }

--- a/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
+++ b/Multiplex/Views/Terminal/CustomAgentCommandPanel.swift
@@ -57,7 +57,7 @@ final class CustomAgentCommandPanelViewController: UIViewController {
     /// The list viewport keeps its rows 2 pt inside the header/footer text
     /// edge at every panel inset.
     nonisolated static let listInset: CGFloat = UIKitChassis.popoverPanelInset - 2
-    /// Below the footer legend's own resistance (see `legendRow`), so a
+    /// Below the footer legend's own resistance (see `TallyEditorLegend`), so a
     /// shortened popover spends the scroll viewport before any chrome.
     private static let listHeightPriority = UILayoutPriority(650)
 
@@ -353,51 +353,22 @@ final class CustomAgentCommandPanelViewController: UIViewController {
     }
 
     private func makeFooter() -> UIView {
-        let legend = UIStackView(arrangedSubviews: [
-            legendRow(
+        let legend = TallyEditorLegend.stack([
+            TallyEditorLegend.row(
                 color: TallyPalette.customCommand,
                 text: "Built-ins and custom commands each live in Bar or More; custom Bar labels keep 9 characters."
             ),
-            legendRow(
+            TallyEditorLegend.row(
                 color: UIKitChassis.signal3,
                 text: "Shared keeps one editable command synchronized across Claude Code, Codex, and Pi."
             ),
         ])
-        legend.axis = .vertical
-        legend.alignment = .fill
-        legend.spacing = 6
-
-        let add = UIKitChassisChip(
-            "ADD COMMAND",
-            systemImage: "plus",
-            accessibilityLabel: "Add command",
-            action: { [weak self] in self?.addCommand() }
+        let actions = TallyEditorFooter.actions(
+            identifierPrefix: "customCommands",
+            add: { [weak self] in self?.addCommand() },
+            cancel: { [weak self] in self?.cancelDrafts() },
+            done: { [weak self] in self?.saveDrafts() }
         )
-        add.accessibilityIdentifier = "customCommands.add"
-        let spacer = UIView()
-        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        let cancel = UIKitChassisChip(
-            "CANCEL",
-            accessibilityLabel: "Cancel",
-            action: { [weak self] in self?.cancelDrafts() }
-        )
-        cancel.accessibilityIdentifier = "customCommands.cancel"
-        let done = UIKitChassisChip(
-            "DONE",
-            prominent: true,
-            accessibilityLabel: "Done",
-            action: { [weak self] in self?.saveDrafts() }
-        )
-        done.accessibilityIdentifier = "customCommands.done"
-        for chip in [add, cancel, done] {
-            chip.setContentHuggingPriority(.required, for: .horizontal)
-            chip.setContentCompressionResistancePriority(.required, for: .horizontal)
-        }
-
-        let actions = UIStackView(arrangedSubviews: [add, spacer, cancel, done])
-        actions.axis = .horizontal
-        actions.alignment = .center
-        actions.spacing = 8
 
         let stack = UIStackView(arrangedSubviews: [legend, actions])
         stack.axis = .vertical
@@ -411,34 +382,6 @@ final class CustomAgentCommandPanelViewController: UIViewController {
             trailing: UIKitChassis.popoverPanelInset
         )
         return stack
-    }
-
-    private func legendRow(color: UIColor, text: String) -> UIView {
-        let dot = UIView()
-        dot.backgroundColor = color
-        dot.layer.cornerRadius = 3
-        dot.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            dot.widthAnchor.constraint(equalToConstant: 6),
-            dot.heightAnchor.constraint(equalToConstant: 6),
-        ])
-        dot.isAccessibilityElement = false
-
-        let label = UILabel()
-        label.text = text
-        label.font = UIKitChassis.monoFont(8, weight: .medium)
-        label.textColor = UIKitChassis.signal2
-        label.numberOfLines = 0
-        // Above the list viewport's resting height, below required: the legend
-        // is the last thing in the panel to give way, and a required floor here
-        // would make a popover shorter than the whole panel unsatisfiable.
-        label.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-
-        let row = UIStackView(arrangedSubviews: [dot, label])
-        row.axis = .horizontal
-        row.alignment = .firstBaseline
-        row.spacing = 8
-        return row
     }
 
     private func divider() -> UIView {
@@ -811,7 +754,7 @@ private final class CustomBuiltInCommandRow: UIView {
 enum CustomCommandChoiceMetrics {
     static let height: CGFloat = 34
     static let seam: CGFloat = 1
-    static let selectionAnimationDuration: TimeInterval = 0.14
+    static let selectionAnimationDuration = TallyEditorMetrics.selectionAnimationDuration
 }
 
 @MainActor
@@ -1025,32 +968,15 @@ private final class CustomCommandRowView: UIView, UITextViewDelegate {
         switches.spacing = 8
         switches.setContentHuggingPriority(.required, for: .horizontal)
 
-        let up = CustomCommandRowActionButton(
-            systemImage: "arrow.up",
-            accessibilityLabel: "Move command up",
-            enabled: index > 0,
-            action: { move(command.id, -1) }
-        )
-        up.accessibilityIdentifier = "customCommands.moveUp.\(command.id.uuidString)"
-        let down = CustomCommandRowActionButton(
-            systemImage: "arrow.down",
-            accessibilityLabel: "Move command down",
-            enabled: index < commandCount - 1,
-            action: { move(command.id, 1) }
-        )
-        down.accessibilityIdentifier = "customCommands.moveDown.\(command.id.uuidString)"
-        let trash = CustomCommandRowActionButton(
-            systemImage: "trash",
-            accessibilityLabel: "Delete command",
-            enabled: true,
-            action: { delete(command.id) }
-        )
-        trash.accessibilityIdentifier = "customCommands.delete.\(command.id.uuidString)"
-        let actions = UIStackView(arrangedSubviews: [up, down, trash])
-        actions.axis = .horizontal
-        actions.alignment = .center
-        actions.spacing = 8
-        actions.setContentHuggingPriority(.required, for: .horizontal)
+        let commandID = command.id
+        let actions = TallyEditorRowActions.make(
+            index: index,
+            count: commandCount,
+            identifierPrefix: "customCommands",
+            rowID: commandID,
+            move: { offset in move(commandID, offset) },
+            delete: { delete(commandID) }
+        ).stack
 
         refreshPlacementLabel()
         placementLabel.setContentHuggingPriority(.required, for: .horizontal)
@@ -1146,10 +1072,11 @@ private final class CustomCommandRowView: UIView, UITextViewDelegate {
         value: Bool,
         keyPath: WritableKeyPath<CustomAgentCommand, Bool>
     ) -> UIView {
-        CustomCommandSwitch(
+        TallyEditorSwitch(
             label: label,
             accessibilityLabel: accessibilityLabel,
             isOn: value,
+            identifierPrefix: "customCommands",
             changed: { [weak self] value in
                 guard let self else { return }
                 self.command[keyPath: keyPath] = value
@@ -1230,186 +1157,6 @@ private final class CustomCommandTextView: UITextView {
         }), abs(height.constant - needed) >= 0.5 {
             height.constant = needed
         }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
-        else { return }
-        layer.borderColor = UIKitChassis.bezelHi
-            .resolvedColor(with: traitCollection).cgColor
-    }
-}
-
-@MainActor
-private final class CustomCommandSwitch: UIControl {
-    private let track = CustomCommandSwitchTrack()
-    private let caption: UIKitChassisLabel
-    private var isOn: Bool
-    private let changed: (Bool) -> Void
-
-    init(
-        label: String,
-        accessibilityLabel: String,
-        isOn: Bool,
-        changed: @escaping (Bool) -> Void
-    ) {
-        self.isOn = isOn
-        self.changed = changed
-        caption = UIKitChassisLabel(
-            label,
-            size: 8,
-            color: isOn ? UIKitChassis.signal : UIKitChassis.signal2
-        )
-        super.init(frame: .zero)
-        isAccessibilityElement = true
-        // The SwiftUI row was a real `Toggle`; `.toggleButton` is UIKit's
-        // equivalent identity, so the switch rotor and the spoken On/Off
-        // state survive the port.
-        accessibilityTraits = [.button, .toggleButton]
-        self.accessibilityLabel = accessibilityLabel
-        accessibilityIdentifier = "customCommands.switch.\(label.lowercased())"
-        addTarget(self, action: #selector(pressed), for: .touchUpInside)
-        #if os(visionOS)
-        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
-        #endif
-
-        let row = UIStackView(arrangedSubviews: [track, caption])
-        row.axis = .horizontal
-        row.alignment = .center
-        row.spacing = 7
-        row.isUserInteractionEnabled = false
-        addSubview(row)
-        row.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            row.leadingAnchor.constraint(equalTo: leadingAnchor),
-            row.trailingAnchor.constraint(equalTo: trailingAnchor),
-            row.topAnchor.constraint(equalTo: topAnchor),
-            row.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
-        render()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
-
-    @objc private func pressed() {
-        isOn.toggle()
-        render(animated: true)
-        changed(isOn)
-    }
-
-    private func render(animated: Bool = false) {
-        track.setOn(isOn, animated: animated)
-        caption.setInk(isOn ? UIKitChassis.signal : UIKitChassis.signal2)
-        accessibilityValue = isOn ? "On" : "Off"
-        if isOn {
-            accessibilityTraits.insert(.selected)
-        } else {
-            accessibilityTraits.remove(.selected)
-        }
-    }
-}
-
-@MainActor
-private final class CustomCommandSwitchTrack: UIKitTallyBorderedView {
-    private let thumb = UIView()
-    private var leading: NSLayoutConstraint!
-    private var trailing: NSLayoutConstraint!
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalToConstant: 26),
-            heightAnchor.constraint(equalToConstant: 14),
-        ])
-        thumb.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(thumb)
-        leading = thumb.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 3)
-        trailing = thumb.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3)
-        NSLayoutConstraint.activate([
-            thumb.widthAnchor.constraint(equalToConstant: 8),
-            thumb.heightAnchor.constraint(equalToConstant: 8),
-            thumb.centerYAnchor.constraint(equalTo: centerYAnchor),
-            leading,
-        ])
-        isAccessibilityElement = false
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
-
-    func setOn(_ on: Bool, animated: Bool = false) {
-        leading.isActive = false
-        trailing.isActive = false
-        (on ? trailing : leading).isActive = true
-        let apply = {
-            self.backgroundColor = on ? UIKitChassis.bezelHi : UIKitChassis.screen
-            self.thumb.backgroundColor = on ? UIKitChassis.signal : UIKitChassis.signal3
-            self.tallyBorderColor = on ? UIKitChassis.signal2 : UIKitChassis.bezelHi
-            // The swapped constraint only moves the thumb inside an animation
-            // transaction if the layout pass runs there too.
-            self.layoutIfNeeded()
-        }
-        guard animated, window != nil, !UIAccessibility.isReduceMotionEnabled else {
-            apply()
-            return
-        }
-        UIView.animate(
-            withDuration: CustomCommandChoiceMetrics.selectionAnimationDuration,
-            delay: 0,
-            options: [.curveEaseOut, .beginFromCurrentState],
-            animations: apply
-        )
-    }
-}
-
-@MainActor
-private final class CustomCommandRowActionButton: UIButton {
-    private let action: () -> Void
-
-    init(
-        systemImage: String,
-        accessibilityLabel: String,
-        enabled: Bool,
-        action: @escaping () -> Void
-    ) {
-        self.action = action
-        super.init(frame: .zero)
-        backgroundColor = GlassPrototype.strataChassis
-        layer.borderWidth = 1
-        layer.borderColor = UIKitChassis.bezelHi
-            .resolvedColor(with: traitCollection).cgColor
-        setImage(
-            UIImage(
-                systemName: systemImage,
-                withConfiguration: UIImage.SymbolConfiguration(
-                    pointSize: 9 * Theme.typeScale,
-                    weight: .semibold
-                )
-            ),
-            for: .normal
-        )
-        tintColor = enabled ? UIKitChassis.signal2 : UIKitChassis.signal3
-        isEnabled = enabled
-        self.accessibilityLabel = accessibilityLabel
-        addTarget(self, action: #selector(pressed), for: .touchUpInside)
-        translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalToConstant: 25),
-            heightAnchor.constraint(equalToConstant: 23),
-        ])
-        #if os(visionOS)
-        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
-        #endif
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
-
-    @objc private func pressed() {
-        action()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Multiplex/Views/Terminal/KeyCommandPanel.swift
+++ b/Multiplex/Views/Terminal/KeyCommandPanel.swift
@@ -1,0 +1,1693 @@
+import SwiftTerm
+import UIKit
+
+/// The hold-CTRL panel — KEY COMMANDS with two tabs. COMMANDS is a square
+/// grid of saved chords (tap sends; a pinned row keeps the panel up; a hold
+/// jumps to that row's setup). CUSTOM SETUP is the COMMAND SETUP editor's
+/// list with an inline composer: KEYS or TEXT, the chord's modifiers and one
+/// key (or one line of text with SUBMIT), REPEAT under the guard, and CLOSE
+/// ON PRESS. Drafts are a transaction: DONE normalizes once and hands the
+/// set to the store; CANCEL or an outside dismissal discards.
+///
+/// The controller owns state; every visual stands on the shortcut panel's
+/// grammar (`ShortcutPanelRootView`, `ShortcutPressControl`,
+/// `TallyHairlineGrid`, `TallyPanelHeader`) and the agent editor's shared
+/// controls (`TallyEditor*`). Presentation belongs to
+/// `KeyCommandPanelPresenter`.
+@MainActor
+final class KeyCommandPanelViewController: UIViewController {
+    enum Tab: Equatable {
+        case commands
+        case setup
+    }
+
+    nonisolated static let commandsWidth: CGFloat =
+        440 + 2 * UIKitChassis.popoverPanelInset
+    nonisolated static let setupWidth: CGFloat =
+        540 + 2 * UIKitChassis.popoverPanelInset
+    /// The CTRL hold that opens the panel: shorter than the keyboard key's
+    /// 0.5 s lock hold, because it is the daily path — a tap latches, a
+    /// beat longer opens.
+    nonisolated static let controlHoldDuration: TimeInterval = 0.3
+    /// A held COMMANDS cell opens its row's setup — the rail keys' hold.
+    nonisolated static let cellHoldDuration: TimeInterval = 0.5
+    /// Below this panel width (an iPhone popover) the composer's KEYS and
+    /// REPEAT lines wrap onto two rows instead of clipping. Measured against
+    /// the scaled controls, so the Mac's larger faces wrap too.
+    nonisolated static let compactComposerWidth: CGFloat = 480
+
+    private let store: KeyCommandStore
+    private weak var terminal: TerminalView?
+    /// The popover's ceiling (the scene width less its margins); the two
+    /// tabs ask for their own widths under it.
+    private let maximumWidth: CGFloat
+    /// The tier's cap and its paywall route (already wrapped by the
+    /// presenter to close this popover first).
+    private let plan: KeyCommandPlan
+    private let perform: (KeyCommand) -> Void
+    private let requestDismiss: () -> Void
+
+    private(set) var selectedTab: Tab = .commands
+    private(set) var drafts: [KeyCommand] = []
+    private(set) var expandedID: UUID?
+    private(set) var panelWidth: CGFloat
+
+    private let panelView: ShortcutPanelRootView
+    private let contentStack = UIStackView()
+    private var rowViews: [UUID: KeyCommandRowView] = [:]
+    private var headerReadout: UIKitChassisMonoLabel?
+    private var observationGeneration = 0
+    /// DONE writes the store, which the grid also observes; the flag keeps
+    /// that observation from rebuilding a panel that is rebuilding itself.
+    private var isApplyingLocalEdit = false
+
+    init(
+        store: KeyCommandStore,
+        terminal: TerminalView?,
+        maximumWidth: CGFloat = KeyCommandPanelViewController.setupWidth,
+        plan: KeyCommandPlan = .unrestricted,
+        perform: @escaping (KeyCommand) -> Void,
+        dismiss: @escaping () -> Void
+    ) {
+        self.store = store
+        self.terminal = terminal
+        self.maximumWidth = maximumWidth
+        self.plan = plan
+        self.perform = perform
+        requestDismiss = dismiss
+        panelWidth = min(Self.commandsWidth, maximumWidth)
+        panelView = ShortcutPanelRootView(width: panelWidth)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    override func loadView() {
+        view = panelView
+        // PROTOTYPE(GLASS): the popover root's smoke is the one ground.
+        panelView.backgroundColor = GlassPrototype.clearedBezel
+        panelView.tallyBorderColor = UIKitChassis.bezelHi
+        contentStack.axis = .vertical
+        contentStack.alignment = .fill
+        contentStack.spacing = 12
+        panelView.install(contentStack: contentStack)
+        rebuild()
+        observeStore()
+    }
+
+    /// A peer's newer set (the Keychain mirror) can land while the panel is
+    /// up; the grid re-reads the store, the setup drafts stay the user's.
+    private func observeStore() {
+        observationGeneration &+= 1
+        let generation = observationGeneration
+        withObservationTracking {
+            _ = store.commands
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, generation == observationGeneration else { return }
+                observeStore()
+                if selectedTab == .commands, !isApplyingLocalEdit { rebuild() }
+            }
+        }
+    }
+
+    func fittingContentSize(for width: CGFloat? = nil) -> CGSize {
+        loadViewIfNeeded()
+        return panelView.fittingSize(for: width ?? panelWidth)
+    }
+
+    func prepareForRemoval() {
+        viewIfLoaded?.endEditing(true)
+    }
+
+    // MARK: Testable action boundary
+
+    func selectTab(_ tab: Tab, expanding id: UUID? = nil) {
+        guard tab != selectedTab || id != expandedID else { return }
+        viewIfLoaded?.endEditing(true)
+        if tab == .setup {
+            if selectedTab != .setup { drafts = store.commands }
+            expandedID = id
+        } else {
+            drafts = []
+            expandedID = nil
+        }
+        selectedTab = tab
+        rebuild()
+    }
+
+    /// COMMANDS tap: send, then close if the row says so.
+    func press(_ command: KeyCommand) {
+        perform(command)
+        if command.closesPanel { requestDismiss() }
+    }
+
+    /// COMMANDS hold: that row's setup, already expanded.
+    func hold(_ command: KeyCommand) {
+        selectTab(.setup, expanding: command.id)
+    }
+
+    func expand(id: UUID?) {
+        guard expandedID != id else { return }
+        viewIfLoaded?.endEditing(true)
+        expandedID = id
+        rebuild()
+    }
+
+    @discardableResult
+    func addCommand() -> KeyCommand? {
+        guard selectedTab == .setup, canAddCommand else { return nil }
+        let command = KeyCommand(kind: .chord(KeyChord(key: .enter)))
+        drafts.append(command)
+        expandedID = command.id
+        rebuild()
+        return command
+    }
+
+    /// The commands this tier lets the set hold; never above the model's cap.
+    var limit: Int { min(plan.limit, KeyCommandSet.maximumCount) }
+
+    var canAddCommand: Bool { drafts.count < limit }
+
+    /// At the tier's cap with room left under the model's: ADD COMMAND
+    /// becomes the Pro route instead of dimming.
+    var addNeedsPro: Bool {
+        !canAddCommand && plan.upgrade != nil && drafts.count < KeyCommandSet.maximumCount
+    }
+
+    /// The footer's ADD: a new draft, or — at the tier's cap — the paywall.
+    /// A set that already holds more than the tier allows (synced from a Pro
+    /// device) keeps every row; only adding is gated.
+    func addOrUpgrade() {
+        if addNeedsPro {
+            plan.upgrade?()
+        } else {
+            addCommand()
+        }
+    }
+
+    func moveCommand(id: UUID, offset: Int) {
+        guard let source = drafts.firstIndex(where: { $0.id == id }) else { return }
+        let destination = source + offset
+        guard drafts.indices.contains(destination) else { return }
+        drafts.swapAt(source, destination)
+        rebuild()
+    }
+
+    func deleteCommand(id: UUID) {
+        drafts.removeAll { $0.id == id }
+        if expandedID == id { expandedID = nil }
+        rebuild()
+    }
+
+    /// The composer's writes: by ID, so a stale field delivery after a
+    /// delete or move edits nothing. Only the row's own header line
+    /// re-renders — typing never changes the panel's height.
+    func updateDraft(_ command: KeyCommand) {
+        guard let index = drafts.firstIndex(where: { $0.id == command.id }) else { return }
+        var stable = command
+        stable.id = drafts[index].id
+        drafts[index] = stable
+        rowViews[stable.id]?.render(command: stable, index: index, count: drafts.count)
+    }
+
+    func saveDrafts() {
+        viewIfLoaded?.endEditing(true)
+        isApplyingLocalEdit = true
+        store.replace(drafts)
+        isApplyingLocalEdit = false
+        selectTab(.commands)
+    }
+
+    func cancelDrafts() {
+        selectTab(.commands)
+    }
+
+    // MARK: Construction
+
+    private func rebuild() {
+        guard isViewLoaded else { return }
+        for view in contentStack.arrangedSubviews {
+            contentStack.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        rowViews.removeAll()
+        panelWidth = min(selectedTab == .commands ? Self.commandsWidth : Self.setupWidth, maximumWidth)
+        panelView.width = panelWidth
+
+        contentStack.addArrangedSubview(makeHeader())
+        contentStack.addArrangedSubview(makeTabPair())
+        switch selectedTab {
+        case .commands:
+            contentStack.addArrangedSubview(makeCommandGrid())
+            contentStack.addArrangedSubview(makeFootnote(
+                "TAP SENDS · DOT = STAYS OPEN · HOLD A CELL TO EDIT · TAP OUTSIDE CLOSES"
+            ))
+        case .setup:
+            contentStack.addArrangedSubview(makeRows())
+            contentStack.addArrangedSubview(makeLegend())
+            contentStack.addArrangedSubview(TallyEditorFooter.actions(
+                identifierPrefix: "keyCommands",
+                addState: addNeedsPro ? .upgrade : (canAddCommand ? .available : .capped),
+                add: { [weak self] in self?.addOrUpgrade() },
+                cancel: { [weak self] in self?.cancelDrafts() },
+                done: { [weak self] in self?.saveDrafts() }
+            ))
+        }
+        refreshPreferredContentSize()
+    }
+
+    private func makeHeader() -> UIView {
+        let readout = UIKitChassisMonoLabel(
+            "",
+            font: UIKitChassis.monoFont(9, weight: .semibold),
+            color: UIKitChassis.signal2,
+            kern: 0.8
+        )
+        readout.accessibilityIdentifier = "keyCommands.readout"
+        headerReadout = readout
+        refreshHeaderReadout()
+        return TallyPanelHeader.make(
+            title: "KEY COMMANDS",
+            trailing: readout,
+            titleIdentifier: "keyCommands.title"
+        )
+    }
+
+    private func refreshHeaderReadout() {
+        switch selectedTab {
+        case .commands:
+            headerReadout?.setText("HOLD CTRL", ink: UIKitChassis.signal2)
+        case .setup:
+            headerReadout?.setText(
+                "ALL HOSTS · \(drafts.count) OF \(limit)",
+                ink: TallyPalette.customCommand
+            )
+        }
+    }
+
+    private func makeTabPair() -> UIView {
+        let commands = KeyCommandSegmentCell(
+            title: "COMMANDS",
+            accessibilityLabel: "Commands",
+            selected: selectedTab == .commands
+        ) { [weak self] in self?.selectTab(.commands) }
+        commands.accessibilityIdentifier = "keyCommands.tab.commands"
+        let setup = KeyCommandSegmentCell(
+            title: "CUSTOM SETUP",
+            accessibilityLabel: "Custom setup",
+            selected: selectedTab == .setup
+        ) { [weak self] in self?.selectTab(.setup) }
+        setup.accessibilityIdentifier = "keyCommands.tab.setup"
+        let pair = TallyHairlineGrid.row([commands, setup])
+        pair.layer.borderWidth = 1
+        pair.layer.borderColor = UIKitChassis.bezelHi.resolvedColor(with: view.traitCollection).cgColor
+        return pair
+    }
+
+    private func makeCommandGrid() -> UIView {
+        var cells: [UIView] = store.commands.map { command in
+            KeyCommandCell(
+                command: command,
+                press: { [weak self] in self?.press(command) },
+                hold: { [weak self] in self?.hold(command) }
+            )
+        }
+        if cells.isEmpty {
+            cells.append(makeEmptyLabel("NO COMMANDS · CUSTOM SETUP"))
+        }
+        return TallyHairlineGrid.grid(cells, columns: 2)
+    }
+
+    private func makeFootnote(_ text: String) -> UIView {
+        let label = UIKitChassisMonoLabel(
+            text,
+            font: UIKitChassis.monoFont(8, weight: .medium),
+            color: UIKitChassis.signal3,
+            kern: 0.6
+        )
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        label.isAccessibilityElement = true
+        return label
+    }
+
+    private func makeRows() -> UIView {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 1
+        stack.backgroundColor = UIKitChassis.bezelHi
+        stack.layer.borderWidth = 1
+        stack.layer.borderColor = UIKitChassis.bezelHi.resolvedColor(with: view.traitCollection).cgColor
+        stack.accessibilityIdentifier = "keyCommands.rows"
+        let compact = panelWidth < Self.compactComposerWidth * KeyCommandMetrics.scale
+        for (index, command) in drafts.enumerated() {
+            let row = KeyCommandRowView(
+                command: command,
+                index: index,
+                count: drafts.count,
+                expanded: expandedID == command.id,
+                compact: compact,
+                terminal: terminal,
+                toggle: { [weak self] id in
+                    guard let self else { return }
+                    expand(id: expandedID == id ? nil : id)
+                },
+                move: { [weak self] id, offset in self?.moveCommand(id: id, offset: offset) },
+                delete: { [weak self] id in self?.deleteCommand(id: id) },
+                changed: { [weak self] command in self?.updateDraft(command) },
+                layoutChanged: { [weak self] in self?.refreshPreferredContentSize() }
+            )
+            rowViews[command.id] = row
+            stack.addArrangedSubview(row)
+        }
+        if drafts.isEmpty {
+            stack.addArrangedSubview(makeEmptyLabel("NO COMMANDS"))
+        }
+        return stack
+    }
+
+    /// The one empty state both tabs share: a dim caps label on the chassis.
+    private func makeEmptyLabel(_ title: String) -> UIView {
+        let empty = UIKitChassisLabel(title, size: 10, color: UIKitChassis.signal3)
+        empty.textAlignment = .center
+        empty.backgroundColor = GlassPrototype.clearedChassis
+        empty.accessibilityIdentifier = "keyCommands.empty"
+        empty.translatesAutoresizingMaskIntoConstraints = false
+        empty.heightAnchor.constraint(equalToConstant: KeyCommandMetrics.emptyStateHeight).isActive = true
+        return empty
+    }
+
+    private func makeLegend() -> UIView {
+        var rows = [
+            TallyEditorLegend.row(
+                color: TallyPalette.customCommand,
+                text: "Chords send what a hardware keyboard would; text rows type one line, "
+                    + "then Enter when SUBMIT is on."
+            ),
+            TallyEditorLegend.row(
+                color: UIKitChassis.signal3,
+                text: "Repeat guard: ×\(KeyCommandRepeatGuard.maximumCount) at most, "
+                    + "\(KeyCommandRepeatGuard.gapRange.lowerBound)–\(KeyCommandRepeatGuard.gapRange.upperBound) ms "
+                    + "between sends, whole burst within \(KeyCommandRepeatGuard.burstLimitMilliseconds / 1000) s. Values clamp."
+            ),
+        ]
+        // The tier line exists only where a tier applies: Pro (and the
+        // tests' unrestricted plan) never see it.
+        if plan.upgrade != nil, limit < KeyCommandSet.maximumCount {
+            let tier = TallyEditorLegend.row(
+                color: UIKitChassis.signal2,
+                text: "Free keeps \(limit) commands; Multiplex Pro raises the set to "
+                    + "\(KeyCommandSet.maximumCount)."
+            )
+            tier.accessibilityIdentifier = "keyCommands.legend.tier"
+            rows.append(tier)
+        }
+        return TallyEditorLegend.stack(rows)
+    }
+
+    private func refreshPreferredContentSize() {
+        guard isViewLoaded else { return }
+        panelView.invalidateIntrinsicContentSize()
+        let size = panelView.fittingSize(for: panelWidth)
+        guard preferredContentSize != size else { return }
+        preferredContentSize = size
+        parent?.preferredContentSizeDidChange(forChildContentContainer: self)
+    }
+}
+
+#if DEBUG
+/// The headless capture hooks: `debug.keycommands` (the grid),
+/// `debug.keycommandsetup` (the list), `debug.keycommandcompose` (a fresh
+/// row's composer up).
+enum KeyCommandDebugMode: String, CaseIterable {
+    case commands
+    case setup
+    case compose
+
+    var hookName: String {
+        switch self {
+        case .commands: "keycommands"
+        case .setup: "keycommandsetup"
+        case .compose: "keycommandcompose"
+        }
+    }
+}
+
+extension KeyCommandPanelViewController {
+    func debugShow(_ mode: KeyCommandDebugMode) {
+        switch mode {
+        case .commands:
+            selectTab(.commands)
+        case .setup:
+            selectTab(.setup)
+        case .compose:
+            selectTab(.setup)
+            if expandedID == nil { addCommand() }
+        }
+    }
+}
+#endif
+
+/// Control geometry in this panel follows the type scale — the one place
+/// the chassis breaks its "geometry stays authored" rule. iOS-on-Mac paints
+/// the iPad grid at 77%; a 26-pt keycap holding a scaled glyph, a 26×14
+/// switch, and 25×23 arrows read as toy parts there (2026-08-16), so every
+/// dimension named here multiplies by `Theme.typeScale`, which is 1.0
+/// everywhere but the Mac. Widths that the popover itself owns (the two tab
+/// widths) stay authored.
+enum KeyCommandMetrics {
+    #if DEBUG
+    /// Tests pin the Mac's 1.3 without running on a Mac.
+    nonisolated(unsafe) static var scaleOverride: CGFloat?
+    nonisolated static var scale: CGFloat { scaleOverride ?? Theme.typeScale }
+    #else
+    nonisolated static var scale: CGFloat { Theme.typeScale }
+    #endif
+
+    nonisolated static func scaled(_ value: CGFloat) -> CGFloat { ceil(value * scale) }
+
+    /// Keycap sides (authored; the face view scales them).
+    nonisolated static let cellCap: CGFloat = 28
+    nonisolated static let rowCap: CGFloat = 24
+    nonisolated static let composerCap: CGFloat = 26
+    /// The stays-open dot on a cap's corner.
+    nonisolated static var pinDot: CGFloat { scaled(4) }
+    /// A COMMANDS cell's floor and a setup row header's floor.
+    nonisolated static var cellMinHeight: CGFloat { scaled(52) }
+    nonisolated static var rowHeaderMinHeight: CGFloat { scaled(30) }
+    /// The composer's eyebrow column and its TYPE pair.
+    nonisolated static var fieldLabelWidth: CGFloat { scaled(46) }
+    nonisolated static var typeRowWidth: CGFloat { scaled(128) }
+    /// The steppers' value box.
+    nonisolated static var stepperValueWidth: CGFloat { scaled(44) }
+    nonisolated static var stepperHeight: CGFloat { scaled(23) }
+    /// Both tabs' empty-state label.
+    nonisolated static var emptyStateHeight: CGFloat { scaled(64) }
+}
+
+// MARK: - Segment cell
+
+/// One cell of a two-way choice — the COMMANDS | CUSTOM SETUP tab pair and
+/// the composer's KEYS | TEXT — on the panel's press ground: bezelHi when
+/// selected, signal ink; chassis and signal3 otherwise.
+@MainActor
+final class KeyCommandSegmentCell: ShortcutPressControl {
+    private let label: UIKitChassisLabel
+    private let action: () -> Void
+    private var isSelectedCell: Bool
+
+    init(
+        title: String,
+        accessibilityLabel: String,
+        selected: Bool,
+        size: CGFloat = 9,
+        inset: CGFloat = 8,
+        action: @escaping () -> Void
+    ) {
+        self.action = action
+        isSelectedCell = selected
+        label = UIKitChassisLabel(
+            title,
+            size: size,
+            color: selected ? UIKitChassis.signal : UIKitChassis.signal3
+        )
+        super.init(frame: .zero)
+        self.accessibilityLabel = accessibilityLabel
+        if selected { accessibilityTraits.insert(.selected) }
+        label.textAlignment = .center
+        label.isUserInteractionEnabled = false
+        addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: inset),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -inset),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: inset),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -inset),
+        ])
+        addTarget(self, action: #selector(pressed), for: .touchUpInside)
+    }
+
+    func setSelected(_ selected: Bool) {
+        isSelectedCell = selected
+        label.setInk(selected ? UIKitChassis.signal : UIKitChassis.signal3)
+        if selected {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
+        refreshBackground()
+    }
+
+    override var restingBackgroundColor: UIColor {
+        isSelectedCell ? UIKitChassis.bezelHi : super.restingBackgroundColor
+    }
+
+    @objc private func pressed() { action() }
+}
+
+// MARK: - Keycap faces
+
+/// One keycap: chassis face, bezel hairline, the SF Symbol (or text) in
+/// `signal` ink; latched swaps to the rail's inverted face.
+@MainActor
+final class KeyCapFaceView: UIKitTallyBorderedView {
+    private let symbolView = UIImageView()
+    private let textLabel = UILabel()
+    private let pin = UIView()
+    private let side: CGFloat
+    private var face: KeyCapFace
+    private var isLatched = false
+
+    /// `side` is the authored size; the drawn face is `side × typeScale`.
+    init(face: KeyCapFace, side: CGFloat, showsPin: Bool = false) {
+        self.face = face
+        self.side = KeyCommandMetrics.scaled(side)
+        super.init(frame: .zero)
+        isAccessibilityElement = false
+        layer.cornerRadius = 3
+        layer.cornerCurve = .continuous
+        clipsToBounds = true
+        symbolView.contentMode = .center
+        symbolView.isUserInteractionEnabled = false
+        textLabel.textAlignment = .center
+        textLabel.numberOfLines = 1
+        textLabel.isUserInteractionEnabled = false
+        addSubview(symbolView)
+        addSubview(textLabel)
+        pin.backgroundColor = TallyPalette.customCommand
+        pin.layer.cornerRadius = KeyCommandMetrics.pinDot / 2
+        pin.isHidden = !showsPin
+        addSubview(pin)
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: self.side).isActive = true
+        widthAnchor.constraint(greaterThanOrEqualToConstant: self.side).isActive = true
+        apply(face: face)
+        refreshInk()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    func setLatched(_ latched: Bool) {
+        guard latched != isLatched else { return }
+        isLatched = latched
+        refreshInk()
+    }
+
+    func setFace(_ face: KeyCapFace) {
+        guard face != self.face else { return }
+        self.face = face
+        apply(face: face)
+        refreshInk()
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let width: CGFloat
+        if face.symbolName != nil {
+            width = side
+        } else {
+            let text = textLabel.intrinsicContentSize.width
+            width = max(side, ceil(text) + 12)
+        }
+        return CGSize(width: width, height: side)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        symbolView.frame = bounds
+        textLabel.frame = bounds.insetBy(dx: 5, dy: 0)
+        let dot = KeyCommandMetrics.pinDot
+        pin.frame = CGRect(x: bounds.maxX - dot - 2, y: bounds.maxY - dot - 2, width: dot, height: dot)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        refreshInk()
+    }
+
+    private func apply(face: KeyCapFace) {
+        // `side` already carries the scale; the fonts below are raw sizes so
+        // the glyph keeps its ratio to the face instead of scaling twice.
+        if let symbolName = face.symbolName,
+           let image = UIImage(
+               systemName: symbolName,
+               withConfiguration: UIImage.SymbolConfiguration(
+                   pointSize: side * 0.46,
+                   weight: .semibold
+               )
+           ) {
+            symbolView.image = image
+            symbolView.isHidden = false
+            textLabel.isHidden = true
+        } else {
+            symbolView.isHidden = true
+            textLabel.isHidden = false
+            let mono = face.text.count <= 2
+            textLabel.font = mono
+                ? .monospacedSystemFont(ofSize: side * 0.44, weight: .semibold)
+                : .monospacedSystemFont(ofSize: side * 0.38, weight: .medium)
+            textLabel.text = face.text
+        }
+        invalidateIntrinsicContentSize()
+    }
+
+    private func refreshInk() {
+        let ink = isLatched ? UIKitChassis.chassis : UIKitChassis.signal
+        symbolView.tintColor = ink
+        textLabel.textColor = ink
+        backgroundColor = isLatched
+            ? UIKitChassis.signal2
+            : (GlassPrototype.enabled
+                ? GlassPrototype.material(GlassPrototype.strataMaterial, fallback: TallyPalette.chassis)
+                : UIKitChassis.chassis)
+        tallyBorderColor = isLatched ? UIKitChassis.signal2 : UIKitChassis.bezelHi
+    }
+}
+
+/// A row of keycap faces with the ↵ and ×N marks — the chord as the grid
+/// and the rows draw it. Re-rendering with the same faces and marks is a
+/// no-op, so a composer keystroke never rebuilds the caps.
+@MainActor
+final class KeyChordFacesView: UIView {
+    private struct Signature: Equatable {
+        var faces: [KeyCapFace]
+        var pinned: Bool
+        var submits: Bool
+        var repeats: Int
+    }
+
+    private let stack = UIStackView()
+    private var signature: Signature?
+
+    init(command: KeyCommand, side: CGFloat) {
+        super.init(frame: .zero)
+        isAccessibilityElement = false
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 4
+        stack.isUserInteractionEnabled = false
+        addSubview(stack)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        render(command: command, side: side)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    func render(command: KeyCommand, side: CGFloat) {
+        let next = Signature(
+            faces: command.faces,
+            pinned: !command.closesPanel,
+            submits: command.textSnippet?.submits == true,
+            repeats: command.repeatCount
+        )
+        guard next != signature else { return }
+        signature = next
+        for view in stack.arrangedSubviews {
+            stack.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        for (index, face) in next.faces.enumerated() {
+            stack.addArrangedSubview(KeyCapFaceView(
+                face: face,
+                side: side,
+                showsPin: index == next.faces.count - 1 && next.pinned
+            ))
+        }
+        if next.submits {
+            stack.addArrangedSubview(UIKitChassisMonoLabel(
+                "↵",
+                font: UIKitChassis.uiFont(side * 0.42, weight: .medium),
+                color: UIKitChassis.signal2
+            ))
+        }
+        if next.repeats > 1 {
+            stack.addArrangedSubview(UIKitChassisMonoLabel(
+                "×\(next.repeats)",
+                font: UIKitChassis.monoFont(9, weight: .semibold),
+                color: UIKitChassis.signal2,
+                kern: 0.4
+            ))
+        }
+    }
+}
+
+// MARK: - COMMANDS cell
+
+@MainActor
+final class KeyCommandCell: ShortcutPressControl {
+    private let press: () -> Void
+    private let hold: () -> Void
+    private var didHold = false
+
+    init(command: KeyCommand, press: @escaping () -> Void, hold: @escaping () -> Void) {
+        self.press = press
+        self.hold = hold
+        super.init(frame: .zero)
+        accessibilityIdentifier = "keyCommands.cell.\(command.id.uuidString)"
+        accessibilityLabel = command.readout(.spoken)
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(
+            greaterThanOrEqualToConstant: KeyCommandMetrics.cellMinHeight
+        ).isActive = true
+
+        let faces = KeyChordFacesView(command: command, side: KeyCommandMetrics.cellCap)
+        faces.setContentHuggingPriority(.required, for: .horizontal)
+        faces.setContentCompressionResistancePriority(.required, for: .horizontal)
+        let name = UIKitChassisLabel(
+            command.name,
+            size: 10,
+            color: command.isShipped ? UIKitChassis.signal : TallyPalette.customCommand
+        )
+        let hintText = command.readout(.cellHint)
+        let hint = UIKitChassisMonoLabel(
+            hintText,
+            font: UIKitChassis.monoFont(8),
+            color: UIKitChassis.signal2
+        )
+        hint.lineBreakMode = .byTruncatingTail
+        hint.isHidden = hintText.isEmpty
+        let labels = UIStackView(arrangedSubviews: [name, hint])
+        labels.axis = .vertical
+        labels.alignment = .leading
+        labels.spacing = 3
+        labels.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let row = UIStackView(arrangedSubviews: [faces, labels])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 10
+        row.isUserInteractionEnabled = false
+        addSubview(row)
+        row.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            row.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
+            row.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 8),
+            row.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -8),
+            row.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
+        addTarget(self, action: #selector(touchDown), for: .touchDown)
+        addTarget(self, action: #selector(released), for: .touchUpInside)
+        let recognizer = UILongPressGestureRecognizer(target: self, action: #selector(held(_:)))
+        recognizer.minimumPressDuration = KeyCommandPanelViewController.cellHoldDuration
+        recognizer.cancelsTouchesInView = false
+        addGestureRecognizer(recognizer)
+    }
+
+    override func accessibilityActivate() -> Bool {
+        press()
+        return true
+    }
+
+    @objc private func touchDown() {
+        didHold = false
+    }
+
+    @objc private func released() {
+        guard !didHold else { return }
+        press()
+    }
+
+    @objc private func held(_ recognizer: UILongPressGestureRecognizer) {
+        guard recognizer.state == .began else { return }
+        didHold = true
+        isHighlighted = false
+        hold()
+    }
+}
+
+// MARK: - CUSTOM SETUP row
+
+@MainActor
+final class KeyCommandRowView: UIView {
+    private let toggle: (UUID) -> Void
+    private let changed: (KeyCommand) -> Void
+    private let layoutChanged: () -> Void
+    private weak var terminal: TerminalView?
+    private(set) var command: KeyCommand
+    private let expanded: Bool
+    private let compact: Bool
+
+    private let indexLabel = UIKitChassisMonoLabel(
+        "",
+        font: UIKitChassis.monoFont(9, weight: .semibold),
+        color: UIKitChassis.signal3
+    )
+    private let facesView: KeyChordFacesView
+    private let nameLabel: UIKitChassisLabel
+    private let readoutLabel = UIKitChassisMonoLabel(
+        "",
+        font: UIKitChassis.monoFont(8, weight: .medium),
+        color: UIKitChassis.signal2,
+        kern: 0.4
+    )
+    private let headerControl = KeyCommandRowHeaderControl()
+    private var actions: TallyEditorRowActions.Trio?
+    private var composer: KeyCommandComposerView?
+
+    init(
+        command: KeyCommand,
+        index: Int,
+        count: Int,
+        expanded: Bool,
+        compact: Bool = false,
+        terminal: TerminalView?,
+        toggle: @escaping (UUID) -> Void,
+        move: @escaping (UUID, Int) -> Void,
+        delete: @escaping (UUID) -> Void,
+        changed: @escaping (KeyCommand) -> Void,
+        layoutChanged: @escaping () -> Void
+    ) {
+        self.command = command
+        self.expanded = expanded
+        self.compact = compact
+        self.terminal = terminal
+        self.toggle = toggle
+        self.changed = changed
+        self.layoutChanged = layoutChanged
+        facesView = KeyChordFacesView(command: command, side: KeyCommandMetrics.rowCap)
+        nameLabel = UIKitChassisLabel(command.name, size: 10)
+        super.init(frame: .zero)
+        backgroundColor = GlassPrototype.clearedChassis
+        accessibilityIdentifier = "keyCommands.row.\(command.id.uuidString)"
+
+        indexLabel.setContentHuggingPriority(.required, for: .horizontal)
+        indexLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        indexLabel.translatesAutoresizingMaskIntoConstraints = false
+        indexLabel.widthAnchor.constraint(equalToConstant: 18).isActive = true
+        facesView.setContentHuggingPriority(.required, for: .horizontal)
+        facesView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        // The readout is the row's secondary line: at phone width it
+        // truncates before the name does.
+        nameLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        readoutLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        readoutLabel.lineBreakMode = .byTruncatingTail
+
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        let rowID = command.id
+        let trio = TallyEditorRowActions.make(
+            index: index,
+            count: count,
+            identifierPrefix: "keyCommands",
+            rowID: rowID,
+            scale: KeyCommandMetrics.scale,
+            move: { offset in move(rowID, offset) },
+            delete: { delete(rowID) }
+        )
+        actions = trio
+
+        let headerContent = UIStackView(arrangedSubviews: [
+            indexLabel, facesView, nameLabel, readoutLabel, spacer,
+        ])
+        headerContent.axis = .horizontal
+        headerContent.alignment = .center
+        headerContent.spacing = 10
+        headerContent.isUserInteractionEnabled = false
+        headerControl.addSubview(headerContent)
+        headerContent.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            headerContent.leadingAnchor.constraint(equalTo: headerControl.leadingAnchor),
+            headerContent.trailingAnchor.constraint(equalTo: headerControl.trailingAnchor),
+            headerContent.topAnchor.constraint(equalTo: headerControl.topAnchor),
+            headerContent.bottomAnchor.constraint(equalTo: headerControl.bottomAnchor),
+            headerControl.heightAnchor.constraint(
+                greaterThanOrEqualToConstant: KeyCommandMetrics.rowHeaderMinHeight
+            ),
+        ])
+        headerControl.accessibilityIdentifier = "keyCommands.rowHeader.\(command.id.uuidString)"
+        headerControl.accessibilityLabel = expanded
+            ? "\(command.name), editing"
+            : "\(command.name), edit"
+        headerControl.addTarget(self, action: #selector(headerPressed), for: .touchUpInside)
+
+        let headerLine = UIStackView(arrangedSubviews: [headerControl, trio.stack])
+        headerLine.axis = .horizontal
+        headerLine.alignment = .center
+        headerLine.spacing = 10
+
+        let content = UIStackView(arrangedSubviews: [headerLine])
+        content.axis = .vertical
+        content.alignment = .fill
+        content.spacing = 10
+        if expanded {
+            let composer = KeyCommandComposerView(
+                command: command,
+                terminal: terminal,
+                compact: compact,
+                changed: { [weak self] command in
+                    guard let self else { return }
+                    self.command = command
+                    changed(command)
+                },
+                layoutChanged: layoutChanged
+            )
+            self.composer = composer
+            content.addArrangedSubview(composer)
+        }
+        addSubview(content)
+        content.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            content.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            content.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            content.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            content.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+        ])
+        if expanded {
+            layer.borderWidth = 1
+            layer.borderColor = UIKitChassis.signal2.resolvedColor(with: traitCollection).cgColor
+        }
+        render(command: command, index: index, count: count)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    /// Re-read the model into the header line — the composer below is the
+    /// writer, so it is never rebuilt here.
+    func render(command: KeyCommand, index: Int, count: Int) {
+        self.command = command
+        indexLabel.setText(String(format: "%02d", index + 1))
+        facesView.render(command: command, side: KeyCommandMetrics.rowCap)
+        nameLabel.setText(command.name)
+        nameLabel.setInk(command.isShipped ? UIKitChassis.signal : TallyPalette.customCommand)
+        readoutLabel.setText(
+            command.readout,
+            ink: command.closesPanel ? UIKitChassis.signal2 : TallyPalette.customCommand
+        )
+        actions?.up.isEnabled = index > 0
+        actions?.down.isEnabled = index < count - 1
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard expanded,
+              traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        layer.borderColor = UIKitChassis.signal2.resolvedColor(with: traitCollection).cgColor
+    }
+
+    @objc private func headerPressed() {
+        toggle(command.id)
+    }
+}
+
+/// The row header's press target — everything left of the ↑ ↓ 🗑 group.
+@MainActor
+private final class KeyCommandRowHeaderControl: UIControl {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    override func accessibilityActivate() -> Bool {
+        sendActions(for: .touchUpInside)
+        return true
+    }
+}
+
+// MARK: - Composer
+
+/// The inline editor under an expanded row. Owns a draft copy of the
+/// command; every control writes the draft, clamps the repeat under the
+/// guard, refreshes the readouts, and hands the command up by ID.
+@MainActor
+final class KeyCommandComposerView: UIView, UITextFieldDelegate {
+    private var command: KeyCommand
+    private weak var terminal: TerminalView?
+    private let compact: Bool
+    private let changed: (KeyCommand) -> Void
+    private let layoutChanged: () -> Void
+
+    private var keysTypeCell: KeyCommandSegmentCell?
+    private var textTypeCell: KeyCommandSegmentCell?
+    private var modifierCaps: [KeyChord.Modifiers: KeyCapControl] = [:]
+    private var keyCaps: [KeyChord.Key: KeyCapControl] = [:]
+    private let characterField = KeyCommandTextField()
+    private let textField = KeyCommandTextField()
+    private var submitSwitch: TallyEditorSwitch?
+    private var countStepper: KeyCommandStepper?
+    private var gapStepper: KeyCommandStepper?
+    private let burstLabel = UIKitChassisMonoLabel(
+        "",
+        font: UIKitChassis.monoFont(8.5, weight: .medium),
+        color: UIKitChassis.signal3,
+        kern: 0.4
+    )
+    private let sendsLabel = UIKitChassisMonoLabel(
+        "",
+        font: UIKitChassis.monoFont(8.5, weight: .medium),
+        color: UIKitChassis.signal2,
+        kern: 0.4
+    )
+    private let keysBlock = UIStackView()
+    private let textBlock = UIStackView()
+
+    init(
+        command: KeyCommand,
+        terminal: TerminalView?,
+        compact: Bool = false,
+        changed: @escaping (KeyCommand) -> Void,
+        layoutChanged: @escaping () -> Void
+    ) {
+        self.command = command
+        self.terminal = terminal
+        self.compact = compact
+        self.changed = changed
+        self.layoutChanged = layoutChanged
+        super.init(frame: .zero)
+        accessibilityIdentifier = "keyCommands.composer"
+        build()
+        refreshFromCommand()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    // MARK: Testable writes
+
+    func setKind(isText: Bool) {
+        switch (command.kind, isText) {
+        case (.chord, true):
+            command.kind = .text(KeyTextSnippet(text: textField.text ?? "", submits: true))
+        case (.text, false):
+            command.kind = .chord(KeyChord(key: .enter))
+        default:
+            return
+        }
+        commit(relayout: true)
+    }
+
+    func toggleModifier(_ modifier: KeyChord.Modifiers) {
+        guard case .chord(var chord) = command.kind else { return }
+        if chord.modifiers.contains(modifier) {
+            chord.modifiers.remove(modifier)
+        } else {
+            chord.modifiers.insert(modifier)
+        }
+        command.kind = .chord(chord)
+        commit()
+    }
+
+    func selectKey(_ key: KeyChord.Key) {
+        guard case .chord(var chord) = command.kind else { return }
+        chord.key = key
+        command.kind = .chord(chord)
+        if case .character = key {} else { characterField.text = "" }
+        commit()
+    }
+
+    func setText(_ text: String) {
+        guard case .text(var snippet) = command.kind else { return }
+        snippet.text = text
+        command.kind = .text(snippet)
+        commit()
+    }
+
+    func setSubmits(_ submits: Bool) {
+        guard case .text(var snippet) = command.kind else { return }
+        snippet.submits = submits
+        command.kind = .text(snippet)
+        commit()
+    }
+
+    func setRepeatCount(_ count: Int) {
+        command.repeatCount = count
+        commit()
+    }
+
+    func setRepeatGap(_ gap: Int) {
+        command.repeatGapMilliseconds = gap
+        commit()
+    }
+
+    func setClosesPanel(_ closes: Bool) {
+        command.closesPanel = closes
+        commit()
+    }
+
+    // MARK: Construction
+
+    private func build() {
+        let lines = UIStackView()
+        lines.axis = .vertical
+        lines.alignment = .fill
+        lines.spacing = 10
+        addSubview(lines)
+        lines.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            lines.leadingAnchor.constraint(equalTo: leadingAnchor),
+            lines.trailingAnchor.constraint(equalTo: trailingAnchor),
+            lines.topAnchor.constraint(equalTo: topAnchor),
+            lines.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        // TYPE
+        let keysCell = KeyCommandSegmentCell(
+            title: "KEYS", accessibilityLabel: "Keys", selected: true, size: 8, inset: 6
+        ) { [weak self] in self?.setKind(isText: false) }
+        keysCell.accessibilityIdentifier = "keyCommands.composer.type.keys"
+        let textCell = KeyCommandSegmentCell(
+            title: "TEXT", accessibilityLabel: "Text", selected: false, size: 8, inset: 6
+        ) { [weak self] in self?.setKind(isText: true) }
+        textCell.accessibilityIdentifier = "keyCommands.composer.type.text"
+        keysTypeCell = keysCell
+        textTypeCell = textCell
+        let typeRow = TallyHairlineGrid.row([keysCell, textCell])
+        typeRow.translatesAutoresizingMaskIntoConstraints = false
+        typeRow.widthAnchor.constraint(equalToConstant: KeyCommandMetrics.typeRowWidth).isActive = true
+        typeRow.layer.borderWidth = 1
+        typeRow.layer.borderColor = UIKitChassis.bezelHi.resolvedColor(with: traitCollection).cgColor
+        lines.addArrangedSubview(field("TYPE", typeRow))
+
+        // KEYS
+        keysBlock.axis = .vertical
+        keysBlock.alignment = .fill
+        keysBlock.spacing = 10
+        let modifiers = UIStackView()
+        modifiers.axis = .horizontal
+        modifiers.alignment = .center
+        modifiers.spacing = 4
+        for modifier in KeyChord.Modifiers.ordered {
+            let cap = KeyCapControl(
+                face: modifier.face,
+                side: KeyCommandMetrics.composerCap,
+                accessibilityLabel: modifier.accessibilityWord
+            ) { [weak self] in
+                self?.toggleModifier(modifier)
+            }
+            cap.accessibilityIdentifier = "keyCommands.composer.modifier.\(modifier.word.lowercased())"
+            modifierCaps[modifier] = cap
+            modifiers.addArrangedSubview(cap)
+        }
+        let plus = UIKitChassisMonoLabel(
+            "+",
+            font: UIKitChassis.monoFont(12),
+            color: UIKitChassis.signal3
+        )
+        func makeCap(_ key: KeyChord.Key) -> KeyCapControl {
+            let cap = KeyCapControl(
+                face: key.face,
+                side: KeyCommandMetrics.composerCap,
+                accessibilityLabel: key.accessibilityWord
+            ) { [weak self] in
+                self?.selectKey(key)
+            }
+            cap.accessibilityIdentifier = "keyCommands.composer.key.\(key.word.lowercased())"
+            keyCaps[key] = cap
+            return cap
+        }
+        func keyRow(_ caps: [UIView]) -> UIStackView {
+            let row = UIStackView(arrangedSubviews: caps)
+            row.axis = .horizontal
+            row.alignment = .center
+            row.spacing = 4
+            return row
+        }
+        characterField.configure(placeholder: "A", width: 30, monoSize: 12, height: KeyCommandMetrics.composerCap)
+        characterField.accessibilityLabel = "Letter or digit"
+        characterField.accessibilityIdentifier = "keyCommands.composer.character"
+        characterField.delegate = self
+        characterField.addTarget(self, action: #selector(characterEdited), for: .editingChanged)
+        let editingCaps = KeyChord.Key.composerEditingSet.map(makeCap)
+        let arrowCaps = KeyChord.Key.composerArrowSet.map(makeCap)
+        if compact {
+            // A phone popover: modifiers + the editing keys on the KEYS line;
+            // the direction keys and the letter field hang under the editing
+            // keys, flush with their right edge, so the two key lines read as
+            // one block beside the modifiers.
+            let editingRow = keyRow(editingCaps)
+            let firstLine = UIStackView(arrangedSubviews: [modifiers, plus, editingRow])
+            firstLine.axis = .horizontal
+            firstLine.alignment = .center
+            firstLine.spacing = 8
+            keysBlock.addArrangedSubview(field("KEYS", firstLine))
+            let secondLine = UIView()
+            let secondRow = keyRow(arrowCaps + [characterField])
+            secondRow.translatesAutoresizingMaskIntoConstraints = false
+            secondLine.addSubview(secondRow)
+            keysBlock.addArrangedSubview(secondLine)
+            NSLayoutConstraint.activate([
+                secondRow.topAnchor.constraint(equalTo: secondLine.topAnchor),
+                secondRow.bottomAnchor.constraint(equalTo: secondLine.bottomAnchor),
+                secondRow.trailingAnchor.constraint(equalTo: editingRow.trailingAnchor),
+                secondRow.leadingAnchor.constraint(greaterThanOrEqualTo: secondLine.leadingAnchor),
+            ])
+        } else {
+            let keysLine = UIStackView(arrangedSubviews: [
+                modifiers, plus, keyRow(editingCaps + arrowCaps + [characterField]),
+            ])
+            keysLine.axis = .horizontal
+            keysLine.alignment = .center
+            keysLine.spacing = 8
+            keysBlock.addArrangedSubview(field("KEYS", keysLine))
+        }
+        lines.addArrangedSubview(keysBlock)
+
+        // TEXT
+        textBlock.axis = .vertical
+        textBlock.alignment = .fill
+        textBlock.spacing = 10
+        textField.configure(
+            placeholder: "One line, typed as-is",
+            width: 220,
+            monoSize: 11,
+            height: KeyCommandMetrics.composerCap
+        )
+        textField.accessibilityLabel = "Text to type"
+        textField.accessibilityIdentifier = "keyCommands.composer.text"
+        textField.delegate = self
+        textField.addTarget(self, action: #selector(textEdited), for: .editingChanged)
+        textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        let submit = TallyEditorSwitch(
+            label: "SUBMIT",
+            accessibilityLabel: "Submit with Enter",
+            isOn: command.textSnippet?.submits ?? true,
+            identifierPrefix: "keyCommands",
+            scale: KeyCommandMetrics.scale
+        ) { [weak self] value in self?.setSubmits(value) }
+        submitSwitch = submit
+        let textLine = UIStackView(arrangedSubviews: [textField, submit])
+        textLine.axis = .horizontal
+        textLine.alignment = .center
+        textLine.spacing = 10
+        textBlock.addArrangedSubview(field("TEXT", textLine, stretch: true))
+        lines.addArrangedSubview(textBlock)
+
+        // REPEAT
+        let count = KeyCommandStepper(
+            value: command.repeatCount,
+            range: 1...KeyCommandRepeatGuard.maximumCount,
+            step: 1,
+            format: { "×\($0)" },
+            accessibilityLabel: "Repeat count",
+            changed: { [weak self] value in self?.setRepeatCount(value) }
+        )
+        count.accessibilityIdentifier = "keyCommands.composer.count"
+        countStepper = count
+        let every = UIKitChassisMonoLabel(
+            "EVERY",
+            font: UIKitChassis.monoFont(8.5, weight: .medium),
+            color: UIKitChassis.signal3,
+            kern: 0.6
+        )
+        let gap = KeyCommandStepper(
+            value: command.repeatGapMilliseconds,
+            range: KeyCommandRepeatGuard.gapRange,
+            step: KeyCommandRepeatGuard.gapStep,
+            format: { "\($0) MS" },
+            accessibilityLabel: "Gap between sends",
+            changed: { [weak self] value in self?.setRepeatGap(value) }
+        )
+        gap.accessibilityIdentifier = "keyCommands.composer.gap"
+        gapStepper = gap
+        burstLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        burstLabel.lineBreakMode = .byTruncatingTail
+        if compact {
+            let steppers = UIStackView(arrangedSubviews: [count, every, gap])
+            steppers.axis = .horizontal
+            steppers.alignment = .center
+            steppers.spacing = 8
+            lines.addArrangedSubview(field("REPEAT", steppers))
+            lines.addArrangedSubview(field("", burstLabel, stretch: true))
+        } else {
+            let repeatLine = UIStackView(arrangedSubviews: [count, every, gap, burstLabel])
+            repeatLine.axis = .horizontal
+            repeatLine.alignment = .center
+            repeatLine.spacing = 8
+            lines.addArrangedSubview(field("REPEAT", repeatLine))
+        }
+
+        // PANEL
+        let closes = TallyEditorSwitch(
+            label: "CLOSE ON PRESS",
+            accessibilityLabel: "Close the panel on press",
+            isOn: command.closesPanel,
+            identifierPrefix: "keyCommands",
+            scale: KeyCommandMetrics.scale
+        ) { [weak self] value in self?.setClosesPanel(value) }
+        lines.addArrangedSubview(field("PANEL", closes))
+
+        // SENDS
+        sendsLabel.numberOfLines = 2
+        sendsLabel.lineBreakMode = .byTruncatingTail
+        sendsLabel.accessibilityIdentifier = "keyCommands.composer.sends"
+        lines.addArrangedSubview(field("SENDS", sendsLabel, stretch: true))
+    }
+
+    /// One eyebrow'd line. The content keeps its own width — a trailing
+    /// spacer takes the slack, or a horizontal stack would stretch the
+    /// content's first keycap across the row — unless `stretch` says the
+    /// content (a wrapping readout) should fill.
+    private func field(_ title: String, _ content: UIView, stretch: Bool = false) -> UIView {
+        let label = UIKitChassisLabel(title, size: 8, color: UIKitChassis.signal2)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.widthAnchor.constraint(equalToConstant: KeyCommandMetrics.fieldLabelWidth).isActive = true
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        var views = [label, content]
+        if !stretch {
+            content.setContentHuggingPriority(.required, for: .horizontal)
+            let spacer = UIView()
+            spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            views.append(spacer)
+        }
+        let row = UIStackView(arrangedSubviews: views)
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 8
+        return row
+    }
+
+    // MARK: State → controls
+
+    private func commit(relayout: Bool = false) {
+        let clamped = KeyCommandRepeatGuard.clamp(
+            count: command.repeatCount,
+            gapMilliseconds: command.repeatGapMilliseconds
+        )
+        command.repeatCount = clamped.count
+        command.repeatGapMilliseconds = clamped.gapMilliseconds
+        refreshFromCommand(clamped: clamped.wasClamped)
+        changed(command)
+        if relayout { layoutChanged() }
+    }
+
+    private func refreshFromCommand(clamped: Bool = false) {
+        let isText: Bool
+        switch command.kind {
+        case .chord(let chord):
+            isText = false
+            for (modifier, cap) in modifierCaps {
+                cap.setLatched(chord.modifiers.contains(modifier))
+            }
+            for (key, cap) in keyCaps {
+                cap.setLatched(key == chord.key)
+            }
+            if case .character(let character) = chord.key {
+                if characterField.text != character.uppercased() {
+                    characterField.text = character.uppercased()
+                }
+                characterField.setActive(true)
+            } else {
+                characterField.setActive(false)
+            }
+        case .text(let snippet):
+            isText = true
+            if textField.text != snippet.text { textField.text = snippet.text }
+            submitSwitch?.setOn(snippet.submits)
+        }
+        keysBlock.isHidden = isText
+        textBlock.isHidden = !isText
+        keysTypeCell?.setSelected(!isText)
+        textTypeCell?.setSelected(isText)
+
+        countStepper?.setValue(command.repeatCount)
+        gapStepper?.setValue(command.repeatGapMilliseconds)
+        gapStepper?.setEnabled(command.isRepeating)
+        let burst = KeyCommandRepeatGuard.burstMilliseconds(
+            count: command.repeatCount,
+            gapMilliseconds: command.repeatGapMilliseconds
+        )
+        let seconds = String(format: "%.2f", Double(burst) / 1000)
+        burstLabel.setText(
+            "BURST \(seconds) S · LIMIT \(KeyCommandRepeatGuard.burstLimitMilliseconds / 1000) S"
+                + (clamped ? " · CLAMPED" : ""),
+            ink: clamped ? TallyPalette.caution : UIKitChassis.signal3
+        )
+        sendsLabel.setText(KeyCommandDispatcher.describe(command, on: terminal))
+    }
+
+    // MARK: Fields
+
+    @objc private func characterEdited() {
+        guard case .chord(var chord) = command.kind else { return }
+        let text = characterField.text ?? ""
+        if let key = KeyChord.Key.fromFieldText(text) {
+            chord.key = key
+            characterField.text = text.uppercased()
+            command.kind = .chord(chord)
+            commit()
+        } else if text.isEmpty, case .character = chord.key {
+            chord.key = .enter
+            command.kind = .chord(chord)
+            commit()
+        }
+    }
+
+    @objc private func textEdited() {
+        setText(textField.text ?? "")
+    }
+
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        guard textField === characterField else {
+            return !string.contains(where: { $0.isNewline })
+        }
+        // One printable character replaces whatever was there.
+        if string.isEmpty { return true }
+        guard KeyChord.Key.fromFieldText(string) != nil else { return false }
+        textField.text = string.uppercased()
+        textField.sendActions(for: .editingChanged)
+        return false
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return false
+    }
+}
+
+/// A keycap that presses: latching modifiers, single-select keys.
+@MainActor
+final class KeyCapControl: UIControl {
+    private let face: KeyCapFaceView
+    private let action: () -> Void
+
+    init(face: KeyCapFace, side: CGFloat, accessibilityLabel: String, action: @escaping () -> Void) {
+        self.face = KeyCapFaceView(face: face, side: side)
+        self.action = action
+        super.init(frame: .zero)
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        self.accessibilityLabel = accessibilityLabel
+        hoverStyle = UIHoverStyle(effect: .highlight, shape: .rect(cornerRadius: 2))
+        self.face.isUserInteractionEnabled = false
+        addSubview(self.face)
+        self.face.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.face.leadingAnchor.constraint(equalTo: leadingAnchor),
+            self.face.trailingAnchor.constraint(equalTo: trailingAnchor),
+            self.face.topAnchor.constraint(equalTo: topAnchor),
+            self.face.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        addTarget(self, action: #selector(pressed), for: .touchUpInside)
+        addTarget(self, action: #selector(touchDown), for: .touchDown)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    func setLatched(_ latched: Bool) {
+        face.setLatched(latched)
+        if latched {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
+    }
+
+    override func accessibilityActivate() -> Bool {
+        action()
+        return true
+    }
+
+    @objc private func touchDown() {
+        TerminalKeyHaptics.keyPress(on: self)
+    }
+
+    @objc private func pressed() { action() }
+}
+
+/// − value + : the composer's count and gap.
+@MainActor
+final class KeyCommandStepper: UIView {
+    private(set) var value: Int
+    private let range: ClosedRange<Int>
+    private let step: Int
+    private let format: (Int) -> String
+    private let changed: (Int) -> Void
+    private var minus: TallyEditorRowActionButton!
+    private var plus: TallyEditorRowActionButton!
+    private let valueLabel = UIKitChassisMonoLabel(
+        "",
+        font: UIKitChassis.monoFont(9.5, weight: .semibold),
+        color: UIKitChassis.signal
+    )
+    private var enabled = true
+
+    init(
+        value: Int,
+        range: ClosedRange<Int>,
+        step: Int,
+        format: @escaping (Int) -> String,
+        accessibilityLabel: String,
+        changed: @escaping (Int) -> Void
+    ) {
+        self.value = value
+        self.range = range
+        self.step = step
+        self.format = format
+        self.changed = changed
+        super.init(frame: .zero)
+        minus = TallyEditorRowActionButton(
+            systemImage: "minus",
+            accessibilityLabel: "\(accessibilityLabel), less",
+            enabled: true,
+            scale: KeyCommandMetrics.scale,
+            action: { [weak self] in self?.adjust(-1) }
+        )
+        plus = TallyEditorRowActionButton(
+            systemImage: "plus",
+            accessibilityLabel: "\(accessibilityLabel), more",
+            enabled: true,
+            scale: KeyCommandMetrics.scale,
+            action: { [weak self] in self?.adjust(1) }
+        )
+        isAccessibilityElement = false
+        valueLabel.textAlignment = .center
+        valueLabel.backgroundColor = UIKitChassis.screen
+        valueLabel.isAccessibilityElement = true
+        valueLabel.accessibilityLabel = accessibilityLabel
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.widthAnchor.constraint(
+            greaterThanOrEqualToConstant: KeyCommandMetrics.stepperValueWidth
+        ).isActive = true
+        valueLabel.heightAnchor.constraint(equalToConstant: KeyCommandMetrics.stepperHeight).isActive = true
+        let row = UIStackView(arrangedSubviews: [minus, valueLabel, plus])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 1
+        row.backgroundColor = UIKitChassis.bezelHi
+        addSubview(row)
+        row.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: trailingAnchor),
+            row.topAnchor.constraint(equalTo: topAnchor),
+            row.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        setContentHuggingPriority(.required, for: .horizontal)
+        setContentCompressionResistancePriority(.required, for: .horizontal)
+        render()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    func setValue(_ value: Int) {
+        guard value != self.value else { return }
+        self.value = value
+        render()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard enabled != self.enabled else { return }
+        self.enabled = enabled
+        render()
+    }
+
+    private func adjust(_ direction: Int) {
+        let next = min(max(range.lowerBound, value + direction * step), range.upperBound)
+        guard next != value else { return }
+        value = next
+        render()
+        changed(next)
+    }
+
+    private func render() {
+        valueLabel.setText(format(value), ink: enabled ? UIKitChassis.signal : UIKitChassis.signal3)
+        valueLabel.accessibilityValue = format(value)
+        minus.isEnabled = enabled && value > range.lowerBound
+        plus.isEnabled = enabled && value < range.upperBound
+        minus.tintColor = minus.isEnabled ? UIKitChassis.signal2 : UIKitChassis.signal3
+        plus.tintColor = plus.isEnabled ? UIKitChassis.signal2 : UIKitChassis.signal3
+    }
+}
+
+/// A one-line mono field on the screen ground with the bezel hairline.
+@MainActor
+final class KeyCommandTextField: UITextField {
+    func configure(placeholder: String, width: CGFloat, monoSize: CGFloat, height: CGFloat = 26) {
+        font = UIKitChassis.monoFont(monoSize)
+        textColor = UIKitChassis.signal
+        tintColor = UIKitChassis.signal
+        backgroundColor = UIKitChassis.screen
+        attributedPlaceholder = NSAttributedString(
+            string: placeholder,
+            attributes: [
+                .font: UIKitChassis.monoFont(monoSize),
+                .foregroundColor: UIKitChassis.signal3,
+            ]
+        )
+        autocorrectionType = .no
+        autocapitalizationType = .none
+        smartDashesType = .no
+        smartQuotesType = .no
+        smartInsertDeleteType = .no
+        spellCheckingType = .no
+        returnKeyType = .done
+        layer.borderWidth = 1
+        layer.borderColor = UIKitChassis.bezelHi.resolvedColor(with: traitCollection).cgColor
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: KeyCommandMetrics.scaled(height)).isActive = true
+        widthAnchor.constraint(
+            greaterThanOrEqualToConstant: KeyCommandMetrics.scaled(width)
+        ).isActive = true
+    }
+
+    /// The character field reads as the chord's key while a character is
+    /// selected: signal border; otherwise the resting hairline.
+    func setActive(_ active: Bool) {
+        layer.borderColor = (active ? UIKitChassis.signal2 : UIKitChassis.bezelHi)
+            .resolvedColor(with: traitCollection).cgColor
+    }
+
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.insetBy(dx: 6, dy: 0)
+    }
+
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.insetBy(dx: 6, dy: 0)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        layer.borderColor = UIKitChassis.bezelHi.resolvedColor(with: traitCollection).cgColor
+    }
+}

--- a/Multiplex/Views/Terminal/KeyCommandPanelPresenter.swift
+++ b/Multiplex/Views/Terminal/KeyCommandPanelPresenter.swift
@@ -1,0 +1,135 @@
+import SwiftTerm
+import UIKit
+
+/// What the plan lets CUSTOM SETUP hold — the free tier's cap and the route
+/// past it. The window that owns the entitlement store builds it; the iPad
+/// rail and the visionOS cluster only carry it to the presenter, so neither
+/// learns about Pro.
+struct KeyCommandPlan {
+    /// Commands the set may hold before ADD COMMAND turns into the Pro
+    /// route (`KeyCommandSet.maximumCount` once Pro).
+    var limit: Int
+    /// Opens the paywall; nil when the plan already holds the full cap.
+    var upgrade: (() -> Void)?
+
+    /// The full cap and no route — Pro, tests, and the DEBUG hooks.
+    static let unrestricted = KeyCommandPlan(limit: KeyCommandSet.maximumCount, upgrade: nil)
+}
+
+/// The one owner of a KEY COMMANDS popover's lifecycle, shared by the iPad
+/// rail (`TerminalKeyBar`) and the visionOS cluster
+/// (`TerminalKeyClusterGroupView`): builds the panel over the shared store,
+/// dispatches presses through the terminal, anchors the popover to the CTRL
+/// key, and hands the keyboard back on dismissal only if one of the panel's
+/// own fields took it. The hosts keep just their anchor, their terminal, and
+/// their appearance step.
+@MainActor
+final class KeyCommandPanelPresenter: NSObject, UIPopoverPresentationControllerDelegate {
+    private(set) weak var panel: KeyCommandPanelViewController?
+    private weak var terminal: TerminalView?
+    /// Whether the terminal owned the keyboard when the panel opened.
+    private var resumesFocus = false
+
+    var isPresented: Bool { panel != nil }
+
+    /// - Parameters:
+    ///   - host: the presenting view controller.
+    ///   - anchor: the CTRL key the popover points at.
+    ///   - maximumWidth: the popover's ceiling (scene width less margins).
+    ///   - plan: the tier's cap and paywall route. The route runs only after
+    ///     this popover is down — the paywall is a sheet from the window, and
+    ///     one presentation must end before the next begins.
+    ///   - feedback: the host's press feedback (the rail's input click).
+    ///   - configure: the host's appearance step — panel ground, popover
+    ///     ground, appearance / glass mirroring — after the view loads and
+    ///     before presentation.
+    func present(
+        from host: UIViewController,
+        anchor: UIView,
+        terminal: TerminalView,
+        maximumWidth: CGFloat,
+        plan: KeyCommandPlan = .unrestricted,
+        feedback: (() -> Void)? = nil,
+        configure: (KeyCommandPanelViewController, UIPopoverPresentationController) -> Void
+    ) {
+        guard panel == nil else { return }
+        self.terminal = terminal
+        let panel = KeyCommandPanelViewController(
+            store: KeyCommandStore.shared,
+            terminal: terminal,
+            maximumWidth: maximumWidth,
+            plan: KeyCommandPlan(
+                limit: plan.limit,
+                upgrade: plan.upgrade.map { route in
+                    { [weak self] in self?.dismiss(then: route) }
+                }
+            ),
+            perform: { [weak terminal] command in
+                feedback?()
+                guard let terminal else { return }
+                KeyCommandDispatcher.perform(command, on: terminal)
+            },
+            dismiss: { [weak self] in self?.dismiss() }
+        )
+        self.panel = panel
+        resumesFocus = terminal.isFirstResponder
+        panel.modalPresentationStyle = .popover
+        // Loading sizes the panel (`preferredContentSize` is set as the
+        // content is built), so no second measure here.
+        panel.loadViewIfNeeded()
+        if let popover = panel.popoverPresentationController {
+            popover.sourceView = anchor
+            popover.sourceRect = anchor.bounds
+            popover.permittedArrowDirections = .down
+            popover.delegate = self
+            configure(panel, popover)
+        }
+        host.present(panel, animated: true)
+        // Labels built before the window attach can retain ink resolved
+        // against the wrong traits; re-resolve once trait delivery settles.
+        panel.refreshDynamicTextColorsAfterTraitPropagation()
+        Task { await KeyCommandStore.shared.refreshFromCloud() }
+    }
+
+    /// - Parameter completion: runs once the popover is down and focus is
+    ///   settled — the plan's paywall route rides here.
+    func dismiss(then completion: (() -> Void)? = nil) {
+        guard let panel else {
+            completion?()
+            return
+        }
+        self.panel = nil
+        panel.prepareForRemoval()
+        panel.dismiss(animated: true) { [weak self] in
+            self?.resumeFocusIfNeeded()
+            completion?()
+        }
+    }
+
+    /// A composer field that took the keyboard hands it back; a panel that
+    /// never touched focus leaves the terminal exactly as it was.
+    private func resumeFocusIfNeeded() {
+        guard resumesFocus, let terminal else { return }
+        resumesFocus = false
+        guard TerminalFocusArbiter.current === terminal, !terminal.isFirstResponder else { return }
+        TerminalFocusArbiter.resumeAfterPresentation(terminal)
+    }
+
+    // MARK: UIPopoverPresentationControllerDelegate
+
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController
+    ) -> UIModalPresentationStyle { .none }
+
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle { .none }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        guard let panel, presentationController.presentedViewController === panel else { return }
+        self.panel = nil
+        panel.prepareForRemoval()
+        resumeFocusIfNeeded()
+    }
+}

--- a/Multiplex/Views/Terminal/ShortcutPanel.swift
+++ b/Multiplex/Views/Terminal/ShortcutPanel.swift
@@ -167,35 +167,13 @@ final class ShortcutPanelViewController: UIViewController {
     }
 
     private func makeHeader() -> UIView {
-        let title = UIKitChassisLabel(content.headerTitle, size: 13)
-        title.accessibilityTraits.insert(.header)
-        let prefix = ShortcutPanelLabel(
+        let prefix = UIKitChassisMonoLabel(
             content.prefixLabel,
             font: UIKitChassis.monoFont(9, weight: .semibold),
             color: UIKitChassis.signal2,
             kern: 0.8
         )
-        prefix.setContentCompressionResistancePriority(.required, for: .horizontal)
-
-        let spacer = UIView()
-        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        let row = UIStackView(arrangedSubviews: [title, spacer, prefix])
-        row.axis = .horizontal
-        row.alignment = .firstBaseline
-        row.spacing = 16
-
-        let container = UIView()
-        container.addSubview(row)
-        row.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            row.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 1),
-            row.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            row.topAnchor.constraint(equalTo: container.topAnchor, constant: 6),
-            row.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
-        return container
+        return TallyPanelHeader.make(title: content.headerTitle, trailing: prefix)
     }
 
     private func makeShortcutSection(_ section: ShortcutPanelSection) -> UIView {
@@ -211,12 +189,15 @@ final class ShortcutPanelViewController: UIViewController {
         if section.usesCompactRow {
             grid = makeCompactRow(section.items)
         } else {
-            grid = makeGrid(section.items.map { item in
-                let button = ShortcutItemButton(item: item)
-                button.addTarget(self, action: #selector(itemPressed(_:)), for: .touchUpInside)
-                itemButtons[item.id] = button
-                return button
-            })
+            grid = TallyHairlineGrid.grid(
+                section.items.map { item in
+                    let button = ShortcutItemButton(item: item)
+                    button.addTarget(self, action: #selector(itemPressed(_:)), for: .touchUpInside)
+                    itemButtons[item.id] = button
+                    return button
+                },
+                columns: 2
+            )
         }
 
         let stack = UIStackView(arrangedSubviews: [title, grid])
@@ -230,7 +211,7 @@ final class ShortcutPanelViewController: UIViewController {
     /// routes through the same `activate` path as the grid rows; a hold goes
     /// coarse and repeats until release. Both leave the panel up.
     private func makeCompactRow(_ items: [ShortcutPanelItem]) -> UIView {
-        makeGrid(
+        TallyHairlineGrid.grid(
             items.map { item in
                 let button = ShortcutCompactItemButton(item: item)
                 button.onTap = { [weak self] in self?.activate(item) }
@@ -255,36 +236,7 @@ final class ShortcutPanelViewController: UIViewController {
             button.addTarget(self, action: #selector(choicePressed(_:)), for: .touchUpInside)
             return button
         }
-        return makeGrid(choiceButtons)
-    }
-
-    /// Equal-width cells over the 1 pt bezel hairline — the panel's one grid
-    /// treatment, whether two columns of full rows or one compact row.
-    private func makeGrid(_ controls: [UIControl], columns: Int = 2) -> UIView {
-        let grid = UIStackView()
-        grid.axis = .vertical
-        grid.alignment = .fill
-        grid.spacing = 1
-        grid.backgroundColor = UIKitChassis.bezelHi
-
-        for offset in stride(from: 0, to: controls.count, by: columns) {
-            let cells = (offset..<offset + columns).map { index -> UIView in
-                guard controls.indices.contains(index) else {
-                    let filler = UIView()
-                    filler.backgroundColor = UIKitChassis.bezelHi
-                    filler.isAccessibilityElement = false
-                    return filler
-                }
-                return controls[index]
-            }
-            let row = UIStackView(arrangedSubviews: cells)
-            row.axis = .horizontal
-            row.alignment = .fill
-            row.distribution = .fillEqually
-            row.spacing = 1
-            grid.addArrangedSubview(row)
-        }
-        return grid
+        return TallyHairlineGrid.grid(choiceButtons, columns: 2)
     }
 
     @objc private func itemPressed(_ sender: ShortcutItemButton) {
@@ -428,6 +380,79 @@ final class ShortcutPanelViewController: UIViewController {
     }
 }
 
+/// Equal-width cells over the 1 pt bezel hairline — the one grid treatment
+/// every TALLY panel uses, whether two columns of full rows, one compact
+/// row, or the Key Commands grid.
+@MainActor
+enum TallyHairlineGrid {
+    static func grid(_ cells: [UIView], columns: Int) -> UIView {
+        let grid = UIStackView()
+        grid.axis = .vertical
+        grid.alignment = .fill
+        grid.spacing = 1
+        grid.backgroundColor = UIKitChassis.bezelHi
+        for offset in stride(from: 0, to: cells.count, by: columns) {
+            let rowCells = (offset..<offset + columns).map { index -> UIView in
+                guard cells.indices.contains(index) else {
+                    let filler = UIView()
+                    filler.backgroundColor = UIKitChassis.bezelHi
+                    filler.isAccessibilityElement = false
+                    return filler
+                }
+                return cells[index]
+            }
+            grid.addArrangedSubview(row(rowCells))
+        }
+        return grid
+    }
+
+    static func row(_ cells: [UIView]) -> UIView {
+        let row = UIStackView(arrangedSubviews: cells)
+        row.axis = .horizontal
+        row.alignment = .fill
+        row.distribution = .fillEqually
+        row.spacing = 1
+        row.backgroundColor = UIKitChassis.bezelHi
+        return row
+    }
+}
+
+/// A panel's title row: compressed-caps title with the header trait, a
+/// spacer, and a trailing readout at the first baseline.
+@MainActor
+enum TallyPanelHeader {
+    static func make(
+        title: String,
+        trailing: UIView,
+        titleIdentifier: String? = nil
+    ) -> UIView {
+        let titleLabel = UIKitChassisLabel(title, size: 13)
+        titleLabel.accessibilityTraits.insert(.header)
+        titleLabel.accessibilityIdentifier = titleIdentifier
+        trailing.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let row = UIStackView(arrangedSubviews: [titleLabel, spacer, trailing])
+        row.axis = .horizontal
+        row.alignment = .firstBaseline
+        row.spacing = 16
+
+        let container = UIView()
+        container.addSubview(row)
+        row.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 1),
+            row.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            row.topAnchor.constraint(equalTo: container.topAnchor, constant: 6),
+            row.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        return container
+    }
+}
+
 /// Press feedback for the panel's rows: the pressed ground lands at once and
 /// fades away. A tap raises and clears the highlight inside one run loop, so
 /// clearing it outright drew no frame and only a long press ever looked
@@ -435,11 +460,12 @@ final class ShortcutPanelViewController: UIViewController {
 /// what makes a quick tap visible.
 private let shortcutPressFadeDuration: TimeInterval = 0.25
 
-/// Shared press chassis for every control in the panel: the square hover
-/// shape, the press wiring, and the fade above. Subclasses supply only their
-/// content and, where state changes it, the resting ground.
+/// Shared press chassis for every control in a TALLY panel — the shortcut
+/// panel's rows and the Key Commands panel's cells and segment cells: the
+/// square hover shape, the press wiring, and the fade above. Subclasses
+/// supply only their content and, where state changes it, the resting ground.
 @MainActor
-private class ShortcutPressControl: UIControl {
+class ShortcutPressControl: UIControl {
     override init(frame: CGRect) {
         super.init(frame: frame)
         isAccessibilityElement = true
@@ -491,9 +517,15 @@ private class ShortcutPressControl: UIControl {
     @objc private func endPress() { isHighlighted = false }
 }
 
+/// The measuring, scrolling root every popover-hosted TALLY panel stands on
+/// (shortcut panel, Key Commands): its intrinsic size is the content stack
+/// measured at `width`, and a panel that changes width (Key Commands' two
+/// tabs) sets it and re-measures.
 @MainActor
-private final class ShortcutPanelRootView: UIKitTallyBorderedView {
-    private var width: CGFloat
+final class ShortcutPanelRootView: UIKitTallyBorderedView {
+    var width: CGFloat {
+        didSet { invalidateIntrinsicContentSize() }
+    }
     private let scrollView = UIScrollView()
     private weak var contentStack: UIStackView?
 
@@ -510,6 +542,9 @@ private final class ShortcutPanelRootView: UIKitTallyBorderedView {
         self.contentStack = contentStack
         scrollView.alwaysBounceVertical = false
         scrollView.showsVerticalScrollIndicator = true
+        #if !os(visionOS)
+        scrollView.keyboardDismissMode = .interactive
+        #endif
         addSubview(scrollView)
         scrollView.addSubview(contentStack)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -554,9 +589,9 @@ private final class ShortcutPanelRootView: UIKitTallyBorderedView {
 private final class ShortcutItemButton: ShortcutPressControl {
     let item: ShortcutPanelItem
 
-    private let titleLabel = ShortcutPanelLabel()
-    private let commandLabel = ShortcutPanelLabel()
-    private let bindingLabel = ShortcutPanelLabel()
+    private let titleLabel = UIKitChassisMonoLabel()
+    private let commandLabel = UIKitChassisMonoLabel()
+    private let bindingLabel = UIKitChassisMonoLabel()
     private let bindingBorder = UIKitTallyBorderedView()
     private var isArmed = false
 
@@ -758,14 +793,14 @@ private final class ShortcutChoiceButton: ShortcutPressControl {
     private(set) var choice: TmuxWindowChoice
 
     private let noun: String
-    private let activeLabel: ShortcutPanelLabel
+    private let activeLabel: UIKitChassisMonoLabel
 
     init(choice: TmuxWindowChoice, noun: String, accessibilityPrefix: String) {
         self.choice = choice
         self.noun = noun
         // Built for every row, hidden while inactive: the panel stays open
         // across a switch, so the marker has to move without a rebuild.
-        activeLabel = ShortcutPanelLabel(
+        activeLabel = UIKitChassisMonoLabel(
             "ACTIVE",
             font: UIKitChassis.monoFont(9, weight: .semibold),
             color: UIKitChassis.signal2
@@ -774,13 +809,13 @@ private final class ShortcutChoiceButton: ShortcutPressControl {
         minimumHeight(40)
         accessibilityIdentifier = accessibilityPrefix + choice.tmuxID
 
-        let index = ShortcutPanelLabel(
+        let index = UIKitChassisMonoLabel(
             "\(choice.index)",
             font: UIKitChassis.monoFont(9, weight: .semibold),
             color: UIKitChassis.signal2
         )
         index.setContentHuggingPriority(.required, for: .horizontal)
-        let name = ShortcutPanelLabel(
+        let name = UIKitChassisMonoLabel(
             choice.name.uppercased(),
             font: UIKitChassis.compressedLabelFont(10),
             color: UIKitChassis.signal,
@@ -816,68 +851,6 @@ private final class ShortcutChoiceButton: ShortcutPressControl {
         accessibilityLabel = active
             ? "\(noun.capitalized) \(choice.index), \(choice.name), current \(noun)"
             : "Switch to \(noun) \(choice.index), \(choice.name)"
-    }
-}
-
-@MainActor
-private final class ShortcutPanelLabel: UILabel {
-    private var sourceText = ""
-    private var sourceFont = UIFont.systemFont(ofSize: 10)
-    private var sourceColor = UIKitChassis.signal
-    private var kern: CGFloat?
-
-    convenience init(
-        _ text: String,
-        font: UIFont,
-        color: UIColor,
-        kern: CGFloat? = nil
-    ) {
-        self.init(frame: .zero)
-        configure(text, font: font, color: color, kern: kern)
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        numberOfLines = 1
-        lineBreakMode = .byClipping
-        isAccessibilityElement = false
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("unused") }
-
-    func configure(
-        _ text: String,
-        font: UIFont,
-        color: UIColor,
-        kern: CGFloat? = nil
-    ) {
-        sourceText = text
-        sourceFont = font
-        sourceColor = color
-        self.kern = kern
-        refreshAttributedText()
-    }
-
-    func setText(_ text: String) {
-        sourceText = text
-        refreshAttributedText()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
-        else { return }
-        refreshAttributedText()
-    }
-
-    private func refreshAttributedText() {
-        var attributes: [NSAttributedString.Key: Any] = [
-            .font: sourceFont,
-            .foregroundColor: sourceColor.resolvedColor(with: traitCollection),
-        ]
-        if let kern { attributes[.kern] = kern }
-        attributedText = NSAttributedString(string: sourceText, attributes: attributes)
     }
 }
 

--- a/Multiplex/Views/Terminal/SwiftTermView.swift
+++ b/Multiplex/Views/Terminal/SwiftTermView.swift
@@ -18,6 +18,9 @@ final class TerminalSurfaceView: UIView {
         /// Which multiplexer owns the rail's shortcut key (TMUX/HRDR); nil
         /// drops the key — plain shells and auxiliary panes have no panel.
         var shortcutBackend: Host.SessionBackend?
+        /// The tier's Key Commands cap and paywall route for the rail's
+        /// hold-CTRL panel.
+        var keyCommandPlan: KeyCommandPlan = .unrestricted
     }
 
     private static let focusTapName = "multiplex.focus-tap"
@@ -191,6 +194,7 @@ final class TerminalSurfaceView: UIView {
         )
         keyBar.contentSafeArea = configuration.contentSafeArea
         keyBar.spendsBottomStrip = configuration.railOwnsBottomSafeArea
+        keyBar.keyCommandPlan = configuration.keyCommandPlan
         coordinator.keyBar = keyBar
         addSubview(view)
         addSubview(keyBar)
@@ -334,6 +338,7 @@ final class TerminalSurfaceView: UIView {
         )
         coordinator.updateContentSafeArea(configuration.contentSafeArea)
         coordinator.setRailOwnsBottomSafeArea(configuration.railOwnsBottomSafeArea)
+        coordinator.keyBar?.keyCommandPlan = configuration.keyCommandPlan
         if fontChanged {
             coordinator.terminalMetricsDidChange()
         }

--- a/Multiplex/Views/Terminal/TerminalGuidePictograms.swift
+++ b/Multiplex/Views/Terminal/TerminalGuidePictograms.swift
@@ -63,6 +63,7 @@ final class TerminalGuidePictogramView: UIView {
         case "dictate": drawDictation()
         case "shiftreturn": drawShiftReturn()
         case "shortcutkey": drawShortcutKey()
+        case "keycommands": drawKeyCommands()
         case "resize": drawResize()
         case "panemenu": drawPaneMenu()
         case "paste": drawPastePermission()
@@ -295,6 +296,55 @@ final class TerminalGuidePictogramView: UIView {
             row.addLine(to: CGPoint(x: 82, y: y))
             stroke(
                 row,
+                color: UIKitChassis.signal2.withAlphaComponent(0.5),
+                dashed: true
+            )
+        }
+    }
+
+    /// A held CTRL key (the long-press arc, "0.3 s") raising the two-column
+    /// Key Commands grid.
+    private func drawKeyCommands() {
+        drawKeycap(
+            CGRect(x: 7, y: 26, width: 30, height: 18),
+            label: "CTRL",
+            labelSize: 6.5
+        )
+        drawMonoText(
+            "0.3 s",
+            at: CGPoint(x: 8, y: 6),
+            size: 6.5,
+            color: UIKitChassis.signal3
+        )
+        let center = CGPoint(x: 22, y: 35)
+        let arc = UIBezierPath(
+            arcCenter: center,
+            radius: 15,
+            startAngle: -.pi / 2,
+            endAngle: .pi,
+            clockwise: true
+        )
+        stroke(arc, color: UIKitChassis.signal)
+        drawArrow(
+            from: CGPoint(x: 41, y: 35),
+            to: CGPoint(x: 49, y: 35),
+            color: UIKitChassis.signal2,
+            endHead: true
+        )
+        let panel = UIBezierPath(roundedRect: CGRect(x: 52, y: 12, width: 38, height: 44), cornerRadius: 2)
+        stroke(panel, color: UIKitChassis.signal)
+        for (row, label) in [(0, "⇧⏎"), (1, "⌃C"), (2, "⌥⌫")] {
+            let y = 18 + CGFloat(row) * 13
+            drawKeycap(
+                CGRect(x: 56, y: y, width: 14, height: 9),
+                label: label,
+                labelSize: 5
+            )
+            let line = UIBezierPath()
+            line.move(to: CGPoint(x: 73, y: y + 4.5))
+            line.addLine(to: CGPoint(x: 86, y: y + 4.5))
+            stroke(
+                line,
                 color: UIKitChassis.signal2.withAlphaComponent(0.5),
                 dashed: true
             )

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -25,6 +25,12 @@ final class TerminalTallyKeyControl: UIControl {
     var longPressAction: (() -> Void)? {
         didSet { configureLongPress() }
     }
+    /// How long a press must hold before `longPressAction` fires. The
+    /// keyboard key's lock keeps the 0.5 s default; CTRL's Key Commands
+    /// hold is shorter (`KeyCommandPanelViewController.controlHoldDuration`).
+    var longPressDuration: TimeInterval = 0.5 {
+        didSet { longPressRecognizer?.minimumPressDuration = longPressDuration }
+    }
     var preferredSize: CGSize {
         didSet { invalidateIntrinsicContentSize() }
     }
@@ -230,7 +236,7 @@ final class TerminalTallyKeyControl: UIControl {
             target: self,
             action: #selector(longPressed(_:))
         )
-        recognizer.minimumPressDuration = 0.5
+        recognizer.minimumPressDuration = longPressDuration
         recognizer.cancelsTouchesInView = false
         addGestureRecognizer(recognizer)
         longPressRecognizer = recognizer
@@ -611,6 +617,10 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     private(set) var renderedKeys: [TerminalTallyKeyControl] = []
     private weak var ctrlKeyControl: TerminalTallyKeyControl?
     private weak var shortcutPopoverController: UIViewController?
+    private let keyCommandsPresenter = KeyCommandPanelPresenter()
+    /// The tier's Key Commands cap and paywall route, handed down with the
+    /// pane's configuration; the rail carries it to the presenter unread.
+    var keyCommandPlan: KeyCommandPlan = .unrestricted
     private var ctrlComboView: TerminalCtrlComboView?
 
     private struct RenderSignature: Equatable {
@@ -730,9 +740,13 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         let metric = specification.metric
         let includesReturn = showsReturnKey || state.keyboardLocked
 
+        // Tap CTRL latches (and raises the C / B slab); a hold on the same
+        // key opens Key Commands and never toggles the latch.
+        var control = caps("CTRL", .ctrl, "Control", identifier: "control", latched: ctrlLatched)
+        control.longPressKey = .keyCommands
         var groups: [[RailKey]] = [[
             caps("ESC", .esc, "Escape", identifier: "escape"),
-            caps("CTRL", .ctrl, "Control", identifier: "control", latched: ctrlLatched),
+            control,
             caps("TAB", .tab, "Tab", identifier: "tab"),
         ]]
         if !specification.symbols.isEmpty {
@@ -831,6 +845,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
                     },
                     action: { [weak self] in self?.press(descriptor.key) }
                 )
+                if let hold = descriptor.longPressKey { control.longPressDuration = hold.holdDuration }
                 control.accessibilityUserInputLabels = [descriptor.accessibility]
                 addSubview(control)
                 renderedKeys.append(control)
@@ -933,7 +948,29 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         case .shortcut(let item):
             click()
             performShortcut(item)
+        case .keyCommands:
+            showKeyCommandsPanel()
         }
+    }
+
+    /// Hold CTRL: the KEY COMMANDS popover, anchored to the CTRL key like the
+    /// TMUX dropdown to its own. The presenter owns the lifecycle; this rail
+    /// supplies the anchor, the click, and the opaque chassis ground.
+    private func showKeyCommandsPanel() {
+        guard let terminal, let presenter = presentingViewController else { return }
+        let sceneWidth = window?.bounds.width ?? presenter.view.bounds.width
+        keyCommandsPresenter.present(
+            from: presenter,
+            anchor: ctrlKeyControl ?? self,
+            terminal: terminal,
+            maximumWidth: max(280, sceneWidth - 24),
+            plan: keyCommandPlan,
+            feedback: { [weak self] in self?.click() },
+            configure: { panel, popover in
+                panel.view.backgroundColor = UIKitChassis.bezel
+                popover.backgroundColor = UIKitChassis.bezel
+            }
+        )
     }
 
     private func showShortcutPanel() {
@@ -1101,6 +1138,15 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         showShortcutPanel()
     }
 
+    /// Hold CTRL, headlessly. `setup` lands on the CUSTOM SETUP tab and
+    /// `compose` also adds a row so its composer is up. A panel already
+    /// present just moves, so one capture run can walk every state.
+    func debugShowKeyCommands(_ mode: KeyCommandDebugMode) {
+        guard let terminal, TerminalFocusArbiter.current === terminal else { return }
+        if !keyCommandsPresenter.isPresented { showKeyCommandsPanel() }
+        keyCommandsPresenter.panel?.debugShow(mode)
+    }
+
     func debugSendTmuxCopyMode() {
         guard let terminal, TerminalFocusArbiter.current === terminal else { return }
         press(.shortcut(ShortcutPanelItem(TmuxShortcut.copyMode)))
@@ -1192,6 +1238,17 @@ private enum TerminalKey {
     case dictation
     case showShortcutPanel
     case shortcut(ShortcutPanelItem)
+    case keyCommands
+
+    /// How long a rail key must hold before it fires this as its hold
+    /// action. Key Commands is the daily path and holds shorter than the
+    /// keyboard key's lock.
+    var holdDuration: TimeInterval {
+        switch self {
+        case .keyCommands: KeyCommandPanelViewController.controlHoldDuration
+        default: 0.5
+        }
+    }
 }
 
 extension TerminalKeyBar: UIPopoverPresentationControllerDelegate {
@@ -1247,6 +1304,13 @@ enum TmuxShortcutDebugHook {
         notify_register_dispatch(
             "app.multiplexterm.multiplex.debug.longpressmenu", &longPressMenuToken, .main
         ) { _ in focusedBar()?.debugShowLongPressMenu() }
+
+        for mode in KeyCommandDebugMode.allCases {
+            var token: Int32 = 0
+            notify_register_dispatch(
+                "app.multiplexterm.multiplex.debug.\(mode.hookName)", &token, .main
+            ) { _ in focusedBar()?.debugShowKeyCommands(mode) }
+        }
 
         var herdrMenuToken: Int32 = 0
         notify_register_dispatch(
@@ -1324,7 +1388,11 @@ struct TerminalKeyClusterMetric: Equatable {
 @MainActor
 final class TerminalKeyClusterContext {
     private weak var controller: TerminalSessionController?
-    private weak var observedTerminal: TerminalView?
+    private(set) weak var observedTerminal: TerminalView?
+    /// The tier's Key Commands cap and paywall route, set by the window that
+    /// holds the entitlement store; every group of this context presents
+    /// with it.
+    var keyCommandPlan: KeyCommandPlan = .unrestricted
     private let groups = NSHashTable<TerminalKeyClusterGroupView>.weakObjects()
     private var controlResetObserver: NSObjectProtocol?
     #if DEBUG
@@ -1351,6 +1419,16 @@ final class TerminalKeyClusterContext {
                 queue: .main
             ) { [weak self] _ in
                 MainActor.assumeIsolated { self?.debugShowCtrlCombos() }
+            },
+            center.addObserver(
+                forName: .multiplexDebugKeyCommands,
+                object: nil,
+                queue: .main
+            ) { [weak self] note in
+                MainActor.assumeIsolated {
+                    guard let mode = note.userInfo?["mode"] as? KeyCommandDebugMode else { return }
+                    self?.debugShowKeyCommands(mode)
+                }
             },
         ]
         #endif
@@ -1474,6 +1552,13 @@ final class TerminalKeyClusterContext {
         broadcast()
         visibleControlGroup?.showCtrlCombos()
     }
+
+    private func debugShowKeyCommands(_ mode: KeyCommandDebugMode) {
+        guard let terminal = observedTerminal,
+              TerminalFocusArbiter.current === terminal
+        else { return }
+        visibleControlGroup?.debugShowKeyCommands(mode)
+    }
     #endif
 }
 
@@ -1497,6 +1582,7 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
     private var standaloneVariant: StandaloneVariant?
     private weak var ctrlKey: TerminalTallyKeyControl?
     private weak var comboPopoverController: UIViewController?
+    private let keyCommandsPresenter = KeyCommandPanelPresenter()
     private(set) var keys: [TerminalTallyKeyControl] = []
 
     var carriesControlKey: Bool { role != .trailing }
@@ -1611,6 +1697,39 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
         comboPopoverController = nil
     }
 
+    /// Hold CTRL: the KEY COMMANDS popover above the ornament's CTRL key —
+    /// the C / B slab's mechanism. The presenter owns the lifecycle; this
+    /// ornament supplies the anchor and carries its appearance and glass
+    /// mirroring across the popover's own window.
+    func showKeyCommands() {
+        guard let ctrlKey,
+              let terminal = context.observedTerminal,
+              let presenter = presentingViewController
+        else { return }
+        let sceneWidth = window?.bounds.width ?? presenter.view.bounds.width
+        keyCommandsPresenter.present(
+            from: presenter,
+            anchor: ctrlKey,
+            terminal: terminal,
+            maximumWidth: max(280, sceneWidth - 24),
+            plan: context.keyCommandPlan
+        ) { panel, _ in
+            panel.overrideUserInterfaceStyle = overrideUserInterfaceStyle
+            panel.view.traitOverrides[GlassAppearanceTrait.self] =
+                traitCollection[GlassAppearanceTrait.self]
+            panel.view.backgroundColor = GlassPrototype.popoverGround(
+                fallback: TallyPalette.bezel
+            )
+        }
+    }
+
+    #if DEBUG
+    func debugShowKeyCommands(_ mode: KeyCommandDebugMode) {
+        if !keyCommandsPresenter.isPresented { showKeyCommands() }
+        keyCommandsPresenter.panel?.debugShow(mode)
+    }
+    #endif
+
     private func rebuildKeys(variant: StandaloneVariant?) {
         for key in keys { key.removeFromSuperview() }
         keys.removeAll(keepingCapacity: true)
@@ -1639,6 +1758,11 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
             ) { [weak self, weak context] in
                 guard let self, let context else { return }
                 context.toggleControl(from: self)
+            }
+            // Hold CTRL opens Key Commands and never toggles the latch.
+            control.longPressDuration = KeyCommandPanelViewController.controlHoldDuration
+            control.longPressAction = { [weak self] in
+                self?.showKeyCommands()
             }
             append(control)
             ctrlKey = control
@@ -1855,6 +1979,7 @@ extension TerminalKeyClusterGroupView: UIPopoverPresentationControllerDelegate {
 extension Notification.Name {
     static let multiplexDebugKeyCluster = Notification.Name("MultiplexDebugKeyCluster")
     static let multiplexDebugCtrlCombos = Notification.Name("MultiplexDebugCtrlCombos")
+    static let multiplexDebugKeyCommands = Notification.Name("MultiplexDebugKeyCommands")
 }
 
 @MainActor
@@ -1876,6 +2001,17 @@ enum KeyClusterDebugHook {
             "app.multiplexterm.multiplex.debug.ctrlcombos", &combosToken, .main
         ) { _ in
             NotificationCenter.default.post(name: .multiplexDebugCtrlCombos, object: nil)
+        }
+
+        for mode in KeyCommandDebugMode.allCases {
+            var token: Int32 = 0
+            notify_register_dispatch(
+                "app.multiplexterm.multiplex.debug.\(mode.hookName)", &token, .main
+            ) { _ in
+                NotificationCenter.default.post(
+                    name: .multiplexDebugKeyCommands, object: nil, userInfo: ["mode": mode]
+                )
+            }
         }
     }
 }

--- a/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalPaneUIKit.swift
@@ -14,6 +14,10 @@ struct TerminalPaneConfiguration {
     var railOwnsBottomSafeArea: Bool
     var isActive: Bool
     var focusAllowed: Bool
+    /// The tier's Key Commands cap and paywall route for the rail's
+    /// hold-CTRL panel (iPad/iPhone; the visionOS cluster gets it from the
+    /// window directly).
+    var keyCommandPlan: KeyCommandPlan = .unrestricted
     var close: () -> Void
 }
 
@@ -228,7 +232,8 @@ final class TerminalPaneViewController: UIViewController, UIDropInteractionDeleg
             contentSafeArea: configuration.contentSafeArea,
             railOwnsBottomSafeArea: configuration.railOwnsBottomSafeArea,
             isActive: configuration.isActive && configuration.focusAllowed,
-            shortcutBackend: configuration.controller?.route.sessionBackend
+            shortcutBackend: configuration.controller?.route.sessionBackend,
+            keyCommandPlan: configuration.keyCommandPlan
         )
     }
 

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -1583,7 +1583,19 @@ extension TerminalWindowViewController {
             railOwnsBottomSafeArea: railOwnsBottomSafeArea,
             isActive: isActive,
             focusAllowed: terminalFocusAllowed,
+            keyCommandPlan: keyCommandPlan,
             close: { [weak self] in self?.closeTab(tab.id) }
+        )
+    }
+
+    /// The hold-CTRL panel's tier: the free cap with the paywall as its
+    /// route, or the full cap once Pro. `entitlements.isPro` is in this
+    /// controller's observation set, so a purchase re-renders every pane
+    /// (and, on visionOS, the cluster contexts) with the lifted plan.
+    private var keyCommandPlan: KeyCommandPlan {
+        KeyCommandPlan(
+            limit: entitlements.keyCommandLimit,
+            upgrade: entitlements.isPro ? nil : { [weak self] in self?.presentPaywall() }
         )
     }
 
@@ -2023,6 +2035,7 @@ extension TerminalWindowViewController {
 
     private func updateVisionOrnaments(forceRevision: Bool = false) {
         guard shell == nil, !appLocked else { return }
+        visionOrnaments.state.keyClusterContext.keyCommandPlan = keyCommandPlan
         visionOrnaments.update(
             tabCount: route.tabs.count,
             isAuxiliary: activeTab?.isAuxiliaryPane == true,
@@ -2084,6 +2097,7 @@ extension TerminalWindowViewController {
             visionShellKeyCluster.removeFromSuperview()
             rootView.addSubview(visionShellKeyCluster)
         }
+        visionShellKeyContext.keyCommandPlan = keyCommandPlan
         visionShellKeyCluster.update(controller: activeController)
         visionShellKeyCluster.isHidden = false
     }

--- a/MultiplexTests/EntitlementStoreTests.swift
+++ b/MultiplexTests/EntitlementStoreTests.swift
@@ -195,21 +195,6 @@ final class EntitlementStoreTests: XCTestCase {
         #endif
     }
 
-    func testFreeKeyCommandLimitIsFiveAndProLiftsItToTheCap() {
-        let (defaults, name) = makeDefaults()
-        defer { defaults.removePersistentDomain(forName: name) }
-        let store = lockedStore(defaults: defaults)
-
-        XCTAssertEqual(EntitlementStore.freeKeyCommandLimit, 5)
-        XCTAssertEqual(store.keyCommandLimit, 5)
-        XCTAssertLessThan(store.keyCommandLimit, KeyCommandSet.maximumCount)
-
-        #if DEBUG
-        store.setDebugUnlocked(true)
-        XCTAssertEqual(store.keyCommandLimit, KeyCommandSet.maximumCount)
-        #endif
-    }
-
     func testProCapabilityPredicatesPreserveGrandfatheredMosh() {
         let (defaults, name) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: name) }
@@ -219,12 +204,15 @@ final class EntitlementStoreTests: XCTestCase {
         XCTAssertTrue(store.canEnableMosh(currentlyEnabled: true))
         XCTAssertFalse(store.canMutateCustomThemes)
         XCTAssertFalse(store.canScheduleAgentAlerts)
+        XCTAssertEqual(store.keyCommandLimit, EntitlementStore.freeKeyCommandLimit)
+        XCTAssertEqual(store.keyCommandLimit, 5)
 
         #if DEBUG
         store.setDebugUnlocked(true)
         XCTAssertTrue(store.canEnableMosh(currentlyEnabled: false))
         XCTAssertTrue(store.canMutateCustomThemes)
         XCTAssertTrue(store.canScheduleAgentAlerts)
+        XCTAssertEqual(store.keyCommandLimit, KeyCommandSet.maximumCount)
         #endif
     }
 

--- a/MultiplexTests/EntitlementStoreTests.swift
+++ b/MultiplexTests/EntitlementStoreTests.swift
@@ -195,6 +195,21 @@ final class EntitlementStoreTests: XCTestCase {
         #endif
     }
 
+    func testFreeKeyCommandLimitIsFiveAndProLiftsItToTheCap() {
+        let (defaults, name) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: name) }
+        let store = lockedStore(defaults: defaults)
+
+        XCTAssertEqual(EntitlementStore.freeKeyCommandLimit, 5)
+        XCTAssertEqual(store.keyCommandLimit, 5)
+        XCTAssertLessThan(store.keyCommandLimit, KeyCommandSet.maximumCount)
+
+        #if DEBUG
+        store.setDebugUnlocked(true)
+        XCTAssertEqual(store.keyCommandLimit, KeyCommandSet.maximumCount)
+        #endif
+    }
+
     func testProCapabilityPredicatesPreserveGrandfatheredMosh() {
         let (defaults, name) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: name) }

--- a/MultiplexTests/KeyChordEncodingTests.swift
+++ b/MultiplexTests/KeyChordEncodingTests.swift
@@ -33,10 +33,6 @@ final class CapturingTerminalDelegate: NSObject, TerminalViewDelegate {
 /// with them, DECCKM-aware for arrows.
 @MainActor
 final class KeyChordEncodingTests: XCTestCase {
-    private func makeTerminal() -> (TerminalView, CapturingTerminalDelegate) {
-        CapturingTerminalDelegate.makeTerminal()
-    }
-
     private func bytes(
         _ key: TerminalKeyChord.Key,
         _ modifiers: TerminalKeyChord.Modifiers = [],
@@ -46,7 +42,7 @@ final class KeyChordEncodingTests: XCTestCase {
     }
 
     func testLegacyChordsMatchTheHardwareRules() {
-        let (terminal, _) = makeTerminal()
+        let (terminal, _) = CapturingTerminalDelegate.makeTerminal()
         XCTAssertEqual(bytes(.enter, [.shift], on: terminal), [0x0A], "Shift+Enter is LF without kitty flags")
         XCTAssertEqual(bytes(.enter, on: terminal), [0x0D])
         XCTAssertEqual(bytes(.enter, [.option], on: terminal), [0x1B, 0x0D], "Option+Enter is ESC CR")
@@ -75,10 +71,8 @@ final class KeyChordEncodingTests: XCTestCase {
         XCTAssertEqual(bytes(.right, [.option], on: terminal), EscapeSequences.emacsForward)
         XCTAssertEqual(bytes(.left, [.control], on: terminal), EscapeSequences.controlLeft)
         XCTAssertEqual(bytes(.up, [.shift], on: terminal), [0x1B, 0x5B, 0x31, 0x3B, 0x32, 0x41], "Shift+Up is CSI 1;2A")
-    }
 
-    func testArrowsFollowDECCKM() {
-        let (terminal, _) = makeTerminal()
+        // Arrows follow DECCKM.
         XCTAssertEqual(bytes(.up, on: terminal), EscapeSequences.moveUpNormal)
         terminal.feed(byteArray: [0x1B, 0x5B, 0x3F, 0x31, 0x68][...]) // CSI ? 1 h
         XCTAssertEqual(bytes(.up, on: terminal), EscapeSequences.moveUpApp)
@@ -86,7 +80,7 @@ final class KeyChordEncodingTests: XCTestCase {
     }
 
     func testKittyFlagsSwitchToCSIUEncodings() {
-        let (terminal, _) = makeTerminal()
+        let (terminal, _) = CapturingTerminalDelegate.makeTerminal()
         terminal.feed(byteArray: [0x1B, 0x5B, 0x3E, 0x31, 0x75][...]) // CSI > 1 u: disambiguate
         XCTAssertFalse(terminal.getTerminal().keyboardEnhancementFlags.isEmpty)
         XCTAssertEqual(
@@ -100,21 +94,5 @@ final class KeyChordEncodingTests: XCTestCase {
         XCTAssertEqual(bytes(.tab, [.shift], on: terminal), Array("\u{1B}[9;2u".utf8))
         XCTAssertEqual(bytes(.backspace, [.option], on: terminal), Array("\u{1B}[127;3u".utf8))
         XCTAssertEqual(bytes(.character("a"), on: terminal), Array("a".utf8), "Plain text stays text")
-    }
-
-    func testSendChordRidesTheDelegatePath() {
-        let (terminal, delegate) = makeTerminal()
-        XCTAssertTrue(terminal.send(chord: TerminalKeyChord(key: .enter, modifiers: [.shift])))
-        XCTAssertEqual(delegate.sent, [[0x0A]])
-    }
-
-    func testAppChordMapsOntoTheForkChord() {
-        let chord = KeyChord(modifiers: [.control, .option], key: .character("x")).terminalChord
-        XCTAssertEqual(chord.key, .character("x"))
-        XCTAssertTrue(chord.modifiers.contains(.control))
-        XCTAssertTrue(chord.modifiers.contains(.option))
-        XCTAssertFalse(chord.modifiers.contains(.shift))
-        XCTAssertEqual(KeyChord(key: .delete).terminalChord.key, .backspace)
-        XCTAssertEqual(KeyChord(key: .space).terminalChord.key, .space)
     }
 }

--- a/MultiplexTests/KeyChordEncodingTests.swift
+++ b/MultiplexTests/KeyChordEncodingTests.swift
@@ -1,0 +1,120 @@
+import SwiftTerm
+import UIKit
+import XCTest
+@testable import Multiplex
+
+/// Captures what a terminal view sends, so a chord's bytes are assertable
+/// end to end through the same delegate path a rail key uses.
+@MainActor
+final class CapturingTerminalDelegate: NSObject, TerminalViewDelegate {
+    var sent: [[UInt8]] = []
+
+    /// A fresh terminal view wired to a fresh capturing delegate.
+    static func makeTerminal() -> (TerminalView, CapturingTerminalDelegate) {
+        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 200))
+        let delegate = CapturingTerminalDelegate()
+        terminal.terminalDelegate = delegate
+        return (terminal, delegate)
+    }
+
+    func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {}
+    func setTerminalTitle(source: TerminalView, title: String) {}
+    func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+    func send(source: TerminalView, data: ArraySlice<UInt8>) {
+        sent.append(Array(data))
+    }
+    func scrolled(source: TerminalView, position: Double) {}
+    func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+    func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+}
+
+/// The fork seam: an app-authored chord encodes exactly as a hardware press
+/// would in the terminal's current mode — legacy without kitty flags, CSI u
+/// with them, DECCKM-aware for arrows.
+@MainActor
+final class KeyChordEncodingTests: XCTestCase {
+    private func makeTerminal() -> (TerminalView, CapturingTerminalDelegate) {
+        CapturingTerminalDelegate.makeTerminal()
+    }
+
+    private func bytes(
+        _ key: TerminalKeyChord.Key,
+        _ modifiers: TerminalKeyChord.Modifiers = [],
+        on terminal: TerminalView
+    ) -> [UInt8]? {
+        terminal.bytes(for: TerminalKeyChord(key: key, modifiers: modifiers))
+    }
+
+    func testLegacyChordsMatchTheHardwareRules() {
+        let (terminal, _) = makeTerminal()
+        XCTAssertEqual(bytes(.enter, [.shift], on: terminal), [0x0A], "Shift+Enter is LF without kitty flags")
+        XCTAssertEqual(bytes(.enter, on: terminal), [0x0D])
+        XCTAssertEqual(bytes(.enter, [.option], on: terminal), [0x1B, 0x0D], "Option+Enter is ESC CR")
+        XCTAssertEqual(bytes(.tab, [.shift], on: terminal), [0x1B, 0x5B, 0x5A], "Shift+Tab is CSI Z")
+        XCTAssertEqual(bytes(.tab, on: terminal), [0x09])
+        XCTAssertEqual(bytes(.escape, on: terminal), [0x1B])
+        XCTAssertEqual(bytes(.backspace, on: terminal), [0x7F])
+        XCTAssertEqual(bytes(.backspace, [.control], on: terminal), [0x08])
+        XCTAssertEqual(
+            bytes(.backspace, [.option], on: terminal),
+            [0x1B, 0x7F],
+            "Option+Backspace is ESC DEL — readline's backward-kill-word, the shipped third default"
+        )
+        XCTAssertEqual(bytes(.space, [.control], on: terminal), [0x00])
+        XCTAssertEqual(bytes(.space, on: terminal), [0x20])
+        XCTAssertEqual(bytes(.character("c"), [.control], on: terminal), [0x03])
+        XCTAssertEqual(
+            bytes(.character("c"), [.control, .shift], on: terminal),
+            [0x03],
+            "Legacy Ctrl+Shift+letter is Ctrl+letter"
+        )
+        XCTAssertEqual(bytes(.character("x"), [.option], on: terminal), [0x1B, 0x78], "Option+letter is ESC letter")
+        XCTAssertEqual(bytes(.character("a"), [.shift], on: terminal), Array("A".utf8))
+        XCTAssertEqual(bytes(.character("a"), on: terminal), Array("a".utf8))
+        XCTAssertEqual(bytes(.left, [.option], on: terminal), EscapeSequences.emacsBack)
+        XCTAssertEqual(bytes(.right, [.option], on: terminal), EscapeSequences.emacsForward)
+        XCTAssertEqual(bytes(.left, [.control], on: terminal), EscapeSequences.controlLeft)
+        XCTAssertEqual(bytes(.up, [.shift], on: terminal), [0x1B, 0x5B, 0x31, 0x3B, 0x32, 0x41], "Shift+Up is CSI 1;2A")
+    }
+
+    func testArrowsFollowDECCKM() {
+        let (terminal, _) = makeTerminal()
+        XCTAssertEqual(bytes(.up, on: terminal), EscapeSequences.moveUpNormal)
+        terminal.feed(byteArray: [0x1B, 0x5B, 0x3F, 0x31, 0x68][...]) // CSI ? 1 h
+        XCTAssertEqual(bytes(.up, on: terminal), EscapeSequences.moveUpApp)
+        XCTAssertEqual(bytes(.down, on: terminal), EscapeSequences.moveDownApp)
+    }
+
+    func testKittyFlagsSwitchToCSIUEncodings() {
+        let (terminal, _) = makeTerminal()
+        terminal.feed(byteArray: [0x1B, 0x5B, 0x3E, 0x31, 0x75][...]) // CSI > 1 u: disambiguate
+        XCTAssertFalse(terminal.getTerminal().keyboardEnhancementFlags.isEmpty)
+        XCTAssertEqual(
+            bytes(.enter, [.shift], on: terminal),
+            Array("\u{1B}[13;2u".utf8),
+            "Shift+Enter rides CSI u once kitty flags are on"
+        )
+        XCTAssertEqual(bytes(.enter, on: terminal), [0x0D], "Plain Enter stays legacy under disambiguate")
+        XCTAssertEqual(bytes(.character("c"), [.control], on: terminal), Array("\u{1B}[99;5u".utf8))
+        XCTAssertEqual(bytes(.up, [.option], on: terminal), Array("\u{1B}[1;3A".utf8))
+        XCTAssertEqual(bytes(.tab, [.shift], on: terminal), Array("\u{1B}[9;2u".utf8))
+        XCTAssertEqual(bytes(.backspace, [.option], on: terminal), Array("\u{1B}[127;3u".utf8))
+        XCTAssertEqual(bytes(.character("a"), on: terminal), Array("a".utf8), "Plain text stays text")
+    }
+
+    func testSendChordRidesTheDelegatePath() {
+        let (terminal, delegate) = makeTerminal()
+        XCTAssertTrue(terminal.send(chord: TerminalKeyChord(key: .enter, modifiers: [.shift])))
+        XCTAssertEqual(delegate.sent, [[0x0A]])
+    }
+
+    func testAppChordMapsOntoTheForkChord() {
+        let chord = KeyChord(modifiers: [.control, .option], key: .character("x")).terminalChord
+        XCTAssertEqual(chord.key, .character("x"))
+        XCTAssertTrue(chord.modifiers.contains(.control))
+        XCTAssertTrue(chord.modifiers.contains(.option))
+        XCTAssertFalse(chord.modifiers.contains(.shift))
+        XCTAssertEqual(KeyChord(key: .delete).terminalChord.key, .backspace)
+        XCTAssertEqual(KeyChord(key: .space).terminalChord.key, .space)
+    }
+}

--- a/MultiplexTests/KeyCommandPanelUIKitTests.swift
+++ b/MultiplexTests/KeyCommandPanelUIKitTests.swift
@@ -1,0 +1,392 @@
+import SwiftTerm
+import UIKit
+import XCTest
+@testable import Multiplex
+
+/// The dispatcher: chords and text rows go through `TerminalView.send`, a
+/// repeat is a guarded burst, and a submitting text row's Enter is its own
+/// later write.
+@MainActor
+final class KeyCommandDispatcherTests: XCTestCase {
+    private func makeTerminal() -> (TerminalView, CapturingTerminalDelegate) {
+        CapturingTerminalDelegate.makeTerminal()
+    }
+
+    func testChordSendsOnceThroughTheDelegate() async {
+        let (terminal, delegate) = makeTerminal()
+        let command = KeyCommand(kind: .chord(KeyChord(modifiers: [.shift], key: .enter)))
+        let task = KeyCommandDispatcher.perform(command, on: terminal)
+        XCTAssertNotNil(task)
+        await task?.value
+        XCTAssertEqual(delegate.sent, [[0x0A]])
+    }
+
+    func testRepeatSendsCountTimesWithTheGap() async {
+        let (terminal, delegate) = makeTerminal()
+        let command = KeyCommand(
+            kind: .chord(KeyChord(modifiers: [.control], key: .character("c"))),
+            repeatCount: 2,
+            repeatGapMilliseconds: 50
+        )
+        let started = ContinuousClock.now
+        await KeyCommandDispatcher.perform(command, on: terminal)?.value
+        let elapsed = ContinuousClock.now - started
+        XCTAssertEqual(delegate.sent, [[0x03], [0x03]])
+        XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(45), "The second send waits out the gap")
+    }
+
+    func testTextRowTypesThenSubmitsAsASeparateWrite() async {
+        let (terminal, delegate) = makeTerminal()
+        let command = KeyCommand(kind: .text(KeyTextSnippet(text: "git status", submits: true)))
+        await KeyCommandDispatcher.perform(command, on: terminal)?.value
+        XCTAssertEqual(delegate.sent, [Array("git status".utf8), [0x0D]])
+
+        delegate.sent = []
+        let quiet = KeyCommand(kind: .text(KeyTextSnippet(text: "ls", submits: false)))
+        await KeyCommandDispatcher.perform(quiet, on: terminal)?.value
+        XCTAssertEqual(delegate.sent, [Array("ls".utf8)])
+    }
+
+    func testBlankTextRowSendsNothing() {
+        let (terminal, delegate) = makeTerminal()
+        let command = KeyCommand(kind: .text(KeyTextSnippet(text: "   ")))
+        XCTAssertNil(KeyCommandDispatcher.perform(command, on: terminal))
+        XCTAssertTrue(delegate.sent.isEmpty)
+    }
+
+    func testDescribeSpellsTheBytesInPlainWords() {
+        let (terminal, _) = makeTerminal()
+        XCTAssertEqual(
+            KeyCommandDispatcher.describe(KeyCommandSet.shipped[0], on: terminal),
+            "LF"
+        )
+        XCTAssertEqual(
+            KeyCommandDispatcher.describe(KeyCommandSet.shipped[1], on: terminal),
+            "^C"
+        )
+        XCTAssertEqual(
+            KeyCommandDispatcher.describe(
+                KeyCommand(kind: .text(KeyTextSnippet(text: "x"))),
+                on: terminal
+            ),
+            "TEXT · THEN CR 160 MS LATER"
+        )
+        XCTAssertEqual(
+            KeyCommandDispatcher.describe(KeyCommandSet.shipped[0], on: nil),
+            "NO ENCODING"
+        )
+    }
+}
+
+/// The panel: two tabs over one store, presses that send and close (or
+/// stay), a hold that opens the row's setup, and a draft transaction that
+/// commits only on DONE.
+@MainActor
+final class KeyCommandPanelUIKitTests: XCTestCase {
+    private var performed: [KeyCommand] = []
+    private var dismissals = 0
+
+    private func makePanel(
+        store providedStore: KeyCommandStore? = nil,
+        plan: KeyCommandPlan = .unrestricted
+    ) -> (KeyCommandPanelViewController, KeyCommandStore) {
+        let store = providedStore ?? KeyCommandStore(directory: nil)
+        performed = []
+        dismissals = 0
+        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 200))
+        let panel = KeyCommandPanelViewController(
+            store: store,
+            terminal: terminal,
+            plan: plan,
+            perform: { [weak self] command in self?.performed.append(command) },
+            dismiss: { [weak self] in self?.dismissals += 1 }
+        )
+        panel.loadViewIfNeeded()
+        panel.view.frame = CGRect(origin: .zero, size: panel.fittingContentSize())
+        panel.view.layoutIfNeeded()
+        return (panel, store)
+    }
+
+    private func descendants(in root: UIView) -> [UIView] {
+        root.subviews + root.subviews.flatMap(descendants(in:))
+    }
+
+    private func view(_ identifier: String, in panel: UIViewController) -> UIView? {
+        descendants(in: panel.view).first { $0.accessibilityIdentifier == identifier }
+    }
+
+    func testCommandsTabShowsEveryStoredRowAsACell() {
+        let (panel, store) = makePanel()
+        XCTAssertEqual(panel.selectedTab, .commands)
+        XCTAssertEqual(
+            panel.preferredContentSize,
+            panel.fittingContentSize(),
+            "Loading the view sizes the popover; the presenter measures nothing twice"
+        )
+        XCTAssertNotNil(view("keyCommands.title", in: panel))
+        XCTAssertNotNil(view("keyCommands.tab.commands", in: panel))
+        XCTAssertNotNil(view("keyCommands.tab.setup", in: panel))
+        let cells = descendants(in: panel.view).compactMap { $0 as? KeyCommandCell }
+        XCTAssertEqual(cells.count, store.commands.count)
+        XCTAssertEqual(
+            cells.map(\.accessibilityLabel),
+            [
+                "Shift Enter, closes the panel",
+                "Control C, 2 times, closes the panel",
+                "Option Delete, panel stays open",
+            ]
+        )
+        XCTAssertLessThanOrEqual(
+            panel.fittingContentSize().width,
+            KeyCommandPanelViewController.commandsWidth
+        )
+    }
+
+    func testPressSendsAndClosesOnlyWhenTheRowSaysSo() {
+        let (panel, store) = makePanel()
+        panel.press(store.commands[0])
+        XCTAssertEqual(performed.map(\.id), [store.commands[0].id])
+        XCTAssertEqual(dismissals, 1)
+
+        panel.press(store.commands[2])
+        XCTAssertEqual(performed.count, 2)
+        XCTAssertEqual(dismissals, 1, "The pinned Delete row keeps the panel up")
+
+        let cell = descendants(in: panel.view)
+            .compactMap { $0 as? KeyCommandCell }
+            .first { $0.accessibilityIdentifier == "keyCommands.cell.\(store.commands[2].id.uuidString)" }
+        XCTAssertNotNil(cell)
+        XCTAssertTrue(cell?.accessibilityActivate() ?? false)
+        XCTAssertEqual(performed.count, 3, "Accessibility activation is a press")
+    }
+
+    func testHoldOpensThatRowsSetup() {
+        let (panel, store) = makePanel()
+        panel.hold(store.commands[1])
+        XCTAssertEqual(panel.selectedTab, .setup)
+        XCTAssertEqual(panel.expandedID, store.commands[1].id)
+        XCTAssertEqual(panel.drafts, store.commands)
+        XCTAssertNotNil(view("keyCommands.composer", in: panel))
+        XCTAssertNotNil(view("keyCommands.rowHeader.\(store.commands[1].id.uuidString)", in: panel))
+        XCTAssertNotNil(view("keyCommands.done", in: panel))
+        XCTAssertNotNil(view("keyCommands.cancel", in: panel))
+        XCTAssertNotNil(view("keyCommands.add", in: panel))
+        XCTAssertGreaterThan(
+            panel.fittingContentSize().width,
+            KeyCommandPanelViewController.commandsWidth,
+            "Setup asks for the wider popover"
+        )
+    }
+
+    func testDraftsCommitOnDoneAndDiscardOnCancel() {
+        let (panel, store) = makePanel()
+        panel.selectTab(.setup)
+        let added = panel.addCommand()
+        XCTAssertNotNil(added)
+        XCTAssertEqual(panel.drafts.count, 4)
+        XCTAssertEqual(panel.expandedID, added?.id)
+        XCTAssertEqual(store.commands.count, 3, "Nothing reaches the store before DONE")
+
+        var edited = added!
+        edited.kind = .chord(KeyChord(modifiers: [.option], key: .enter))
+        edited.repeatCount = 3
+        panel.updateDraft(edited)
+        panel.moveCommand(id: edited.id, offset: -1)
+        XCTAssertEqual(panel.drafts.map(\.name), ["SHIFT ENTER", "CTRL C", "OPTION ENTER", "OPTION DELETE"])
+
+        panel.saveDrafts()
+        XCTAssertEqual(store.commands.map(\.name), ["SHIFT ENTER", "CTRL C", "OPTION ENTER", "OPTION DELETE"])
+        XCTAssertEqual(store.commands[2].repeatCount, 3)
+        XCTAssertFalse(store.commands[2].isShipped)
+        XCTAssertEqual(panel.selectedTab, .commands, "DONE lands back on the grid")
+        XCTAssertEqual(
+            descendants(in: panel.view).compactMap { $0 as? KeyCommandCell }.count,
+            4
+        )
+
+        panel.selectTab(.setup)
+        panel.deleteCommand(id: store.commands[0].id)
+        XCTAssertEqual(panel.drafts.count, 3)
+        panel.cancelDrafts()
+        XCTAssertEqual(store.commands.count, 4, "CANCEL discards the draft")
+        XCTAssertEqual(panel.selectedTab, .commands)
+    }
+
+    func testNarrowPanelWrapsTheComposerInsteadOfClipping() {
+        let store = KeyCommandStore(directory: nil)
+        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 200))
+        let panel = KeyCommandPanelViewController(
+            store: store,
+            terminal: terminal,
+            maximumWidth: 366,
+            perform: { _ in },
+            dismiss: {}
+        )
+        panel.loadViewIfNeeded()
+        XCTAssertEqual(panel.fittingContentSize().width, 366)
+        panel.hold(store.commands[0])
+        let size = panel.fittingContentSize()
+        XCTAssertEqual(size.width, 366, "A phone popover never widens past the scene")
+        panel.view.frame = CGRect(origin: .zero, size: size)
+        panel.view.layoutIfNeeded()
+        let composer = descendants(in: panel.view).compactMap { $0 as? KeyCommandComposerView }.first
+        XCTAssertNotNil(composer)
+        // Every keycap in the composer stays inside the panel's bounds.
+        for cap in descendants(in: panel.view).compactMap({ $0 as? KeyCapControl }) {
+            let frame = cap.convert(cap.bounds, to: panel.view)
+            XCTAssertLessThanOrEqual(frame.maxX, size.width + 0.5, "\(cap.accessibilityLabel ?? "") clips")
+            XCTAssertGreaterThanOrEqual(frame.minX, -0.5)
+        }
+        // The direction keys and the letter field take the second line.
+        let enter = view("keyCommands.composer.key.enter", in: panel)
+        let up = view("keyCommands.composer.key.up", in: panel)
+        let field = view("keyCommands.composer.character", in: panel)
+        let enterY = enter.map { $0.convert($0.bounds, to: panel.view).minY } ?? 0
+        let upY = up.map { $0.convert($0.bounds, to: panel.view).minY } ?? 0
+        let fieldY = field.map { $0.convert($0.bounds, to: panel.view).minY } ?? 0
+        XCTAssertGreaterThan(upY, enterY + 10, "Arrows drop to the second line on a phone")
+        XCTAssertEqual(fieldY, upY, accuracy: 6, "The letter field sits with the arrows")
+        // The second line hangs flush with the editing keys' right edge.
+        let space = view("keyCommands.composer.key.space", in: panel)
+        let spaceMaxX = space.map { $0.convert($0.bounds, to: panel.view).maxX } ?? 0
+        let fieldMaxX = field.map { $0.convert($0.bounds, to: panel.view).maxX } ?? 0
+        XCTAssertGreaterThan(spaceMaxX, 0)
+        XCTAssertEqual(fieldMaxX, spaceMaxX, accuracy: 0.5, "The second line aligns right, under the editing keys")
+    }
+
+    func testMacScaleGrowsTheControlsAndWrapsTheComposer() {
+        KeyCommandMetrics.scaleOverride = 1.3
+        defer { KeyCommandMetrics.scaleOverride = nil }
+        let store = KeyCommandStore(directory: nil)
+        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 200))
+        let panel = KeyCommandPanelViewController(
+            store: store,
+            terminal: terminal,
+            perform: { _ in },
+            dismiss: {}
+        )
+        panel.loadViewIfNeeded()
+        panel.hold(store.commands[0])
+        let size = panel.fittingContentSize()
+        XCTAssertEqual(size.width, KeyCommandPanelViewController.setupWidth)
+        panel.view.frame = CGRect(origin: .zero, size: size)
+        panel.view.layoutIfNeeded()
+        let caps = descendants(in: panel.view).compactMap { $0 as? KeyCapControl }
+        XCTAssertFalse(caps.isEmpty)
+        for cap in caps {
+            let frame = cap.convert(cap.bounds, to: panel.view)
+            XCTAssertEqual(frame.height, ceil(26 * 1.3), accuracy: 0.5, "Composer keycaps grow with the scale")
+            XCTAssertLessThanOrEqual(frame.maxX, size.width + 0.5, "\(cap.accessibilityLabel ?? "") clips at Mac scale")
+        }
+        let switches = descendants(in: panel.view).compactMap { $0 as? TallyEditorSwitchTrack }
+        XCTAssertFalse(switches.isEmpty)
+        for track in switches {
+            XCTAssertEqual(track.bounds.height, ceil(14 * 1.3), accuracy: 0.5)
+        }
+    }
+
+    private func filledStore(count: Int) -> KeyCommandStore {
+        let store = KeyCommandStore(directory: nil)
+        store.replace((0..<count).map { index in
+            KeyCommand(kind: .chord(KeyChord(key: .character(String(index % 10)))))
+        })
+        return store
+    }
+
+    func testAddStopsAtTheCap() throws {
+        let (panel, _) = makePanel(store: filledStore(count: KeyCommandSet.maximumCount))
+        panel.selectTab(.setup)
+        XCTAssertFalse(panel.canAddCommand)
+        XCTAssertFalse(panel.addNeedsPro, "The model's cap is a wall, not a Pro route")
+        XCTAssertNil(panel.addCommand())
+        XCTAssertEqual(panel.drafts.count, KeyCommandSet.maximumCount)
+        let add = try XCTUnwrap(view("keyCommands.add", in: panel))
+        XCTAssertFalse(add.isUserInteractionEnabled)
+        XCTAssertNil(view("keyCommands.legend.tier", in: panel), "An unrestricted plan shows no tier line")
+    }
+
+    func testFreePlanAddTurnsIntoTheProRouteAtItsCap() throws {
+        var upgrades = 0
+        let plan = KeyCommandPlan(limit: 5, upgrade: { upgrades += 1 })
+        let (panel, store) = makePanel(store: filledStore(count: 4), plan: plan)
+        panel.selectTab(.setup)
+        XCTAssertEqual(panel.limit, 5)
+        XCTAssertTrue(panel.canAddCommand)
+        XCTAssertNotNil(view("keyCommands.legend.tier", in: panel), "The free tier says why the cap is 5")
+        let readout = try XCTUnwrap(view("keyCommands.readout", in: panel) as? UILabel)
+        XCTAssertEqual(readout.text, "ALL HOSTS · 4 OF 5")
+
+        // The fifth is free; ADD then becomes the Pro route.
+        panel.addOrUpgrade()
+        XCTAssertEqual(panel.drafts.count, 5)
+        XCTAssertEqual(upgrades, 0)
+        XCTAssertFalse(panel.canAddCommand)
+        XCTAssertTrue(panel.addNeedsPro)
+        XCTAssertEqual((view("keyCommands.readout", in: panel) as? UILabel)?.text, "ALL HOSTS · 5 OF 5")
+        let add = try XCTUnwrap(view("keyCommands.add", in: panel) as? UIKitChassisChip)
+        XCTAssertTrue(add.isUserInteractionEnabled, "The route stays live at the tier's cap")
+        XCTAssertTrue(add.isProminent)
+        XCTAssertEqual(add.accessibilityLabel, "Add command with Multiplex Pro")
+        panel.addOrUpgrade()
+        XCTAssertEqual(upgrades, 1)
+        XCTAssertEqual(panel.drafts.count, 5, "The route adds nothing")
+        XCTAssertNil(panel.addCommand(), "Nor does a direct add past the tier's cap")
+
+        // DONE keeps the five; the plan never trims a set.
+        panel.saveDrafts()
+        XCTAssertEqual(store.commands.count, 5)
+    }
+
+    func testFreePlanKeepsASyncedSetAboveItsCap() {
+        var upgrades = 0
+        let plan = KeyCommandPlan(limit: 5, upgrade: { upgrades += 1 })
+        let (panel, store) = makePanel(store: filledStore(count: 8), plan: plan)
+        XCTAssertEqual(
+            descendants(in: panel.view).compactMap { $0 as? KeyCommandCell }.count,
+            8,
+            "Every synced row stays pressable"
+        )
+        panel.selectTab(.setup)
+        XCTAssertEqual(panel.drafts.count, 8)
+        XCTAssertFalse(panel.canAddCommand)
+        XCTAssertTrue(panel.addNeedsPro)
+        panel.addOrUpgrade()
+        XCTAssertEqual(upgrades, 1)
+        panel.saveDrafts()
+        XCTAssertEqual(store.commands.count, 8, "Saving never trims to the tier")
+    }
+
+    func testComposerWritesTheDraftAndClampsRepeats() throws {
+        let (panel, store) = makePanel()
+        panel.hold(store.commands[0])
+        let composerView = try XCTUnwrap(
+            descendants(in: panel.view).compactMap { $0 as? KeyCommandComposerView }.first
+        )
+
+        composerView.toggleModifier(.control)
+        composerView.selectKey(.left)
+        composerView.setRepeatCount(5)
+        composerView.setRepeatGap(500)
+        composerView.setClosesPanel(false)
+        let draft = panel.drafts[0]
+        XCTAssertEqual(draft.chord, KeyChord(modifiers: [.control, .shift], key: .left))
+        XCTAssertEqual(draft.repeatCount, 5)
+        XCTAssertEqual(draft.repeatGapMilliseconds, 500)
+        XCTAssertFalse(draft.closesPanel)
+        XCTAssertEqual(draft.readout, "×5 · 500 MS · STAYS")
+
+        composerView.setKind(isText: true)
+        composerView.setText("git status")
+        composerView.setSubmits(false)
+        let text = panel.drafts[0]
+        XCTAssertEqual(text.textSnippet, KeyTextSnippet(text: "git status", submits: false))
+        XCTAssertEqual(text.name, "git status")
+
+        composerView.setKind(isText: false)
+        XCTAssertEqual(panel.drafts[0].chord, KeyChord(key: .enter), "Back to KEYS starts from a plain Enter")
+        XCTAssertNotNil(view("keyCommands.composer.modifier.ctrl", in: panel))
+        XCTAssertNotNil(view("keyCommands.composer.key.enter", in: panel))
+        XCTAssertNotNil(view("keyCommands.composer.character", in: panel))
+        XCTAssertNotNil(view("keyCommands.switch.close on press", in: panel))
+    }
+}

--- a/MultiplexTests/KeyCommandPanelUIKitTests.swift
+++ b/MultiplexTests/KeyCommandPanelUIKitTests.swift
@@ -79,8 +79,8 @@ final class KeyCommandDispatcherTests: XCTestCase {
 }
 
 /// The panel: two tabs over one store, presses that send and close (or
-/// stay), a hold that opens the row's setup, and a draft transaction that
-/// commits only on DONE.
+/// stay), a hold that opens the row's setup, a draft transaction that
+/// commits only on DONE, the tier's cap, and the composer's layouts.
 @MainActor
 final class KeyCommandPanelUIKitTests: XCTestCase {
     private var performed: [KeyCommand] = []
@@ -88,6 +88,7 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
 
     private func makePanel(
         store providedStore: KeyCommandStore? = nil,
+        maximumWidth: CGFloat = KeyCommandPanelViewController.setupWidth,
         plan: KeyCommandPlan = .unrestricted
     ) -> (KeyCommandPanelViewController, KeyCommandStore) {
         let store = providedStore ?? KeyCommandStore(directory: nil)
@@ -97,14 +98,27 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
         let panel = KeyCommandPanelViewController(
             store: store,
             terminal: terminal,
+            maximumWidth: maximumWidth,
             plan: plan,
             perform: { [weak self] command in self?.performed.append(command) },
             dismiss: { [weak self] in self?.dismissals += 1 }
         )
         panel.loadViewIfNeeded()
+        layout(panel)
+        return (panel, store)
+    }
+
+    private func layout(_ panel: KeyCommandPanelViewController) {
         panel.view.frame = CGRect(origin: .zero, size: panel.fittingContentSize())
         panel.view.layoutIfNeeded()
-        return (panel, store)
+    }
+
+    private func filledStore(count: Int) -> KeyCommandStore {
+        let store = KeyCommandStore(directory: nil)
+        store.replace((0..<count).map { index in
+            KeyCommand(kind: .chord(KeyChord(key: .character(String(index % 10)))))
+        })
+        return store
     }
 
     private func descendants(in root: UIView) -> [UIView] {
@@ -113,6 +127,31 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
 
     private func view(_ identifier: String, in panel: UIViewController) -> UIView? {
         descendants(in: panel.view).first { $0.accessibilityIdentifier == identifier }
+    }
+
+    private func frame(_ identifier: String, in panel: UIViewController) -> CGRect {
+        view(identifier, in: panel).map { $0.convert($0.bounds, to: panel.view) } ?? .null
+    }
+
+    /// Every keycap in the composer stays inside the panel's bounds.
+    private func assertNoKeycapClips(
+        in panel: KeyCommandPanelViewController,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let caps = descendants(in: panel.view).compactMap { $0 as? KeyCapControl }
+        XCTAssertFalse(caps.isEmpty, file: file, line: line)
+        for cap in caps {
+            let frame = cap.convert(cap.bounds, to: panel.view)
+            XCTAssertLessThanOrEqual(
+                frame.maxX,
+                panel.view.bounds.width + 0.5,
+                "\(cap.accessibilityLabel ?? "") clips",
+                file: file,
+                line: line
+            )
+            XCTAssertGreaterThanOrEqual(frame.minX, -0.5, file: file, line: line)
+        }
     }
 
     func testCommandsTabShowsEveryStoredRowAsACell() {
@@ -136,13 +175,10 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
                 "Option Delete, panel stays open",
             ]
         )
-        XCTAssertLessThanOrEqual(
-            panel.fittingContentSize().width,
-            KeyCommandPanelViewController.commandsWidth
-        )
+        XCTAssertLessThanOrEqual(panel.fittingContentSize().width, KeyCommandPanelViewController.commandsWidth)
     }
 
-    func testPressSendsAndClosesOnlyWhenTheRowSaysSo() {
+    func testPressSendsAndClosesAsTheRowSaysAndHoldOpensItsSetup() {
         let (panel, store) = makePanel()
         panel.press(store.commands[0])
         XCTAssertEqual(performed.map(\.id), [store.commands[0].id])
@@ -155,13 +191,9 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
         let cell = descendants(in: panel.view)
             .compactMap { $0 as? KeyCommandCell }
             .first { $0.accessibilityIdentifier == "keyCommands.cell.\(store.commands[2].id.uuidString)" }
-        XCTAssertNotNil(cell)
         XCTAssertTrue(cell?.accessibilityActivate() ?? false)
         XCTAssertEqual(performed.count, 3, "Accessibility activation is a press")
-    }
 
-    func testHoldOpensThatRowsSetup() {
-        let (panel, store) = makePanel()
         panel.hold(store.commands[1])
         XCTAssertEqual(panel.selectedTab, .setup)
         XCTAssertEqual(panel.expandedID, store.commands[1].id)
@@ -170,7 +202,6 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
         XCTAssertNotNil(view("keyCommands.rowHeader.\(store.commands[1].id.uuidString)", in: panel))
         XCTAssertNotNil(view("keyCommands.done", in: panel))
         XCTAssertNotNil(view("keyCommands.cancel", in: panel))
-        XCTAssertNotNil(view("keyCommands.add", in: panel))
         XCTAssertGreaterThan(
             panel.fittingContentSize().width,
             KeyCommandPanelViewController.commandsWidth,
@@ -199,10 +230,7 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
         XCTAssertEqual(store.commands[2].repeatCount, 3)
         XCTAssertFalse(store.commands[2].isShipped)
         XCTAssertEqual(panel.selectedTab, .commands, "DONE lands back on the grid")
-        XCTAssertEqual(
-            descendants(in: panel.view).compactMap { $0 as? KeyCommandCell }.count,
-            4
-        )
+        XCTAssertEqual(descendants(in: panel.view).compactMap { $0 as? KeyCommandCell }.count, 4)
 
         panel.selectTab(.setup)
         panel.deleteCommand(id: store.commands[0].id)
@@ -210,150 +238,6 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
         panel.cancelDrafts()
         XCTAssertEqual(store.commands.count, 4, "CANCEL discards the draft")
         XCTAssertEqual(panel.selectedTab, .commands)
-    }
-
-    func testNarrowPanelWrapsTheComposerInsteadOfClipping() {
-        let store = KeyCommandStore(directory: nil)
-        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 200))
-        let panel = KeyCommandPanelViewController(
-            store: store,
-            terminal: terminal,
-            maximumWidth: 366,
-            perform: { _ in },
-            dismiss: {}
-        )
-        panel.loadViewIfNeeded()
-        XCTAssertEqual(panel.fittingContentSize().width, 366)
-        panel.hold(store.commands[0])
-        let size = panel.fittingContentSize()
-        XCTAssertEqual(size.width, 366, "A phone popover never widens past the scene")
-        panel.view.frame = CGRect(origin: .zero, size: size)
-        panel.view.layoutIfNeeded()
-        let composer = descendants(in: panel.view).compactMap { $0 as? KeyCommandComposerView }.first
-        XCTAssertNotNil(composer)
-        // Every keycap in the composer stays inside the panel's bounds.
-        for cap in descendants(in: panel.view).compactMap({ $0 as? KeyCapControl }) {
-            let frame = cap.convert(cap.bounds, to: panel.view)
-            XCTAssertLessThanOrEqual(frame.maxX, size.width + 0.5, "\(cap.accessibilityLabel ?? "") clips")
-            XCTAssertGreaterThanOrEqual(frame.minX, -0.5)
-        }
-        // The direction keys and the letter field take the second line.
-        let enter = view("keyCommands.composer.key.enter", in: panel)
-        let up = view("keyCommands.composer.key.up", in: panel)
-        let field = view("keyCommands.composer.character", in: panel)
-        let enterY = enter.map { $0.convert($0.bounds, to: panel.view).minY } ?? 0
-        let upY = up.map { $0.convert($0.bounds, to: panel.view).minY } ?? 0
-        let fieldY = field.map { $0.convert($0.bounds, to: panel.view).minY } ?? 0
-        XCTAssertGreaterThan(upY, enterY + 10, "Arrows drop to the second line on a phone")
-        XCTAssertEqual(fieldY, upY, accuracy: 6, "The letter field sits with the arrows")
-        // The second line hangs flush with the editing keys' right edge.
-        let space = view("keyCommands.composer.key.space", in: panel)
-        let spaceMaxX = space.map { $0.convert($0.bounds, to: panel.view).maxX } ?? 0
-        let fieldMaxX = field.map { $0.convert($0.bounds, to: panel.view).maxX } ?? 0
-        XCTAssertGreaterThan(spaceMaxX, 0)
-        XCTAssertEqual(fieldMaxX, spaceMaxX, accuracy: 0.5, "The second line aligns right, under the editing keys")
-    }
-
-    func testMacScaleGrowsTheControlsAndWrapsTheComposer() {
-        KeyCommandMetrics.scaleOverride = 1.3
-        defer { KeyCommandMetrics.scaleOverride = nil }
-        let store = KeyCommandStore(directory: nil)
-        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 400, height: 200))
-        let panel = KeyCommandPanelViewController(
-            store: store,
-            terminal: terminal,
-            perform: { _ in },
-            dismiss: {}
-        )
-        panel.loadViewIfNeeded()
-        panel.hold(store.commands[0])
-        let size = panel.fittingContentSize()
-        XCTAssertEqual(size.width, KeyCommandPanelViewController.setupWidth)
-        panel.view.frame = CGRect(origin: .zero, size: size)
-        panel.view.layoutIfNeeded()
-        let caps = descendants(in: panel.view).compactMap { $0 as? KeyCapControl }
-        XCTAssertFalse(caps.isEmpty)
-        for cap in caps {
-            let frame = cap.convert(cap.bounds, to: panel.view)
-            XCTAssertEqual(frame.height, ceil(26 * 1.3), accuracy: 0.5, "Composer keycaps grow with the scale")
-            XCTAssertLessThanOrEqual(frame.maxX, size.width + 0.5, "\(cap.accessibilityLabel ?? "") clips at Mac scale")
-        }
-        let switches = descendants(in: panel.view).compactMap { $0 as? TallyEditorSwitchTrack }
-        XCTAssertFalse(switches.isEmpty)
-        for track in switches {
-            XCTAssertEqual(track.bounds.height, ceil(14 * 1.3), accuracy: 0.5)
-        }
-    }
-
-    private func filledStore(count: Int) -> KeyCommandStore {
-        let store = KeyCommandStore(directory: nil)
-        store.replace((0..<count).map { index in
-            KeyCommand(kind: .chord(KeyChord(key: .character(String(index % 10)))))
-        })
-        return store
-    }
-
-    func testAddStopsAtTheCap() throws {
-        let (panel, _) = makePanel(store: filledStore(count: KeyCommandSet.maximumCount))
-        panel.selectTab(.setup)
-        XCTAssertFalse(panel.canAddCommand)
-        XCTAssertFalse(panel.addNeedsPro, "The model's cap is a wall, not a Pro route")
-        XCTAssertNil(panel.addCommand())
-        XCTAssertEqual(panel.drafts.count, KeyCommandSet.maximumCount)
-        let add = try XCTUnwrap(view("keyCommands.add", in: panel))
-        XCTAssertFalse(add.isUserInteractionEnabled)
-        XCTAssertNil(view("keyCommands.legend.tier", in: panel), "An unrestricted plan shows no tier line")
-    }
-
-    func testFreePlanAddTurnsIntoTheProRouteAtItsCap() throws {
-        var upgrades = 0
-        let plan = KeyCommandPlan(limit: 5, upgrade: { upgrades += 1 })
-        let (panel, store) = makePanel(store: filledStore(count: 4), plan: plan)
-        panel.selectTab(.setup)
-        XCTAssertEqual(panel.limit, 5)
-        XCTAssertTrue(panel.canAddCommand)
-        XCTAssertNotNil(view("keyCommands.legend.tier", in: panel), "The free tier says why the cap is 5")
-        let readout = try XCTUnwrap(view("keyCommands.readout", in: panel) as? UILabel)
-        XCTAssertEqual(readout.text, "ALL HOSTS · 4 OF 5")
-
-        // The fifth is free; ADD then becomes the Pro route.
-        panel.addOrUpgrade()
-        XCTAssertEqual(panel.drafts.count, 5)
-        XCTAssertEqual(upgrades, 0)
-        XCTAssertFalse(panel.canAddCommand)
-        XCTAssertTrue(panel.addNeedsPro)
-        XCTAssertEqual((view("keyCommands.readout", in: panel) as? UILabel)?.text, "ALL HOSTS · 5 OF 5")
-        let add = try XCTUnwrap(view("keyCommands.add", in: panel) as? UIKitChassisChip)
-        XCTAssertTrue(add.isUserInteractionEnabled, "The route stays live at the tier's cap")
-        XCTAssertTrue(add.isProminent)
-        XCTAssertEqual(add.accessibilityLabel, "Add command with Multiplex Pro")
-        panel.addOrUpgrade()
-        XCTAssertEqual(upgrades, 1)
-        XCTAssertEqual(panel.drafts.count, 5, "The route adds nothing")
-        XCTAssertNil(panel.addCommand(), "Nor does a direct add past the tier's cap")
-
-        // DONE keeps the five; the plan never trims a set.
-        panel.saveDrafts()
-        XCTAssertEqual(store.commands.count, 5)
-    }
-
-    func testFreePlanKeepsASyncedSetAboveItsCap() {
-        var upgrades = 0
-        let plan = KeyCommandPlan(limit: 5, upgrade: { upgrades += 1 })
-        let (panel, store) = makePanel(store: filledStore(count: 8), plan: plan)
-        XCTAssertEqual(
-            descendants(in: panel.view).compactMap { $0 as? KeyCommandCell }.count,
-            8,
-            "Every synced row stays pressable"
-        )
-        panel.selectTab(.setup)
-        XCTAssertEqual(panel.drafts.count, 8)
-        XCTAssertFalse(panel.canAddCommand)
-        XCTAssertTrue(panel.addNeedsPro)
-        panel.addOrUpgrade()
-        XCTAssertEqual(upgrades, 1)
-        panel.saveDrafts()
-        XCTAssertEqual(store.commands.count, 8, "Saving never trims to the tier")
     }
 
     func testComposerWritesTheDraftAndClampsRepeats() throws {
@@ -388,5 +272,88 @@ final class KeyCommandPanelUIKitTests: XCTestCase {
         XCTAssertNotNil(view("keyCommands.composer.key.enter", in: panel))
         XCTAssertNotNil(view("keyCommands.composer.character", in: panel))
         XCTAssertNotNil(view("keyCommands.switch.close on press", in: panel))
+    }
+
+    /// The tier's cap turns ADD COMMAND into the Pro route; the model's cap
+    /// is a wall; a set that already holds more than the tier allows is kept.
+    func testAddIsCappedByTheTierThenTheModel() throws {
+        var upgrades = 0
+        let free = KeyCommandPlan(limit: 5, upgrade: { upgrades += 1 })
+        let (panel, store) = makePanel(store: filledStore(count: 4), plan: free)
+        panel.selectTab(.setup)
+        XCTAssertEqual(panel.limit, 5)
+        XCTAssertNotNil(view("keyCommands.legend.tier", in: panel), "The free tier says why the cap is 5")
+        XCTAssertEqual((view("keyCommands.readout", in: panel) as? UILabel)?.text, "ALL HOSTS · 4 OF 5")
+
+        // The fifth is free; ADD then becomes the Pro route.
+        panel.addOrUpgrade()
+        XCTAssertEqual(panel.drafts.count, 5)
+        XCTAssertEqual(upgrades, 0)
+        XCTAssertFalse(panel.canAddCommand)
+        XCTAssertTrue(panel.addNeedsPro)
+        XCTAssertEqual((view("keyCommands.readout", in: panel) as? UILabel)?.text, "ALL HOSTS · 5 OF 5")
+        let add = try XCTUnwrap(view("keyCommands.add", in: panel) as? UIKitChassisChip)
+        XCTAssertTrue(add.isUserInteractionEnabled, "The route stays live at the tier's cap")
+        XCTAssertTrue(add.isProminent)
+        XCTAssertEqual(add.accessibilityLabel, "Add command with Multiplex Pro")
+        panel.addOrUpgrade()
+        XCTAssertEqual(upgrades, 1)
+        XCTAssertNil(panel.addCommand(), "Neither route adds past the tier's cap")
+        XCTAssertEqual(panel.drafts.count, 5)
+        panel.saveDrafts()
+        XCTAssertEqual(store.commands.count, 5)
+
+        // A synced set above the tier keeps every row; only adding is gated.
+        let (synced, syncedStore) = makePanel(store: filledStore(count: 8), plan: free)
+        XCTAssertEqual(descendants(in: synced.view).compactMap { $0 as? KeyCommandCell }.count, 8)
+        synced.selectTab(.setup)
+        XCTAssertTrue(synced.addNeedsPro)
+        synced.saveDrafts()
+        XCTAssertEqual(syncedStore.commands.count, 8, "Saving never trims to the tier")
+
+        // The model's cap dims the chip instead — no route, no tier line.
+        let (full, _) = makePanel(store: filledStore(count: KeyCommandSet.maximumCount))
+        full.selectTab(.setup)
+        XCTAssertFalse(full.canAddCommand)
+        XCTAssertFalse(full.addNeedsPro)
+        XCTAssertNil(full.addCommand())
+        XCTAssertFalse(try XCTUnwrap(view("keyCommands.add", in: full)).isUserInteractionEnabled)
+        XCTAssertNil(view("keyCommands.legend.tier", in: full))
+    }
+
+    /// A phone popover wraps the composer's keys onto two lines (the second
+    /// hanging flush-right under the editing keys); the Mac's larger scale
+    /// grows the controls; neither clips a keycap.
+    func testCompactAndScaledComposersStayInsideThePanel() {
+        let (phone, phoneStore) = makePanel(maximumWidth: 366)
+        XCTAssertEqual(phone.fittingContentSize().width, 366)
+        phone.hold(phoneStore.commands[0])
+        layout(phone)
+        XCTAssertEqual(phone.view.bounds.width, 366, "A phone popover never widens past the scene")
+        assertNoKeycapClips(in: phone)
+        let enter = frame("keyCommands.composer.key.enter", in: phone)
+        let up = frame("keyCommands.composer.key.up", in: phone)
+        let field = frame("keyCommands.composer.character", in: phone)
+        let space = frame("keyCommands.composer.key.space", in: phone)
+        XCTAssertGreaterThan(up.minY, enter.minY + 10, "Arrows drop to the second line on a phone")
+        XCTAssertEqual(field.minY, up.minY, accuracy: 6, "The letter field sits with the arrows")
+        XCTAssertGreaterThan(space.maxX, 0)
+        XCTAssertEqual(field.maxX, space.maxX, accuracy: 0.5, "The second line aligns right, under the editing keys")
+
+        KeyCommandMetrics.scaleOverride = 1.3
+        defer { KeyCommandMetrics.scaleOverride = nil }
+        let (mac, macStore) = makePanel()
+        mac.hold(macStore.commands[0])
+        layout(mac)
+        XCTAssertEqual(mac.view.bounds.width, KeyCommandPanelViewController.setupWidth)
+        assertNoKeycapClips(in: mac)
+        for cap in descendants(in: mac.view).compactMap({ $0 as? KeyCapControl }) {
+            XCTAssertEqual(cap.bounds.height, ceil(26 * 1.3), accuracy: 0.5, "Composer keycaps grow with the scale")
+        }
+        let switches = descendants(in: mac.view).compactMap { $0 as? TallyEditorSwitchTrack }
+        XCTAssertFalse(switches.isEmpty)
+        for track in switches {
+            XCTAssertEqual(track.bounds.height, ceil(14 * 1.3), accuracy: 0.5)
+        }
     }
 }

--- a/MultiplexTests/KeyCommandRailHookTests.swift
+++ b/MultiplexTests/KeyCommandRailHookTests.swift
@@ -1,0 +1,72 @@
+import SwiftTerm
+import UIKit
+import XCTest
+@testable import Multiplex
+
+/// The rail's CTRL key carries the Key Commands hold on both platforms —
+/// shorter than the keyboard key's lock hold, and separate from the tap
+/// that latches.
+@MainActor
+final class KeyCommandRailHookTests: XCTestCase {
+    #if os(visionOS)
+    func testClusterControlKeyHoldsIntoKeyCommands() {
+        let context = TerminalKeyClusterContext()
+        let group = TerminalKeyClusterGroupView(role: .leading, metric: .regular, context: context)
+        let control = group.keys.first { $0.accessibilityIdentifier == "terminal.keyCluster.control" }
+        XCTAssertNotNil(control?.longPressAction, "Hold CTRL opens Key Commands")
+        XCTAssertEqual(
+            control?.longPressDuration,
+            KeyCommandPanelViewController.controlHoldDuration
+        )
+        let escape = group.keys.first { $0.accessibilityIdentifier == "terminal.keyCluster.escape" }
+        XCTAssertNil(escape?.longPressAction)
+    }
+    #else
+    func testRailControlKeyHoldsIntoKeyCommands() {
+        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 600, height: 200))
+        let bar = TerminalKeyBar(
+            terminal: terminal,
+            controller: nil,
+            performShortcut: { _ in },
+            finishTmuxCopyMode: {},
+            shortcutBackend: .tmux
+        )
+        bar.frame = CGRect(x: 0, y: 0, width: 600, height: TerminalKeyBar.barHeight)
+        bar.layoutIfNeeded()
+        let control = bar.renderedKeys.first { $0.accessibilityIdentifier == "terminal.keybar.control" }
+        XCTAssertNotNil(control?.longPressAction, "Hold CTRL opens Key Commands")
+        XCTAssertEqual(
+            control?.longPressDuration,
+            KeyCommandPanelViewController.controlHoldDuration
+        )
+        let escape = bar.renderedKeys.first { $0.accessibilityIdentifier == "terminal.keybar.escape" }
+        XCTAssertNil(escape?.longPressAction)
+        XCTAssertEqual(control?.accessibilityLabel, "Control", "The tap's label is unchanged")
+    }
+    #endif
+
+    func testControlHoldIsShorterThanTheKeyboardLockHold() {
+        XCTAssertLessThan(KeyCommandPanelViewController.controlHoldDuration, 0.5)
+        XCTAssertGreaterThanOrEqual(KeyCommandPanelViewController.controlHoldDuration, 0.25)
+        let key = TerminalTallyKeyControl(
+            face: .text("CTRL", font: UIKitChassis.monoFont(11, weight: .semibold), kerning: 1.1),
+            width: 46,
+            height: 34,
+            accessibilityLabel: "Control",
+            accessibilityIdentifier: "test.control",
+            longPressAction: {},
+            action: {}
+        )
+        XCTAssertEqual(key.longPressDuration, 0.5, "The default hold is the keyboard key's lock hold")
+        key.longPressDuration = KeyCommandPanelViewController.controlHoldDuration
+        // UIKit installs recognizers of its own on a UIControl; the key's is
+        // the one carrying the hold it was given.
+        let holds = (key.gestureRecognizers ?? [])
+            .compactMap { $0 as? UILongPressGestureRecognizer }
+            .map(\.minimumPressDuration)
+        XCTAssertTrue(
+            holds.contains(KeyCommandPanelViewController.controlHoldDuration),
+            "The hold recognizer follows longPressDuration: \(holds)"
+        )
+    }
+}

--- a/MultiplexTests/KeyCommandRailHookTests.swift
+++ b/MultiplexTests/KeyCommandRailHookTests.swift
@@ -8,18 +8,32 @@ import XCTest
 /// that latches.
 @MainActor
 final class KeyCommandRailHookTests: XCTestCase {
+    private func assertControlKeyHoldsIntoKeyCommands(
+        control: TerminalTallyKeyControl?,
+        escape: TerminalTallyKeyControl?
+    ) {
+        XCTAssertNotNil(control?.longPressAction, "Hold CTRL opens Key Commands")
+        XCTAssertNil(escape?.longPressAction)
+        let hold = KeyCommandPanelViewController.controlHoldDuration
+        XCTAssertEqual(control?.longPressDuration, hold)
+        XCTAssertLessThan(hold, 0.5, "Shorter than the keyboard key's lock hold")
+        XCTAssertGreaterThanOrEqual(hold, 0.25)
+        // UIKit installs recognizers of its own on a UIControl; the key's is
+        // the one carrying the hold it was given.
+        let holds = (control?.gestureRecognizers ?? [])
+            .compactMap { $0 as? UILongPressGestureRecognizer }
+            .map(\.minimumPressDuration)
+        XCTAssertTrue(holds.contains(hold), "The hold recognizer follows longPressDuration: \(holds)")
+    }
+
     #if os(visionOS)
     func testClusterControlKeyHoldsIntoKeyCommands() {
         let context = TerminalKeyClusterContext()
         let group = TerminalKeyClusterGroupView(role: .leading, metric: .regular, context: context)
-        let control = group.keys.first { $0.accessibilityIdentifier == "terminal.keyCluster.control" }
-        XCTAssertNotNil(control?.longPressAction, "Hold CTRL opens Key Commands")
-        XCTAssertEqual(
-            control?.longPressDuration,
-            KeyCommandPanelViewController.controlHoldDuration
+        assertControlKeyHoldsIntoKeyCommands(
+            control: group.keys.first { $0.accessibilityIdentifier == "terminal.keyCluster.control" },
+            escape: group.keys.first { $0.accessibilityIdentifier == "terminal.keyCluster.escape" }
         )
-        let escape = group.keys.first { $0.accessibilityIdentifier == "terminal.keyCluster.escape" }
-        XCTAssertNil(escape?.longPressAction)
     }
     #else
     func testRailControlKeyHoldsIntoKeyCommands() {
@@ -34,39 +48,11 @@ final class KeyCommandRailHookTests: XCTestCase {
         bar.frame = CGRect(x: 0, y: 0, width: 600, height: TerminalKeyBar.barHeight)
         bar.layoutIfNeeded()
         let control = bar.renderedKeys.first { $0.accessibilityIdentifier == "terminal.keybar.control" }
-        XCTAssertNotNil(control?.longPressAction, "Hold CTRL opens Key Commands")
-        XCTAssertEqual(
-            control?.longPressDuration,
-            KeyCommandPanelViewController.controlHoldDuration
+        assertControlKeyHoldsIntoKeyCommands(
+            control: control,
+            escape: bar.renderedKeys.first { $0.accessibilityIdentifier == "terminal.keybar.escape" }
         )
-        let escape = bar.renderedKeys.first { $0.accessibilityIdentifier == "terminal.keybar.escape" }
-        XCTAssertNil(escape?.longPressAction)
         XCTAssertEqual(control?.accessibilityLabel, "Control", "The tap's label is unchanged")
     }
     #endif
-
-    func testControlHoldIsShorterThanTheKeyboardLockHold() {
-        XCTAssertLessThan(KeyCommandPanelViewController.controlHoldDuration, 0.5)
-        XCTAssertGreaterThanOrEqual(KeyCommandPanelViewController.controlHoldDuration, 0.25)
-        let key = TerminalTallyKeyControl(
-            face: .text("CTRL", font: UIKitChassis.monoFont(11, weight: .semibold), kerning: 1.1),
-            width: 46,
-            height: 34,
-            accessibilityLabel: "Control",
-            accessibilityIdentifier: "test.control",
-            longPressAction: {},
-            action: {}
-        )
-        XCTAssertEqual(key.longPressDuration, 0.5, "The default hold is the keyboard key's lock hold")
-        key.longPressDuration = KeyCommandPanelViewController.controlHoldDuration
-        // UIKit installs recognizers of its own on a UIControl; the key's is
-        // the one carrying the hold it was given.
-        let holds = (key.gestureRecognizers ?? [])
-            .compactMap { $0 as? UILongPressGestureRecognizer }
-            .map(\.minimumPressDuration)
-        XCTAssertTrue(
-            holds.contains(KeyCommandPanelViewController.controlHoldDuration),
-            "The hold recognizer follows longPressDuration: \(holds)"
-        )
-    }
 }

--- a/MultiplexTests/KeyCommandStoreTests.swift
+++ b/MultiplexTests/KeyCommandStoreTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import XCTest
+@testable import Multiplex
+
+@MainActor
+final class KeyCommandStoreTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("keycommands-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    func testFreshStoreShipsTheDefaultsAndPersistsReplacements() {
+        let store = KeyCommandStore(directory: directory)
+        XCTAssertEqual(store.commands, KeyCommandSet.shipped)
+        XCTAssertEqual(store.updatedAt, .distantPast)
+
+        let custom = KeyCommand(kind: .chord(KeyChord(modifiers: [.option], key: .enter)))
+        let stamp = Date(timeIntervalSince1970: 1_800_000_000)
+        store.replace(KeyCommandSet.shipped + [custom], now: stamp)
+        XCTAssertEqual(store.commands.count, 4)
+        XCTAssertEqual(store.updatedAt, stamp)
+
+        let reloaded = KeyCommandStore(directory: directory)
+        XCTAssertEqual(reloaded.commands, store.commands, "The set comes back from keycommands.json")
+        XCTAssertEqual(reloaded.updatedAt, stamp)
+    }
+
+    func testReplaceNormalizesBeforePersisting() {
+        let store = KeyCommandStore(directory: directory)
+        var wild = KeyCommand(kind: .chord(KeyChord(key: .tab)))
+        wild.repeatCount = 99
+        wild.repeatGapMilliseconds = 1
+        store.replace([wild, KeyCommand(kind: .text(KeyTextSnippet(text: "  ")))])
+        XCTAssertEqual(store.commands.count, 1)
+        XCTAssertEqual(store.commands[0].repeatCount, KeyCommandRepeatGuard.maximumCount)
+        XCTAssertEqual(store.commands[0].repeatGapMilliseconds, KeyCommandRepeatGuard.gapRange.lowerBound)
+    }
+
+    func testCloudMergeIsLastWriterWins() throws {
+        let store = KeyCommandStore(directory: directory)
+        let local = KeyCommand(kind: .chord(KeyChord(key: .space)))
+        store.replace([local], now: Date(timeIntervalSince1970: 2_000))
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let older = KeyCommandSet(
+            commands: [KeyCommand(kind: .chord(KeyChord(key: .escape)))],
+            updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        store.adopt(cloudRecord: try encoder.encode(older))
+        XCTAssertEqual(store.commands, [local], "An older mirror never overwrites a newer local set")
+
+        let newer = KeyCommandSet(
+            commands: [KeyCommand(kind: .chord(KeyChord(key: .escape)))],
+            updatedAt: Date(timeIntervalSince1970: 3_000)
+        )
+        store.adopt(cloudRecord: try encoder.encode(newer))
+        XCTAssertEqual(store.commands.map(\.name), ["ESC"], "A newer peer set replaces the local one whole")
+        XCTAssertEqual(store.updatedAt, Date(timeIntervalSince1970: 3_000))
+
+        store.adopt(cloudRecord: Data("not json".utf8))
+        XCTAssertEqual(store.commands.map(\.name), ["ESC"], "Garbage in the mirror is ignored")
+
+        let reloaded = KeyCommandStore(directory: directory)
+        XCTAssertEqual(reloaded.commands.map(\.name), ["ESC"], "An adopted set is persisted locally")
+    }
+
+    func testMemoryOnlyStoreDoesNotTouchDisk() {
+        let store = KeyCommandStore(directory: nil)
+        store.replace([KeyCommand(kind: .chord(KeyChord(key: .tab)))])
+        XCTAssertEqual(store.commands.count, 1)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: directory.appendingPathComponent("keycommands.json").path)
+        )
+    }
+}

--- a/MultiplexTests/KeyCommandStoreTests.swift
+++ b/MultiplexTests/KeyCommandStoreTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import XCTest
 @testable import Multiplex
 
+/// The app-wide store: the shipped set until edited, `keycommands.json`
+/// persistence, and the Keychain mirror's last-writer-wins merge.
 @MainActor
 final class KeyCommandStoreTests: XCTestCase {
     private var directory: URL!
@@ -18,31 +20,27 @@ final class KeyCommandStoreTests: XCTestCase {
         super.tearDown()
     }
 
-    func testFreshStoreShipsTheDefaultsAndPersistsReplacements() {
+    func testFreshStoreShipsTheDefaultsAndPersistsNormalizedReplacements() {
         let store = KeyCommandStore(directory: directory)
         XCTAssertEqual(store.commands, KeyCommandSet.shipped)
         XCTAssertEqual(store.updatedAt, .distantPast)
 
-        let custom = KeyCommand(kind: .chord(KeyChord(modifiers: [.option], key: .enter)))
+        var wild = KeyCommand(kind: .chord(KeyChord(modifiers: [.option], key: .enter)))
+        wild.repeatCount = 99
+        wild.repeatGapMilliseconds = 1
         let stamp = Date(timeIntervalSince1970: 1_800_000_000)
-        store.replace(KeyCommandSet.shipped + [custom], now: stamp)
-        XCTAssertEqual(store.commands.count, 4)
+        store.replace(
+            KeyCommandSet.shipped + [wild, KeyCommand(kind: .text(KeyTextSnippet(text: "  ")))],
+            now: stamp
+        )
+        XCTAssertEqual(store.commands.count, 4, "The blank text row is dropped")
+        XCTAssertEqual(store.commands[3].repeatCount, KeyCommandRepeatGuard.maximumCount)
+        XCTAssertEqual(store.commands[3].repeatGapMilliseconds, KeyCommandRepeatGuard.gapRange.lowerBound)
         XCTAssertEqual(store.updatedAt, stamp)
 
         let reloaded = KeyCommandStore(directory: directory)
         XCTAssertEqual(reloaded.commands, store.commands, "The set comes back from keycommands.json")
         XCTAssertEqual(reloaded.updatedAt, stamp)
-    }
-
-    func testReplaceNormalizesBeforePersisting() {
-        let store = KeyCommandStore(directory: directory)
-        var wild = KeyCommand(kind: .chord(KeyChord(key: .tab)))
-        wild.repeatCount = 99
-        wild.repeatGapMilliseconds = 1
-        store.replace([wild, KeyCommand(kind: .text(KeyTextSnippet(text: "  ")))])
-        XCTAssertEqual(store.commands.count, 1)
-        XCTAssertEqual(store.commands[0].repeatCount, KeyCommandRepeatGuard.maximumCount)
-        XCTAssertEqual(store.commands[0].repeatGapMilliseconds, KeyCommandRepeatGuard.gapRange.lowerBound)
     }
 
     func testCloudMergeIsLastWriterWins() throws {
@@ -72,14 +70,5 @@ final class KeyCommandStoreTests: XCTestCase {
 
         let reloaded = KeyCommandStore(directory: directory)
         XCTAssertEqual(reloaded.commands.map(\.name), ["ESC"], "An adopted set is persisted locally")
-    }
-
-    func testMemoryOnlyStoreDoesNotTouchDisk() {
-        let store = KeyCommandStore(directory: nil)
-        store.replace([KeyCommand(kind: .chord(KeyChord(key: .tab)))])
-        XCTAssertEqual(store.commands.count, 1)
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: directory.appendingPathComponent("keycommands.json").path)
-        )
     }
 }

--- a/MultiplexTests/KeyCommandTests.swift
+++ b/MultiplexTests/KeyCommandTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import XCTest
 @testable import Multiplex
 
-/// The pure Key Command model: derived names and faces, the repeat guard,
-/// set normalization, and the byte notation the composer's SENDS line uses.
+/// The pure Key Command model: the shipped defaults, derived names / faces /
+/// readouts, and set normalization under the repeat guard.
 final class KeyCommandTests: XCTestCase {
     func testShippedSetIsTheThreeDefaultsInOrder() {
         let shipped = KeyCommandSet.shipped
@@ -19,7 +19,7 @@ final class KeyCommandTests: XCTestCase {
         )
     }
 
-    func testChordNamesFacesAndReadouts() {
+    func testDerivedNamesFacesAndReadouts() {
         let optionUp = KeyCommand(
             kind: .chord(KeyChord(modifiers: [.option, .shift], key: .up)),
             repeatCount: 3,
@@ -27,52 +27,49 @@ final class KeyCommandTests: XCTestCase {
             closesPanel: false
         )
         XCTAssertEqual(optionUp.name, "SHIFT OPTION UP", "Modifiers print in keycap order ⌃ ⇧ ⌥")
-        XCTAssertEqual(
-            optionUp.faces.map(\.symbolName),
-            ["shift", "option", "arrow.up"]
-        )
+        XCTAssertEqual(optionUp.faces.map(\.symbolName), ["shift", "option", "arrow.up"])
         XCTAssertEqual(optionUp.readout, "×3 · 100 MS · STAYS")
         XCTAssertTrue(optionUp.isRepeating)
 
         let letter = KeyCommand(kind: .chord(KeyChord(modifiers: [.control], key: .character("c"))))
         XCTAssertEqual(letter.name, "CTRL C")
         XCTAssertEqual(letter.faces.map(\.text), ["⌃", "C"], "Letters render as their uppercase text face")
-        XCTAssertNil(letter.faces.last?.symbolName)
         XCTAssertEqual(letter.readout, "×1 · CLOSES")
         XCTAssertEqual(letter.chord?.accessibilityName, "Control C")
-    }
 
-    func testTextRowsDeriveTheirLabelAndSubmitReadout() {
         let short = KeyCommand(kind: .text(KeyTextSnippet(text: "git status")))
         XCTAssertEqual(short.name, "git status")
         XCTAssertEqual(short.faces, [.text("git status")])
         XCTAssertEqual(short.readout, "SUBMITS · ×1 · CLOSES")
-
         let long = KeyCommand(kind: .text(KeyTextSnippet(text: "  make -j8 test\tVERBOSE=1\n", submits: false)))
         XCTAssertEqual(long.textSnippet?.normalizedText, "make -j8 test\tVERBOSE=1")
         XCTAssertEqual(long.name, "make -j8 tes...")
         XCTAssertEqual(long.readout, "×1 · CLOSES")
-
-        let controlBytes = KeyTextSnippet(text: "ls\u{02}\u{1B}[A")
-        XCTAssertEqual(controlBytes.normalizedText, "ls[A", "Terminal control bytes never survive normalization")
+        XCTAssertEqual(
+            KeyTextSnippet(text: "ls\u{02}\u{1B}[A").normalizedText,
+            "ls[A",
+            "Terminal control bytes never survive normalization"
+        )
         XCTAssertFalse(KeyCommand(kind: .text(KeyTextSnippet(text: " \n "))).isSendable)
-    }
 
-    func testCharacterFieldAcceptsOnePrintableASCIICharacter() {
-        XCTAssertEqual(KeyChord.Key.fromFieldText("c"), .character("c"))
+        // The composer's letter field takes one printable ASCII character.
         XCTAssertEqual(KeyChord.Key.fromFieldText("C"), .character("c"), "The base key is lowercase")
         XCTAssertEqual(KeyChord.Key.fromFieldText(" 7 "), .character("7"))
         XCTAssertNil(KeyChord.Key.fromFieldText("ab"))
         XCTAssertNil(KeyChord.Key.fromFieldText(""))
         XCTAssertNil(KeyChord.Key.fromFieldText("é"))
         XCTAssertNil(KeyChord.Key.fromFieldText("\u{1B}"))
+
+        // The SENDS line's byte notation.
+        XCTAssertEqual(KeyBytesNotation.describe([0x0A]), "LF")
+        XCTAssertEqual(KeyBytesNotation.describe([0x1B, 0x5B, 0x31, 0x33, 0x3B, 0x32, 0x75]), "ESC [13;2u")
+        XCTAssertEqual(KeyBytesNotation.describe([0x03]), "^C")
+        XCTAssertEqual(KeyBytesNotation.describe([0x1B, 0x62]), "ESC b")
+        XCTAssertEqual(KeyBytesNotation.describe([0x7F, 0x00]), "DEL NUL")
+        XCTAssertEqual(KeyBytesNotation.describe(Array("héllo".utf8)), "héllo")
     }
 
-    func testRepeatGuardClampsCountGapAndBurst() {
-        XCTAssertEqual(
-            KeyCommandRepeatGuard.clamp(count: 2, gapMilliseconds: 150),
-            .init(count: 2, gapMilliseconds: 150, wasClamped: false)
-        )
+    func testNormalizationClampsRepeatsDropsBlankTextDedupesAndCaps() {
         XCTAssertEqual(
             KeyCommandRepeatGuard.clamp(count: 9, gapMilliseconds: 10),
             .init(count: 5, gapMilliseconds: 50, wasClamped: true)
@@ -88,9 +85,7 @@ final class KeyCommandTests: XCTestCase {
         )
         XCTAssertEqual(KeyCommandRepeatGuard.burstMilliseconds(count: 5, gapMilliseconds: 500), 2000)
         XCTAssertEqual(KeyCommandRepeatGuard.burstMilliseconds(count: 1, gapMilliseconds: 500), 0)
-    }
 
-    func testNormalizedSetDropsEmptyTextDedupesIDsAndCaps() {
         let sharedID = UUID()
         var many: [KeyCommand] = (0..<14).map { index in
             KeyCommand(kind: .chord(KeyChord(key: .character(String(index % 10)))))
@@ -105,32 +100,5 @@ final class KeyCommandTests: XCTestCase {
         XCTAssertEqual(Set(normalized.map(\.id)).count, normalized.count, "IDs are unique after normalization")
         XCTAssertFalse(normalized.contains { $0.textSnippet != nil }, "Blank text rows are dropped")
         XCTAssertEqual(normalized[2].repeatCount, KeyCommandRepeatGuard.maximumCount)
-    }
-
-    func testSetRoundTripsThroughJSON() throws {
-        let set = KeyCommandSet(
-            commands: KeyCommandSet.shipped + [
-                KeyCommand(kind: .text(KeyTextSnippet(text: "git status", submits: false)), closesPanel: false),
-                KeyCommand(kind: .chord(KeyChord(modifiers: [.control, .option], key: .character("x")))),
-            ],
-            updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
-        )
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        let data = try encoder.encode(set)
-        let decoded = try decoder.decode(KeyCommandSet.self, from: data)
-        XCTAssertEqual(decoded, set)
-    }
-
-    func testByteNotationNamesControlsAndKeepsText() {
-        XCTAssertEqual(KeyBytesNotation.describe([0x0A]), "LF")
-        XCTAssertEqual(KeyBytesNotation.describe([0x1B, 0x5B, 0x31, 0x33, 0x3B, 0x32, 0x75]), "ESC [13;2u")
-        XCTAssertEqual(KeyBytesNotation.describe([0x03]), "^C")
-        XCTAssertEqual(KeyBytesNotation.describe([0x1B, 0x62]), "ESC b")
-        XCTAssertEqual(KeyBytesNotation.describe([0x7F]), "DEL")
-        XCTAssertEqual(KeyBytesNotation.describe([0x00]), "NUL")
-        XCTAssertEqual(KeyBytesNotation.describe(Array("héllo".utf8)), "héllo")
     }
 }

--- a/MultiplexTests/KeyCommandTests.swift
+++ b/MultiplexTests/KeyCommandTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import XCTest
+@testable import Multiplex
+
+/// The pure Key Command model: derived names and faces, the repeat guard,
+/// set normalization, and the byte notation the composer's SENDS line uses.
+final class KeyCommandTests: XCTestCase {
+    func testShippedSetIsTheThreeDefaultsInOrder() {
+        let shipped = KeyCommandSet.shipped
+        XCTAssertEqual(shipped.map(\.name), ["SHIFT ENTER", "CTRL C", "OPTION DELETE"])
+        XCTAssertEqual(shipped.map(\.repeatCount), [1, 2, 1])
+        XCTAssertEqual(shipped.map(\.closesPanel), [true, true, false])
+        XCTAssertTrue(shipped.allSatisfy(\.isShipped))
+        XCTAssertEqual(shipped[1].repeatGapMilliseconds, 150)
+        XCTAssertEqual(
+            Set(shipped.map(\.id)).count,
+            3,
+            "The defaults keep stable, distinct IDs so peers merge to the same rows"
+        )
+    }
+
+    func testChordNamesFacesAndReadouts() {
+        let optionUp = KeyCommand(
+            kind: .chord(KeyChord(modifiers: [.option, .shift], key: .up)),
+            repeatCount: 3,
+            repeatGapMilliseconds: 100,
+            closesPanel: false
+        )
+        XCTAssertEqual(optionUp.name, "SHIFT OPTION UP", "Modifiers print in keycap order ⌃ ⇧ ⌥")
+        XCTAssertEqual(
+            optionUp.faces.map(\.symbolName),
+            ["shift", "option", "arrow.up"]
+        )
+        XCTAssertEqual(optionUp.readout, "×3 · 100 MS · STAYS")
+        XCTAssertTrue(optionUp.isRepeating)
+
+        let letter = KeyCommand(kind: .chord(KeyChord(modifiers: [.control], key: .character("c"))))
+        XCTAssertEqual(letter.name, "CTRL C")
+        XCTAssertEqual(letter.faces.map(\.text), ["⌃", "C"], "Letters render as their uppercase text face")
+        XCTAssertNil(letter.faces.last?.symbolName)
+        XCTAssertEqual(letter.readout, "×1 · CLOSES")
+        XCTAssertEqual(letter.chord?.accessibilityName, "Control C")
+    }
+
+    func testTextRowsDeriveTheirLabelAndSubmitReadout() {
+        let short = KeyCommand(kind: .text(KeyTextSnippet(text: "git status")))
+        XCTAssertEqual(short.name, "git status")
+        XCTAssertEqual(short.faces, [.text("git status")])
+        XCTAssertEqual(short.readout, "SUBMITS · ×1 · CLOSES")
+
+        let long = KeyCommand(kind: .text(KeyTextSnippet(text: "  make -j8 test\tVERBOSE=1\n", submits: false)))
+        XCTAssertEqual(long.textSnippet?.normalizedText, "make -j8 test\tVERBOSE=1")
+        XCTAssertEqual(long.name, "make -j8 tes...")
+        XCTAssertEqual(long.readout, "×1 · CLOSES")
+
+        let controlBytes = KeyTextSnippet(text: "ls\u{02}\u{1B}[A")
+        XCTAssertEqual(controlBytes.normalizedText, "ls[A", "Terminal control bytes never survive normalization")
+        XCTAssertFalse(KeyCommand(kind: .text(KeyTextSnippet(text: " \n "))).isSendable)
+    }
+
+    func testCharacterFieldAcceptsOnePrintableASCIICharacter() {
+        XCTAssertEqual(KeyChord.Key.fromFieldText("c"), .character("c"))
+        XCTAssertEqual(KeyChord.Key.fromFieldText("C"), .character("c"), "The base key is lowercase")
+        XCTAssertEqual(KeyChord.Key.fromFieldText(" 7 "), .character("7"))
+        XCTAssertNil(KeyChord.Key.fromFieldText("ab"))
+        XCTAssertNil(KeyChord.Key.fromFieldText(""))
+        XCTAssertNil(KeyChord.Key.fromFieldText("é"))
+        XCTAssertNil(KeyChord.Key.fromFieldText("\u{1B}"))
+    }
+
+    func testRepeatGuardClampsCountGapAndBurst() {
+        XCTAssertEqual(
+            KeyCommandRepeatGuard.clamp(count: 2, gapMilliseconds: 150),
+            .init(count: 2, gapMilliseconds: 150, wasClamped: false)
+        )
+        XCTAssertEqual(
+            KeyCommandRepeatGuard.clamp(count: 9, gapMilliseconds: 10),
+            .init(count: 5, gapMilliseconds: 50, wasClamped: true)
+        )
+        XCTAssertEqual(
+            KeyCommandRepeatGuard.clamp(count: 0, gapMilliseconds: 5000),
+            .init(count: 1, gapMilliseconds: 500, wasClamped: true)
+        )
+        // ×5 every 500 ms is a 2 s burst — exactly the limit, allowed.
+        XCTAssertEqual(
+            KeyCommandRepeatGuard.clamp(count: 5, gapMilliseconds: 500),
+            .init(count: 5, gapMilliseconds: 500, wasClamped: false)
+        )
+        XCTAssertEqual(KeyCommandRepeatGuard.burstMilliseconds(count: 5, gapMilliseconds: 500), 2000)
+        XCTAssertEqual(KeyCommandRepeatGuard.burstMilliseconds(count: 1, gapMilliseconds: 500), 0)
+    }
+
+    func testNormalizedSetDropsEmptyTextDedupesIDsAndCaps() {
+        let sharedID = UUID()
+        var many: [KeyCommand] = (0..<14).map { index in
+            KeyCommand(kind: .chord(KeyChord(key: .character(String(index % 10)))))
+        }
+        many[0].id = sharedID
+        many[1].id = sharedID
+        many.insert(KeyCommand(kind: .text(KeyTextSnippet(text: "   "))), at: 2)
+        many[3].repeatCount = 40
+
+        let normalized = KeyCommandSet.normalized(many)
+        XCTAssertEqual(normalized.count, KeyCommandSet.maximumCount)
+        XCTAssertEqual(Set(normalized.map(\.id)).count, normalized.count, "IDs are unique after normalization")
+        XCTAssertFalse(normalized.contains { $0.textSnippet != nil }, "Blank text rows are dropped")
+        XCTAssertEqual(normalized[2].repeatCount, KeyCommandRepeatGuard.maximumCount)
+    }
+
+    func testSetRoundTripsThroughJSON() throws {
+        let set = KeyCommandSet(
+            commands: KeyCommandSet.shipped + [
+                KeyCommand(kind: .text(KeyTextSnippet(text: "git status", submits: false)), closesPanel: false),
+                KeyCommand(kind: .chord(KeyChord(modifiers: [.control, .option], key: .character("x")))),
+            ],
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let data = try encoder.encode(set)
+        let decoded = try decoder.decode(KeyCommandSet.self, from: data)
+        XCTAssertEqual(decoded, set)
+    }
+
+    func testByteNotationNamesControlsAndKeepsText() {
+        XCTAssertEqual(KeyBytesNotation.describe([0x0A]), "LF")
+        XCTAssertEqual(KeyBytesNotation.describe([0x1B, 0x5B, 0x31, 0x33, 0x3B, 0x32, 0x75]), "ESC [13;2u")
+        XCTAssertEqual(KeyBytesNotation.describe([0x03]), "^C")
+        XCTAssertEqual(KeyBytesNotation.describe([0x1B, 0x62]), "ESC b")
+        XCTAssertEqual(KeyBytesNotation.describe([0x7F]), "DEL")
+        XCTAssertEqual(KeyBytesNotation.describe([0x00]), "NUL")
+        XCTAssertEqual(KeyBytesNotation.describe(Array("héllo".utf8)), "héllo")
+    }
+}

--- a/MultiplexTests/TerminalGuideTests.swift
+++ b/MultiplexTests/TerminalGuideTests.swift
@@ -4,11 +4,11 @@ import XCTest
 final class TerminalGuideTests: XCTestCase {
     func testDeckIntegrityAndCanonicalFigures() {
         let entries = TerminalGuide.allEntries
-        XCTAssertEqual(entries.count, 14)
+        XCTAssertEqual(entries.count, 15)
 
         let figures = entries.compactMap(\.figure)
-        XCTAssertEqual(figures, Array(1...13))
-        XCTAssertEqual(Set(figures).count, 13)
+        XCTAssertEqual(figures, Array(1...14))
+        XCTAssertEqual(Set(figures).count, 14)
         for entry in entries {
             XCTAssertFalse(entry.title.isEmpty, entry.id)
             XCTAssertFalse(entry.body.isEmpty, entry.id)
@@ -23,7 +23,7 @@ final class TerminalGuideTests: XCTestCase {
         ))
         XCTAssertEqual(entries.map(\.id), [
             "doubletap", "longpress", "rightclick", "pan",
-            "link", "path", "shiftreturn", "shortcutkey",
+            "link", "path", "shiftreturn", "shortcutkey", "keycommands",
         ])
     }
 
@@ -55,7 +55,7 @@ final class TerminalGuideTests: XCTestCase {
         ))
         let link = try XCTUnwrap(entries.first { $0.id == "link" })
         XCTAssertEqual(link.figure, 6)
-        XCTAssertEqual(entries.compactMap(\.figure), [1, 2, 3, 4, 6, 7, 10, 11])
+        XCTAssertEqual(entries.compactMap(\.figure), [1, 2, 3, 4, 6, 7, 10, 11, 12])
     }
 
     func testBankOrder() {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A spatial SSH terminal for remote **tmux** — visionOS first, with iPadOS and i
 - **Fleet-wide deck:** live tmux and herdr sessions across every host, with password, OpenSSH-key, or `mpx bind` setup and iCloud Keychain sync.
 - **Real terminal windows:** spatial scenes on visionOS, Stage Manager on iPad, and an adaptive iPhone shell. Tabs can move or merge without reconnecting.
 - **Agent awareness:** detects Claude Code, Codex, and Pi; surfaces questions, permissions, and completed turns on the wall and through notifications.
-- **Purpose-built input:** keyboard-focus arbitration, key rail, IME, dictation, remote scrolling, tmux Copy Mode, and text selection.
+- **Purpose-built input:** keyboard-focus arbitration, key rail with hold-CTRL Key Commands (saved chords and text macros), IME, dictation, remote scrolling, tmux Copy Mode, and text selection.
 - **More than a shell:** docked web and file viewers, SFTP uploads, optional clean-room mosh, widgets, Shortcuts, deep links, and custom themes.
 
 

--- a/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSKeyChord.swift
+++ b/Vendor/SwiftTerm/Sources/SwiftTerm/iOS/iOSKeyChord.swift
@@ -1,0 +1,144 @@
+//
+//  iOSKeyChord.swift: app-authored key chords.
+//
+//  Multiplex patch (fourteenth group): a host app that offers saved key
+//  chords on its own chrome (Multiplex's hold-CTRL Key Commands) must send
+//  exactly the bytes a hardware keyboard would send for the same chord at
+//  the same moment — kitty enhancement flags, DECCKM, the backspace mode.
+//  Re-deriving those rules app-side would drift from `pressesBegan`; this
+//  seam names the chord and lets the view encode it.
+//
+#if os(iOS) || os(visionOS)
+import Foundation
+
+/// One modifier set plus one key, spelled the way a keycap reads.
+public struct TerminalKeyChord: Equatable {
+    public enum Key: Equatable {
+        case enter
+        case tab
+        case escape
+        case backspace
+        case space
+        case up
+        case down
+        case left
+        case right
+        /// One printable character; the encoder takes its lowercase base as
+        /// the key and reports the shifted form when `.shift` is held.
+        case character(Character)
+    }
+
+    public struct Modifiers: OptionSet {
+        public let rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        public static let shift = Modifiers(rawValue: 1 << 0)
+        public static let control = Modifiers(rawValue: 1 << 1)
+        public static let option = Modifiers(rawValue: 1 << 2)
+    }
+
+    public var key: Key
+    public var modifiers: Modifiers
+
+    public init(key: Key, modifiers: Modifiers = []) {
+        self.key = key
+        self.modifiers = modifiers
+    }
+}
+
+extension TerminalView {
+    /// The bytes a hardware press of `chord` would send right now. Nil when the
+    /// chord has no encoding (a bare modifier, an unencodable character).
+    ///
+    /// With kitty enhancement flags active the chord rides
+    /// `KittyKeyboardEncoder` exactly as `pressesBegan` does. Without them the
+    /// same encoder's legacy branch applies, plus the three cases the legacy
+    /// `pressesBegan` path decides for itself: Shift+Enter is LF (the CLI
+    /// agents' insert-newline — see the Return case there), Option+Left/Right
+    /// are the readline word motions (`ESC b` / `ESC f`), and Ctrl+Shift+char
+    /// is Ctrl+char (there is no legacy spelling for the shift).
+    public func bytes(for chord: TerminalKeyChord) -> [UInt8]? {
+        let flags = terminal.keyboardEnhancementFlags
+        if flags.isEmpty {
+            if case .enter = chord.key, chord.modifiers.contains(.shift) {
+                return [10]
+            }
+            if chord.modifiers == [.option] {
+                switch chord.key {
+                case .left: return EscapeSequences.emacsBack
+                case .right: return EscapeSequences.emacsForward
+                default: break
+                }
+            }
+        }
+        var event = kittyEvent(for: chord)
+        if flags.isEmpty, event.modifiers.contains(.ctrl) {
+            event.modifiers.remove(.shift)
+            event.shiftedKey = nil
+        }
+        let encoder = KittyKeyboardEncoder(flags: flags,
+                                           applicationCursor: terminal.applicationCursor,
+                                           backspaceSendsControlH: backspaceSendsControlH)
+        return encoder.encode(event)
+    }
+
+    /// Encodes `chord` for the terminal's current mode and sends it through
+    /// the same delegate path as every other key. Returns false when the chord
+    /// has no encoding.
+    @discardableResult
+    public func send(chord: TerminalKeyChord) -> Bool {
+        guard let bytes = bytes(for: chord) else { return false }
+        send(bytes)
+        return true
+    }
+
+    private func kittyEvent(for chord: TerminalKeyChord) -> KittyKeyEvent {
+        var modifiers: KittyKeyboardModifiers = []
+        if chord.modifiers.contains(.shift) { modifiers.insert(.shift) }
+        if chord.modifiers.contains(.control) { modifiers.insert(.ctrl) }
+        if chord.modifiers.contains(.option) { modifiers.insert(.alt) }
+        let carriesText = !modifiers.contains(.ctrl) && !modifiers.contains(.alt)
+
+        let key: KittyKey
+        var text: String?
+        var shiftedKey: UnicodeScalar?
+        switch chord.key {
+        case .enter: key = .functional(.enter)
+        case .tab: key = .functional(.tab)
+        case .escape: key = .functional(.escape)
+        case .backspace: key = .functional(.backspace)
+        case .up: key = .functional(.up)
+        case .down: key = .functional(.down)
+        case .left: key = .functional(.left)
+        case .right: key = .functional(.right)
+        case .space:
+            key = .unicode(32)
+            if carriesText { text = " " }
+        case .character(let character):
+            let lowered = String(character).lowercased()
+            let base: UnicodeScalar = lowered.unicodeScalars.first
+                ?? String(character).unicodeScalars.first
+                ?? UnicodeScalar(32)
+            key = .unicode(base.value)
+            let shifted = String(character).uppercased()
+            let typed = modifiers.contains(.shift) ? shifted : String(character)
+            if carriesText { text = typed }
+            if modifiers.contains(.shift),
+               let shiftedScalar = shifted.unicodeScalars.first,
+               shiftedScalar != base {
+                shiftedKey = shiftedScalar
+            }
+        }
+        return KittyKeyEvent(key: key,
+                             modifiers: modifiers,
+                             eventType: .press,
+                             text: text,
+                             shiftedKey: shiftedKey,
+                             baseLayoutKey: nil,
+                             composing: false)
+    }
+}
+#endif

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -19,6 +19,14 @@ UIKit scene runtime (MultiplexSceneDelegate + UIKitSceneRootViewController;
                      iCloud Keychain (KeychainStore); host records include
                      per-host agent command configuration
   ThemeStore         terminal color schemes (themes.json); device-local
+  KeyCommandStore    the app-wide hold-CTRL Key Commands set (.shared;
+                     keycommands.json + ONE synchronizable Keychain item,
+                     last writer wins by updatedAt); KeyCommand/KeyChord/
+                     KeyTextSnippet pure; KeyCommandDispatcher sends through
+                     TerminalView.send, chords encoded by the fork at press
+                     time (TerminalView.bytes(for:)); the tier's cap rides
+                     KeyCommandPlan from the terminal window (which holds
+                     EntitlementStore) down to the rail / cluster presenter
   AgentCommandConfiguration  pure per-host Bar/More overrides + ordered
                      custom helpers; shared UUIDs mirror between profiles
   ConnectionHub      one HostConnectionModel per host — the probe connection;

--- a/docs/agents/design-conventions.md
+++ b/docs/agents/design-conventions.md
@@ -44,6 +44,12 @@ Split from AGENTS.md — the TALLY identity in code. Visual rationale: DESIGN.md
   `adjustsFontForContentSizeCategory = true` in UIKit) and get the Mac
   boost once at the scene root (`traitOverrides
   .preferredContentSizeCategory`); the two mechanisms never compound.
+  One recorded exception to "geometry stays authored": the hold-CTRL Key
+  Commands panel scales its keycap faces, row buttons, steppers, switches,
+  and fields by `Theme.typeScale` too (`KeyCommandMetrics`) — a 26-pt
+  keycap holding a scaled glyph read as a toy part on the Mac
+  (2026-08-16); the agent editor's shared switch/arrow controls keep the
+  authored size unless handed a `scale`.
 - **visionOS hover**: set `hoverStyle` (square `.rect(cornerRadius: 2)`)
   on every custom button/menu — on the CONTROL itself, never a
   subview/label (a label-level shape is silently ignored and you get the

--- a/docs/agents/e2e-headless.md
+++ b/docs/agents/e2e-headless.md
@@ -175,6 +175,10 @@ app.multiplexterm.multiplex.<name>`:
 - `debug.tmuxshortcuts` / `debug.customcommands` / `debug.msghistory` — open
   the focused tab's shortcut popover (TMUX content, or HRDR on a herdr
   tab) / Command Setup editor / agent HISTORY panel for layout capture.
+- `debug.keycommands` / `debug.keycommandsetup` / `debug.keycommandcompose` —
+  the hold-CTRL KEY COMMANDS popover (iPad rail or visionOS cluster) on its
+  COMMANDS grid / CUSTOM SETUP list / with a fresh row's composer expanded.
+  A panel already up just switches, so one run can capture all three.
 - `debug.guide` — open the focused terminal's GUIDE field manual for layout capture.
 - `debug.link` — activate the first visible link through the resolve →
   policy → confirmation path (URL → link sheet, path → file-viewer sheet;

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -87,7 +87,57 @@ routing, tab moves, keyboard avoidance, or secret fields.
   restores only if that tab still owns focus. Every key sends through
   `TerminalView.send` → delegate → ordered pump — never a side channel;
   CTRL rides `controlModifier`, latch released on
-  `.terminalViewControlModifierReset`. visionOS: `TerminalKeyCluster`
+  `.terminalViewControlModifierReset`. **Hold CTRL (0.3 s,
+  `KeyCommandPanelViewController.controlHoldDuration`; a tap still
+  latches and never fires the hold) opens KEY COMMANDS** — a popover
+  anchored to the CTRL key on both platforms (`KeyCommandPanelViewController`
+  in `KeyCommandPanel.swift`; ONE `KeyCommandPanelPresenter` owns present /
+  dismiss / focus-resume / popover delegate for both hosts — `TerminalKeyBar`
+  and the visionOS `TerminalKeyClusterGroupView` supply only the anchor and
+  their appearance step, the ornament carrying the C / B popover's appearance
+  and glass mirroring). The panel stands on the shortcut panel's now-shared
+  grammar (`ShortcutPanelRootView`, `ShortcutPressControl`,
+  `TallyHairlineGrid`, `TallyPanelHeader`, `UIKitChassisMonoLabel`) and the
+  agent editor's shared controls in `Design/TallyEditorControls.swift`
+  (`TallyEditorSwitch`, `TallyEditorRowActionButton`, `TallyEditorRowActions`,
+  `TallyEditorLegend`, `TallyEditorFooter`). Two tabs: COMMANDS is a two-column hairline grid of
+  saved rows (tap sends; a row with CLOSE ON PRESS off keeps the panel up;
+  a 0.5 s hold jumps to that row's setup); CUSTOM SETUP is the agent editor's
+  numbered list with an inline composer (TYPE KEYS | TEXT, ⌃ ⇧ ⌥ + one key
+  from ↩ ⇥ ⎋ ⌫ ␣ ↑ ↓ ← → or a one-character field, or one line of text with
+  SUBMIT = CR ~160 ms later, REPEAT count + gap under the guard ×5 · 50–500 ms ·
+  burst ≤ 2 s, PANEL, SENDS readout of the live bytes) — a draft
+  transaction, DONE normalizes once, CANCEL/outside dismissal discards.
+  The model (`KeyCommand`, `KeyChord`, `KeyTextSnippet`, `KeyCommandSet`
+  with the three shipped defaults ⇧↩ · ⌃C×2 · ⌥⌫-stays, `KeyCommandRepeatGuard`)
+  is pure; **chords are never bytes** — `KeyCommandDispatcher` asks the fork
+  (`TerminalView.bytes(for:)`, fourteenth patch group) at press time, so a
+  chord sends exactly what a hardware press would in the terminal's current
+  mode (kitty flags, DECCKM, backspace mode), and text rows ride
+  `send(txt:)` + a delayed CR like slash chips. Every send is
+  `TerminalView.send`, i.e. the ordered pump. Storage is app-wide
+  (`KeyCommandStore.shared`: `keycommands.json` beside `hosts.json` plus one
+  synchronizable Keychain item; `KeyCommandSync.merge` is the pure
+  last-writer-wins rule; refreshed at launch and when the panel opens, at
+  most once a minute — no CloudKit/KVS entitlement exists). Tier: free
+  keeps `EntitlementStore.freeKeyCommandLimit` (5) commands, Pro the model's
+  cap (12) — the same rule as hosts: a set that already holds more (synced
+  from a Pro device) is never trimmed and every row keeps sending; only
+  ADD COMMAND is gated, turning into the prominent "ADD COMMAND · PRO"
+  chip that opens the paywall (a legend line says why the cap is 5). The
+  rail and cluster never learn about Pro: the terminal window builds a
+  `KeyCommandPlan` (limit + paywall route) from its `EntitlementStore` and
+  hands it down — iPad through `TerminalPaneConfiguration` →
+  `TerminalSurfaceView.Configuration` → `TerminalKeyBar.keyCommandPlan`,
+  visionOS onto both `TerminalKeyClusterContext`s (shell + ornament) — and
+  the presenter wraps the route so the popover is down before the paywall
+  sheet presents (`presentPaywall` refuses while anything is presented).
+  `entitlements.isPro` is in the window's observation set, so a purchase
+  re-renders with the lifted plan. The terminal
+  GUIDE carries a HOLD CTRL card (figure 12). Focus: the
+  panel never suspends the terminal; only if one of its own fields took the
+  keyboard does dismissal `resumeAfterPresentation`. Design record + grill:
+  `local-plan/key-commands-bakeoff/`. visionOS: `TerminalKeyCluster`
   (same keys + latch + DEBUG hook) flanks the UMD on ONE console line in
   the bottom ornament. ViewThatFits compacts key faces first; when even
   compact can't fit, a `fixedSize` floor lets the row overflow the window

--- a/docs/agents/swiftterm-fork.md
+++ b/docs/agents/swiftterm-fork.md
@@ -7,7 +7,7 @@ input encoding, or terminal rendering.
   - `swift-nio-ssh` — Citadel 0.12.0's resolved fork (`Joannis` 0.3.5),
     patched to declare the `NIO` product it imports (Xcode 27 rejects the
     undeclared import); also freezes the SSH transport supply chain.
-  - `SwiftTerm` — 1.15.0 (rev `dd2fb8a`), patched in thirteen behavior groups
+  - `SwiftTerm` — 1.15.0 (rev `dd2fb8a`), patched in fourteen behavior groups
     (marked `Multiplex patch`):
     - `keyboardType` settable; kept `.default` so the user's language and
       multistage IME survive.
@@ -98,6 +98,16 @@ input encoding, or terminal rendering.
       by polling the physical Shift keys at the HID layer — real hardware
       only (synthetic keystrokes never reach HID, so neither Mac path can
       be driven headlessly).
+    - **App-authored key chords** (`iOS/iOSKeyChord.swift`, the fourteenth
+      group): `TerminalKeyChord` (⌃ ⇧ ⌥ + enter/tab/escape/backspace/space/
+      arrows/one character) and `TerminalView.bytes(for:)` / `send(chord:)`.
+      The app's Key Commands panel names the chord and the view encodes it
+      through the SAME `KittyKeyboardEncoder` a hardware press uses, plus
+      the three rules the legacy `pressesBegan` path decides for itself
+      (Shift+Enter → LF, Option+Left/Right → `ESC b`/`ESC f`, Ctrl+Shift+char
+      → Ctrl+char). Never re-derive chord bytes app-side — they would drift
+      from the hardware path the moment a remote toggles kitty flags.
+      Pinned by `KeyChordEncodingTests` (legacy, DECCKM, and `CSI > 1 u`).
     - Link activation is touch-reachable and app-answerable:
       `linkActivationIgnoresHighlight` (upstream needed pointer hover),
       `linkActivationHandler` (the app can decline a match; carries the

--- a/docs/store-metadata.md
+++ b/docs/store-metadata.md
@@ -186,6 +186,11 @@ Current product split:
   locked closed), app-owned terminal dictation from the physical-keyboard rail
   or software-keyboard-lock tip (on device wherever the locale supports it,
   typed into the session as it settles and never submitted),
+  Key Commands on a CTRL hold (saved chords the software keyboard cannot
+  press — Shift+Enter, a double Ctrl-C, Option+Backspace — plus custom chords and
+  one-line text macros with repeat and stay-open rules, one app-wide set
+  synced through iCloud Keychain; free keeps five saved commands, and ADD
+  COMMAND at that cap opens the paywall),
   and primary-button touch/pointer input for mouse-aware TUIs, all-pane agent
   detection and wall
   telemetry with foreground-aware helpers in tmux panes, herdr sessions,
@@ -274,10 +279,14 @@ Current product split:
   the HISTORY panel (a Claude Code session's prompt history read from
   Claude's own session file, with full text where the TUI truncates, plus
   jump-back-to-message on tmux and herdr tabs — Claude Code only; Codex/Pi
-  history was deliberately withdrawn 2026-07-16 to keep the jump exact), and
-  custom-theme editing.
-- Existing/synced hosts, existing mosh configuration, and existing custom
-  themes are never deleted or disabled when Pro is absent.
+  history was deliberately withdrawn 2026-07-16 to keep the jump exact),
+  custom-theme editing, and a twelve-command Key Commands set (added
+  2026-08-16; free keeps five).
+- Existing/synced hosts, existing mosh configuration, existing custom
+  themes, and a Key Commands set that already holds more than five (synced
+  from a Pro device, or after an entitlement lapse) are never deleted,
+  trimmed, or disabled when Pro is absent — every saved command keeps
+  sending; only adding past the cap is gated.
 
 When this split changes, update this document, the local StoreKit catalog,
 the app description and release notes, review notes, paywall copy, affected
@@ -302,7 +311,10 @@ public tree in `local-plan/` (untracked).
 | `local-plan/iap-review-screenshot.png` | Lossless 2064×2752 source/export retained for regeneration (3,907,546 bytes) |
 
 The 2026-07-13 image revision is fully processed in App Store Connect; the
-2026-07-15 local replacement above is not uploaded yet. The replacement shows
+2026-07-15 local replacement above is not uploaded yet, and it predates the
+2026-08-16 paywall change (a fifth benefit, "12 KEY COMMANDS", and the free-tier
+sentence naming five saved Key Commands) — regenerate before the next upload.
+The replacement shows
 the real locked `ProPaywallView`, including the one-time US $19.99 purchase CTA
 and Restore Purchases action. It is not a hand-built mock. In DEBUG builds,
 `MULTIPLEX_AUTO_PAYWALL=1` opens that real paywall with a deterministic $19.99

--- a/fastlane/metadata/en-US/description_ios.txt
+++ b/fastlane/metadata/en-US/description_ios.txt
@@ -16,13 +16,13 @@ MOSH BUILT IN
 With Pro, switch a host to mosh and the session survives sleep, roaming, and IP changes — a native Swift mosh client, no companion app.
 
 A REAL TERMINAL
-Full xterm-256color emulation, multilingual system-keyboard input, touch and pointer clicks for mouse-aware TUIs, hardware keyboards, live PTY resize, and a built-in menu of everyday tmux commands — with herdr's own set on herdr tabs. Long-press, double-tap, or secondary-click for pane-clamped text selection on either backend. System, Light, and Dark switch the whole chassis, each keeping its own terminal theme — ten built in, and Pro adds an editor for background, text, cursor, and all 16 ANSI colors.
+Full xterm-256color emulation, multilingual system-keyboard input, touch and pointer clicks for mouse-aware TUIs, hardware keyboards, live PTY resize, and a built-in menu of everyday tmux commands — with herdr's own set on herdr tabs. Hold CTRL for Key Commands: saved chords the software keyboard cannot press (Shift+Enter, a double Ctrl-C, Option+Backspace to delete a word) and one-line text macros, with your own repeats and stay-open rules, kept in sync across your devices. Long-press, double-tap, or secondary-click for pane-clamped text selection on either backend. System, Light, and Dark switch the whole chassis, each keeping its own terminal theme — ten built in, and Pro adds an editor for background, text, cursor, and all 16 ANSI colors.
 
 PRIVATE BY DESIGN
 Hosts, agent-command setups, and secrets sync between your devices through iCloud Keychain, end-to-end encrypted. Nothing touches our servers — there are none. No account, no analytics, no tracking.
 
 MULTIPLEX PRO
-One purchase, no subscription: unlimited hosts, mosh, agent notifications, the unmetered command strip, and custom themes on all your devices. Free includes two hosts, the complete terminal, and 10 agent-command chip taps a day.
+One purchase, no subscription: unlimited hosts, mosh, agent notifications, the unmetered command strip, custom themes, and twelve Key Commands on all your devices. Free includes two hosts, the complete terminal, five Key Commands, and 10 agent-command chip taps a day.
 
 WHAT YOU NEED
 A remote host you can reach over SSH (password or OpenSSH ed25519/RSA key). The live wall and persistent sessions need tmux 1.8+ or herdr 0.7.5+; plain SSH shells work without either. mosh needs mosh-server on the host.

--- a/fastlane/metadata/en-US/description_visionos.txt
+++ b/fastlane/metadata/en-US/description_visionos.txt
@@ -16,13 +16,13 @@ MOSH BUILT IN
 With Pro, switch a host to mosh and the session survives sleep, roaming, and IP changes — a native Swift mosh client, no companion app.
 
 A REAL TERMINAL
-Full xterm-256color emulation, multilingual system-keyboard input, gaze-and-pinch clicks for mouse-aware TUIs, hardware keyboards, live PTY resize, and a built-in menu of everyday tmux commands — with herdr's own set on herdr tabs. Long-press or double-pinch for pane-clamped text selection on either backend. System, Light, Dark, and smoked Glass switch the whole chassis; Glass admits the room and shares Dark's terminal theme. Ten themes built in, and Pro adds an editor for background, text, cursor, and all 16 ANSI colors.
+Full xterm-256color emulation, multilingual system-keyboard input, gaze-and-pinch clicks for mouse-aware TUIs, hardware keyboards, live PTY resize, and a built-in menu of everyday tmux commands — with herdr's own set on herdr tabs. Hold CTRL for Key Commands: saved chords the software keyboard cannot press (Shift+Enter, a double Ctrl-C, Option+Backspace to delete a word) and one-line text macros, with your own repeats and stay-open rules, kept in sync across your devices. Long-press or double-pinch for pane-clamped text selection on either backend. System, Light, Dark, and smoked Glass switch the whole chassis; Glass admits the room and shares Dark's terminal theme. Ten themes built in, and Pro adds an editor for background, text, cursor, and all 16 ANSI colors.
 
 PRIVATE BY DESIGN
 Hosts, agent-command setups, and secrets sync between your devices through iCloud Keychain, end-to-end encrypted. Nothing touches our servers — there are none. No account, no analytics, no tracking.
 
 MULTIPLEX PRO
-One purchase, no subscription: unlimited hosts, mosh, agent notifications, the unmetered command strip, and custom themes on all your devices. Free includes two hosts, the full spatial experience, and 10 agent-command chip taps a day.
+One purchase, no subscription: unlimited hosts, mosh, agent notifications, the unmetered command strip, custom themes, and twelve Key Commands on all your devices. Free includes two hosts, the full spatial experience, five Key Commands, and 10 agent-command chip taps a day.
 
 WHAT YOU NEED
 A remote host you can reach over SSH (password or OpenSSH ed25519/RSA key). The live wall and persistent sessions need tmux 1.8+ or herdr 0.7.5+; plain SSH shells work without either. mosh needs mosh-server on the host.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -8,11 +8,13 @@ NEW SINCE 1.3.1
 • FILE VIEWER OPENS PDFs — continuous pages, pinch to zoom, page readout; locked PDFs offer UNLOCK.
 • FILE VIEWER PLAYS SOUND FILES — MP3, M4A, WAV, FLAC, AIFF, CAF: PLAY/PAUSE, scrubber, 15 s skips, a volume slider that is remembered; keeps playing while you type in another tab.
 • KEYS TAP BACK on iPhone and iPad — the key rail, TMUX/HRDR panel buttons and agent chips give a light haptic on press.
+• KEY COMMANDS — hold CTRL on the key rail (or the visionOS key cluster) for saved chords the software keyboard cannot press: Shift+Enter, a double Ctrl-C, Option+Backspace to delete a word (stays open). CUSTOM SETUP adds your own — any Ctrl/Shift/Option chord or a one-line text macro, repeated up to 5 times, closing the panel or not — synced to your other devices. Free keeps five; Pro raises the set to twelve. The terminal GUIDE gains a HOLD CTRL card.
 
 PLEASE TRY
 1. Hop through windows from the TMUX panel — it should stay up, with ACTIVE following.
 2. If your device lists several languages, tap the globe while dictating and speak in the language you pick.
 3. Confirm split, resize, create, rename and close still work in both panels.
 4. Long-press a .pdf or .mp3 path in terminal output and open it with VIEW; try a link inside the PDF (it should ask first) and scrub the sound file.
+5. Hold CTRL in a Claude Code or Codex session: SHIFT ENTER should add a newline, CTRL C x2 should exit, OPTION DELETE should erase a word and keep the panel up. Add a text macro in CUSTOM SETUP and check it types (and submits) on your other device too.
 
 Feedback: screenshot in TestFlight


### PR DESCRIPTION
## What

Hold **CTRL** for 0.3 s on the key rail (iPad / iPhone) or the visionOS key cluster and a **KEY COMMANDS** popover opens above the key — saved chords the software keyboard cannot press, plus one-line text macros. The tap-CTRL latch and its C / B slab are untouched.

- **COMMANDS** — a two-column grid of keycap rows: tap sends; a dot marks a row that keeps the panel up; a 0.5 s hold jumps to that row's setup. Three ship: **⇧↩ SHIFT ENTER** (closes) · **⌃C ×2 CTRL C** at 150 ms (closes) · **⌥⌫ OPTION DELETE** to delete a word (stays).
- **CUSTOM SETUP** — the agent editor's numbered list with an inline composer: TYPE `KEYS | TEXT`; ⌃ ⇧ ⌥ + one key from ↩ ⇥ ⎋ ⌫ ␣ ↑ ↓ ← → or a one-character field, or one line of text with a **SUBMIT** switch (CR ~160 ms later); **REPEAT** count and gap between sends under a fixed guard (×5 · 50–500 ms · whole burst ≤ 2 s, values clamp); **PANEL** CLOSE ON PRESS; a live **SENDS** readout of the bytes. Derived names, ↑ ↓ reorder, cap 12. Drafts commit on DONE, CANCEL / tap-outside discards.
- One **app-wide set**, synced to the user's other devices. **Free keeps 5 commands; Pro lifts the set to 12** — like hosts, a synced set above the cap is never trimmed (every row keeps sending); only ADD COMMAND turns into the prominent `ADD COMMAND · PRO` chip that closes the popover and opens the paywall, and a legend line says why the cap is 5.
- The terminal **GUIDE** gains a HOLD CTRL card (figure 12). Controls scale with `Theme.typeScale` on iOS-for-Mac; on an iPhone the composer's KEYS and REPEAT lines wrap onto two rows (the second key line hangs flush-right under the editing keys).

Design record and grill (three HTML flow mockups → Candidate A): `local-plan/key-commands-bakeoff/` (untracked, plus a private artifact).

## How

- **Fork seam (fourteenth SwiftTerm patch group)** — `Vendor/SwiftTerm/.../iOS/iOSKeyChord.swift`: `TerminalKeyChord` + `TerminalView.bytes(for:)` / `send(chord:)`. **Chords are never bytes app-side**: a chord is encoded through the same `KittyKeyboardEncoder` and legacy rules a hardware press takes (kitty flags, DECCKM, backspace mode, ⇧↩→LF, ⌥←/→ → `ESC b`/`ESC f`, legacy ctrl drops shift), in the terminal's current mode at press time.
- **Models** (pure) — `KeyCommand` / `KeyChord` / `KeyTextSnippet` / `KeyCapFace` / `KeyCommandRepeatGuard` / `KeyCommandSet` (normalize + cap) / `KeyBytesNotation`, `KeyCommand.readout(.row/.cellHint/.spoken)`; `KeyCommandSync.merge` is the last-writer-wins rule (`HostSync`'s shape).
- **Services** — `KeyCommandStore.shared`: `keycommands.json` beside `hosts.json` plus **one synchronizable Keychain item** (no CloudKit/KVS entitlement exists — the host list's channel); encodes once, mirrors off-actor, cloud refresh throttled to 60 s and warmed at launch. `KeyCommandDispatcher` sends through `TerminalView.send` (chords) / `send(txt:)` + delayed CR (SUBMIT), repeat burst as a task. `EntitlementStore.freeKeyCommandLimit` / `keyCommandLimit` beside the host cap and the slash-chip meter.
- **Views** — `KeyCommandPanelViewController` (tabs, grid, rows, composer, `KeyCommandMetrics` scaled dims, compact wrap below 480 × scale), one `KeyCommandPanelPresenter` for both hosts (present / dismiss / focus-resume / popover delegate; the paywall route runs only after the popover is down). The rail and cluster never learn about Pro: the terminal window builds a `KeyCommandPlan` (limit + route) from its `EntitlementStore` and hands it down — iPad through `TerminalPaneConfiguration → TerminalSurfaceView.Configuration → TerminalKeyBar`, visionOS onto both `TerminalKeyClusterContext`s; `isPro` is in the window's observation set so a purchase re-renders with the lifted plan. `TerminalTallyKeyControl.longPressDuration` / `TerminalKey.holdDuration` carry the 0.3 s CTRL hold.
- **Shared grammar (from the /simplify pass)** — the shortcut panel's private pieces promoted: `ShortcutPanelRootView`, `ShortcutPressControl`, `TallyHairlineGrid`, `TallyPanelHeader`, `UIKitChassisMonoLabel`; the agent editor's controls now live in `Design/TallyEditorControls.swift` (`TallyEditorSwitch`, `TallyEditorRowActionButton`, `TallyEditorRowActions`, `TallyEditorLegend`, `TallyEditorFooter` with an add-state) and `CustomAgentCommandPanel` consumes them (−295 lines there).
- **Pro copy that moves with the split** — Settings' Pro rows (Key Commands · UP TO 5), paywall (free-tier sentence + a fifth benefit), both store descriptions, `docs/store-metadata.md` (Free/Pro lists, never-trimmed rule; the IAP review screenshot is flagged stale for its next upload).
- **Docs** — `input-and-windows.md`, `swiftterm-fork.md` (fourteen groups), `e2e-headless.md` (`debug.keycommands` / `keycommandsetup` / `keycommandcompose`), `architecture.md`, `design-conventions.md` (the recorded scale exception), `DESIGN.md`, `README.md`.

Traps recorded in the docs: `UIViewController.tab` (iOS 18 `UITab`) and ObjC `selected` name collisions, `keyboardDismissMode` missing on visionOS, UIStackView rows stretching the first keycap without a trailing spacer, UIControl's own long-press recognizers in tests.

## Verification

- New tests: `KeyChordEncodingTests` (legacy / DECCKM / kitty bytes pinned per chord, incl. `ESC DEL` / `CSI 127;3u` for ⌥⌫), `KeyCommandTests`, `KeyCommandStoreTests` (LWW merge, persistence, normalization), `KeyCommandPanelUIKitTests` (grid, hold → setup, drafts, composer clamps, hard cap, **free cap → Pro route, synced set above the cap kept**, phone-width wrap + right-aligned second line, Mac scale), `KeyCommandRailHookTests`, `TerminalGuideTests` (15 entries), `EntitlementStoreTests` (5 free / 12 Pro).
- Full unit suites green on **visionOS (1288)** and **iPad (1287)**; SwiftLint `--strict` at zero; `Tools/check-metadata.rb` passes.
- Simulator proofs via the debug hooks against the dev-sshd harness: COMMANDS grid, CUSTOM SETUP, expanded composer on visionOS (dark) and iPad (light); phone-width composer offscreen render; GUIDE card; free-tier state (`MULTIPLEX_PRO_LOCKED=1`) showing `5 OF 5`, the tier legend line, and the `ADD COMMAND · PRO` chip on both platforms.
- `fastlane/testflight-whats-new.txt` updated (bullet + PLEASE TRY 5).
