### PR TITLE
Talkback: a chat-style message box under the pane

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -167,7 +167,19 @@ agent's option picker without summoning it). Holding `CTRL` opens **KEY
 COMMANDS**, a two-tab TALLY popover on the shortcut panel's grammar:
 COMMANDS is a hairline grid of keycap chords (⇧↩ · ⌃C ×2 · ⌥⌫, and the user's
 own, in custom ink), CUSTOM SETUP is the agent editor's numbered list with an
-inline composer — bake-off record in `local-plan/key-commands-bakeoff/`. The iPad toolbar keeps the
+inline composer — bake-off record in `local-plan/key-commands-bakeoff/`. The
+speech-bubble key beside `RET` (`RET · talk · keyboard`, latched while open)
+opens **Talkback**, the chat-style message box: on visionOS a rounded card in
+its own slab hanging below the console row, on iPad and iPhone the same card
+docked between the pane and the key rail. Its eyebrow names the target in
+mono (`TO MAIN · DEVBOX`) beside the agent's mark and name, with RUNNING as
+grey telemetry and NEEDS YOU as the amber lamp; a round paperclip, a native
+text field, and a filled ↑ that sends the message as one paste — attached
+files upload on pick and show as 46 pt previews (28 pt thumbs and compact
+document chips on the phone), their paths typed first. Chat grammar on the
+chassis: rounded, hairlined, chassis-grounded, so it still belongs to the
+window — bake-off record in `local-plan/talkback-bakeoff/` (Candidate B).
+The iPad toolbar keeps the
 full chip set: `DECK`,
 source label, lamp, then
 `A− · A+ · + TAB · FILE · TMUX · MERGE · DETACH` chips; the keyboard

--- a/Multiplex/Models/AgentSignature.swift
+++ b/Multiplex/Models/AgentSignature.swift
@@ -17,6 +17,19 @@ enum AgentKind: String, Hashable, Codable, CaseIterable {
         }
     }
 
+    /// The agent's own mark — the helper strip's folded dot and the Talkback
+    /// eyebrow wear it. Grok has no single-glyph mark of its own in the TUI;
+    /// the plain capital reads as xAI's without leaning on a font-fallback
+    /// symbol.
+    var glyph: String {
+        switch self {
+        case .claudeCode: "✳"
+        case .codex: "◆"
+        case .pi: "π"
+        case .grok: "X"
+        }
+    }
+
     /// Deck telemetry token ("3 WIN · 2h · CLAUDE").
     var telemetryLabel: String {
         switch self {
@@ -307,6 +320,9 @@ struct AgentCommand: Identifiable, Hashable {
     /// "/new\r" leaves the text sitting in the composer; a CR ≥120 ms later
     /// submits). The other supported agents accept the delayed shape too.
     var submitsAfterPause = false
+    /// The pause — one number for every "type, then Enter" road (slash
+    /// chips, Key Commands text rows, Talkback SEND).
+    static let submitDelay: Duration = .milliseconds(160)
 
     var id: String { label }
 

--- a/Multiplex/Models/ComposedText.swift
+++ b/Multiplex/Models/ComposedText.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Text a person composed in an app field on its way into a pane — a custom
+/// agent command, a Talkback message. One rule for what may ride: line
+/// breaks become LF (CR / CRLF included), tabs stay, every other control
+/// character (C0, DEL, C1) is dropped — no Escape, no Ctrl-B, no CSI can
+/// travel inside typed text. Callers decide the trimming.
+enum ComposedText {
+    static func lineNormalized(_ text: String) -> String {
+        let lineEndings = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        return lineEndings.unicodeScalars.reduce(into: "") { result, scalar in
+            let allowedControl = scalar.value == 0x09 || scalar.value == 0x0A
+            if allowedControl || !CharacterSet.controlCharacters.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+            }
+        }
+    }
+}

--- a/Multiplex/Models/CustomAgentCommand.swift
+++ b/Multiplex/Models/CustomAgentCommand.swift
@@ -55,16 +55,7 @@ struct CustomAgentCommand: Identifiable, Codable, Hashable {
     }
 
     private static func normalizeContent(_ content: String) -> String {
-        let normalizedLineEndings = content
-            .replacingOccurrences(of: "\r\n", with: "\n")
-            .replacingOccurrences(of: "\r", with: "\n")
-        let safeText = normalizedLineEndings.unicodeScalars.reduce(into: "") { result, scalar in
-            let allowedControl = scalar.value == 0x09 || scalar.value == 0x0A
-            if allowedControl || !CharacterSet.controlCharacters.contains(scalar) {
-                result.append(Character(scalar))
-            }
-        }
-        return safeText
+        ComposedText.lineNormalized(content)
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Multiplex/Models/Talkback.swift
+++ b/Multiplex/Models/Talkback.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Talkback — the chat-style message box under a terminal pane. Pure state
+/// and byte composition; the composer view renders it and
+/// `TerminalSessionController` moves attachments through their upload
+/// states. Design record: `local-plan/talkback-bakeoff/` (Candidate B).
+
+/// One file the composer holds until SEND. Uploaded on pick over the tab's
+/// own SFTP into the pane's cwd (the FILE drop path), so a chip is either on
+/// its way, landed with the path SEND will type, or failed with a reason.
+struct TalkbackAttachment: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case image
+        case file
+    }
+
+    enum State: Equatable {
+        case uploading(fraction: Double)
+        /// `path` is the path as typed into the pane — relative to the cwd
+        /// where the drop path could verify it, absolute otherwise —
+        /// UNQUOTED; SEND quotes through `DropText.typedPaths`.
+        case ready(path: String)
+        case failed(String)
+    }
+
+    let id: UUID
+    var name: String
+    var byteCount: Int
+    var kind: Kind
+    /// A small JPEG for the composer's thumbnail; nil for non-images.
+    var preview: Data?
+    var state: State
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        byteCount: Int,
+        kind: Kind,
+        preview: Data? = nil,
+        state: State = .uploading(fraction: 0)
+    ) {
+        self.id = id
+        self.name = name
+        self.byteCount = byteCount
+        self.kind = kind
+        self.preview = preview
+        self.state = state
+    }
+
+    var isUploading: Bool {
+        if case .uploading = state { return true }
+        return false
+    }
+
+    var isFailed: Bool {
+        if case .failed = state { return true }
+        return false
+    }
+
+    var readyPath: String? {
+        if case .ready(let path) = state { return path }
+        return nil
+    }
+
+    /// The image test the drop path can afford: an extension, not the bytes
+    /// — the file viewer's own classification.
+    static func kind(forName name: String) -> Kind {
+        FileKind.classify(fileName: name) == .image ? .image : .file
+    }
+}
+
+/// The per-tab draft: what's typed and what's attached. Lives on the tab's
+/// session controller (beside its open state) so it follows the tab across
+/// window and tab switches and dies with the tab — never persisted.
+struct TalkbackDraft: Equatable {
+    /// The SEND face. `.waiting` while an upload is still in flight (the
+    /// message is never sent half); `.disabled` with nothing to send, with a
+    /// failed chip still attached, or while the pane can't take input.
+    enum SendState: Equatable {
+        case disabled
+        case waiting
+        case ready
+    }
+
+    var text = ""
+    var attachments: [TalkbackAttachment] = []
+    /// Bumped by the key that opens the box: the composer focuses its field
+    /// exactly once per request, so a tab switch back to an open box never
+    /// steals the keyboard.
+    var focusRequest = 0
+
+    var isEmpty: Bool {
+        TalkbackMessage.sanitizedBody(text).isEmpty && attachments.isEmpty
+    }
+
+    var hasUploadInFlight: Bool { attachments.contains(where: \.isUploading) }
+    var hasFailedAttachment: Bool { attachments.contains(where: \.isFailed) }
+
+    /// Paths of the landed attachments, in attach order.
+    var readyPaths: [String] { attachments.compactMap(\.readyPath) }
+
+    /// The SEND face for a pane that can take input; the controller folds
+    /// its own liveness in on top.
+    var sendState: SendState {
+        if isEmpty || hasFailedAttachment { return .disabled }
+        if hasUploadInFlight { return .waiting }
+        return .ready
+    }
+
+    /// What SEND leaves behind: an empty box (the open state lives outside).
+    mutating func clearAfterSend() {
+        text = ""
+        attachments.removeAll()
+    }
+
+    mutating func update(_ id: UUID, _ change: (inout TalkbackAttachment) -> Void) {
+        guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
+        change(&attachments[index])
+    }
+}
+
+/// The bytes SEND writes, and the rules that keep them honest.
+enum TalkbackMessage {
+    /// A CR sent as a SEPARATE write this long after the text — the slash
+    /// chips' proven shape (Codex reads a same-burst Enter as a pasted
+    /// newline; verified rust-v0.144, Claude / Pi / Grok accept it too).
+    static let submitDelay = AgentCommand.submitDelay
+    /// The most lines the field grows to before scrolling inside itself.
+    static let maximumVisibleLines = 5
+
+    static let bracketedPasteStart = Data([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E])
+    static let bracketedPasteEnd = Data([0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E])
+    static let submit = Data([0x0D])
+
+    /// The body as it goes on the wire: the composed-text rule (CR / CRLF
+    /// become LF, tabs stay, every other control is dropped — no Escape, no
+    /// Ctrl-B, no CSI can ride a message) with trailing blank space trimmed
+    /// so a submitting CR never lands on an empty line. Leading space stays:
+    /// the user typed it.
+    static func sanitizedBody(_ text: String) -> String {
+        var body = ComposedText.lineNormalized(text)
+        while let last = body.unicodeScalars.last,
+              last == " " || last == "\n" || last == "\t" {
+            body.unicodeScalars.removeLast()
+        }
+        return body
+    }
+
+    /// One paste: the landed attachment paths first (quoted only where a
+    /// shell would need it, space-joined, one trailing space — exactly what
+    /// the FILE button types), then the sanitized body verbatim, newlines
+    /// included. Wrapped in the bracketed-paste markers when the pane has
+    /// mode 2004 on (Claude Code and Codex do — a multi-line body then lands
+    /// as one message); at a bare shell the lines go as-is, PASTE's own
+    /// behaviour. Empty when there is nothing to say.
+    static func payload(body: String, paths: [String], bracketed: Bool) -> Data {
+        let text = DropText.typedPaths(paths) + sanitizedBody(body)
+        guard !text.isEmpty else { return Data() }
+        var data = Data()
+        if bracketed { data.append(bracketedPasteStart) }
+        data.append(Data(text.utf8))
+        if bracketed { data.append(bracketedPasteEnd) }
+        return data
+    }
+
+    /// The field's empty-state copy, in the target's own name.
+    static func placeholder(agentName: String?) -> String {
+        agentName.map { "Message \($0)…" } ?? "Message this pane…"
+    }
+}

--- a/Multiplex/Models/TerminalGuide.swift
+++ b/Multiplex/Models/TerminalGuide.swift
@@ -210,8 +210,26 @@ enum TerminalGuide {
             ]
         ),
         TerminalGuideEntry(
-            id: "resize",
+            id: "talkback",
             figure: 13,
+            bank: .keyboard,
+            title: "MESSAGE BOX",
+            tag: nil,
+            body: [
+                .text("The speech-bubble key beside "),
+                .key("RET"),
+                .text(" opens a message box: write with autocorrect and your keyboard's "
+                    + "own dictation, attach photos or files, then "),
+                .control("↑"),
+                .text(" sends it all as one message. The rail keeps driving the pane "
+                    + "while you write; hold "),
+                .control("↑"),
+                .text(" to type without submitting. Locking the keyboard closes it."),
+            ]
+        ),
+        TerminalGuideEntry(
+            id: "resize",
+            figure: 14,
             bank: .herdrPanes,
             title: "RESIZE PANES",
             tag: "herdr",
@@ -221,7 +239,7 @@ enum TerminalGuide {
         ),
         TerminalGuideEntry(
             id: "panemenu",
-            figure: 14,
+            figure: 15,
             bank: .herdrPanes,
             title: "PANE MENU",
             tag: "herdr",

--- a/Multiplex/Services/FileViewerController.swift
+++ b/Multiplex/Services/FileViewerController.swift
@@ -33,7 +33,7 @@ final class FileViewerController: AuxiliaryPaneController {
     /// The longest edge the viewer decodes to. Encoded bytes bound nothing
     /// about a bitmap's size, and the screen this renders on is smaller than
     /// this in every dimension.
-    static let imageMaxPixelEdge = 4096
+    nonisolated static let imageMaxPixelEdge = 4096
 
     /// The ceiling for an image shown INSIDE a document. A rendered column is
     /// at most 760 pt wide, so this is retina-generous — and a README can
@@ -43,7 +43,8 @@ final class FileViewerController: AuxiliaryPaneController {
     /// Decode through ImageIO with a pixel ceiling, so a decompression bomb
     /// from the host costs a downsample instead of the app's memory.
     /// Falls back to nothing (i.e. "binary") when the bytes aren't an image.
-    static func decodeImage(_ data: Data, maxPixelEdge: Int = imageMaxPixelEdge) -> UIImage? {
+    /// Actor-free: the Talkback thumbnail runs it off the main thread.
+    nonisolated static func decodeImage(_ data: Data, maxPixelEdge: Int = imageMaxPixelEdge) -> UIImage? {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil),
               CGImageSourceGetCount(source) > 0
         else { return nil }

--- a/Multiplex/Services/KeyCommandDispatcher.swift
+++ b/Multiplex/Services/KeyCommandDispatcher.swift
@@ -10,7 +10,7 @@ import SwiftTerm
 enum KeyCommandDispatcher {
     /// The slash-chip shape: a text row's Enter is a separate write this long
     /// after the text (Codex treats a same-burst CR as a pasted newline).
-    static let submitDelay: Duration = .milliseconds(160)
+    static let submitDelay = AgentCommand.submitDelay
 
     /// Starts the send (or the repeat burst) and returns its task; nil when
     /// the command has nothing to send in this terminal's mode. The burst

--- a/Multiplex/Services/TalkbackThumbnail.swift
+++ b/Multiplex/Services/TalkbackThumbnail.swift
@@ -1,0 +1,34 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// The Talkback composer's photo thumbnails: a small JPEG made once at attach
+/// time (off the main thread) so the draft carries it across tab switches
+/// without holding the original. ImageIO decodes straight at the reduced
+/// size — a camera HEIC never materializes its full bitmap.
+enum TalkbackThumbnail {
+    static let maximumPixelEdge = 192
+
+    static func jpeg(from data: Data) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maximumPixelEdge,
+        ]
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+        else { return nil }
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output, UTType.jpeg.identifier as CFString, 1, nil
+        ) else { return nil }
+        CGImageDestinationAddImage(
+            destination,
+            thumbnail,
+            [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}

--- a/Multiplex/Services/TalkbackThumbnail.swift
+++ b/Multiplex/Services/TalkbackThumbnail.swift
@@ -1,24 +1,19 @@
-import CoreGraphics
-import Foundation
 import ImageIO
+import UIKit
 import UniformTypeIdentifiers
 
 /// The Talkback composer's photo thumbnails: a small JPEG made once at attach
 /// time (off the main thread) so the draft carries it across tab switches
-/// without holding the original. ImageIO decodes straight at the reduced
-/// size — a camera HEIC never materializes its full bitmap.
+/// without holding the original. The file viewer's ImageIO downsample
+/// decodes straight at the reduced size — a camera HEIC never materializes
+/// its full bitmap.
 enum TalkbackThumbnail {
     static let maximumPixelEdge = 192
 
     static func jpeg(from data: Data) -> Data? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
-        let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maximumPixelEdge,
-        ]
-        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
-        else { return nil }
+        guard let thumbnail = FileViewerController.decodeImage(
+            data, maxPixelEdge: maximumPixelEdge
+        )?.cgImage else { return nil }
         let output = NSMutableData()
         guard let destination = CGImageDestinationCreateWithData(
             output, UTType.jpeg.identifier as CFString, 1, nil

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -1820,16 +1820,29 @@ final class TerminalSessionController {
     }
 
     /// The one upload for both roads — the pane's drop path and the Talkback
-    /// draft: the destination resolved once, names sanitized, the 64 MB cap
-    /// applied, and the paths as they will be typed handed back. Progress
-    /// arrives per file index; failure throws (`DropError` carries the
-    /// user-facing words).
+    /// draft: the destination resolved once per batch, names sanitized, the
+    /// 64 MB cap applied, and the paths as they will be typed handed back.
+    /// Progress arrives per file index; failure throws (`DropError` carries
+    /// the user-facing words).
     private func uploadForTypedPaths(
         _ files: [DroppedFile],
         over connection: SSHConnection,
         onProgress: @escaping @Sendable (_ index: Int, _ fraction: Double) -> Void
     ) async throws -> [String] {
-        let destination = try await dropDestination(over: connection)
+        try await upload(
+            files,
+            to: dropDestination(over: connection),
+            over: connection,
+            onProgress: onProgress
+        )
+    }
+
+    private func upload(
+        _ files: [DroppedFile],
+        to destination: DropDestination,
+        over connection: SSHConnection,
+        onProgress: @escaping @Sendable (_ index: Int, _ fraction: Double) -> Void
+    ) async throws -> [String] {
         let uploads = try files.map { file -> SSHUpload in
             guard file.data.count <= DropText.maxBytes else {
                 throw DropError(message: "\(file.name) is over 64 MB")
@@ -1939,7 +1952,12 @@ final class TerminalSessionController {
     /// sent or the chip removed, so a failed upload retries without another
     /// trip through the picker.
     @ObservationIgnored private var talkbackFiles: [UUID: DroppedFile] = [:]
-    @ObservationIgnored private var talkbackUploadQueue: [UUID] = []
+    /// Each queued chip remembers its pick: the drop destination is resolved
+    /// once per pick (one exec, like a drop's batch), not once per file — a
+    /// later pick re-resolves, the pane's cwd may have moved between picks.
+    @ObservationIgnored private var talkbackUploadQueue: [(id: UUID, pick: Int)] = []
+    @ObservationIgnored private var talkbackPicks = 0
+    @ObservationIgnored private var talkbackPickDestination: (pick: Int, destination: DropDestination)?
     @ObservationIgnored private var talkbackUploadTask: Task<Void, Never>?
     /// The last focus request the composer consumed — per tab, so a tab
     /// switch back to an open box never re-takes the keyboard.
@@ -1985,6 +2003,7 @@ final class TerminalSessionController {
     /// with the drop path's own words instead of dropping the intent
     /// silently.
     func attachTalkbackFiles(_ files: [DroppedFile]) {
+        talkbackPicks &+= 1
         for file in files {
             let kind = TalkbackAttachment.kind(forName: file.name)
             let attachment = TalkbackAttachment(
@@ -1994,7 +2013,7 @@ final class TerminalSessionController {
             )
             talkbackFiles[attachment.id] = file
             talkback.attachments.append(attachment)
-            enqueueTalkbackUpload(attachment.id)
+            enqueueTalkbackUpload(attachment.id, pick: talkbackPicks)
             guard kind == .image else { continue }
             // Decoding a camera-sized photo is tens of milliseconds; the chip
             // shows its ring first and its picture a beat later.
@@ -2016,13 +2035,16 @@ final class TerminalSessionController {
         talkbackFiles[id] = nil
     }
 
-    /// A failed chip's tap: back to uploading, back in the queue.
+    /// A failed chip's tap: back to uploading, back in the queue as a pick
+    /// of its own (the destination is resolved afresh — it may be what
+    /// failed).
     func retryTalkbackAttachment(_ id: UUID) {
         guard talkbackFiles[id] != nil,
               talkback.attachments.first(where: { $0.id == id })?.isFailed == true
         else { return }
         talkback.update(id) { $0.state = .uploading(fraction: 0) }
-        enqueueTalkbackUpload(id)
+        talkbackPicks &+= 1
+        enqueueTalkbackUpload(id, pick: talkbackPicks)
     }
 
     /// SEND (`submit`) or a long-press SEND (type only): one paste through
@@ -2064,8 +2086,8 @@ final class TerminalSessionController {
         }
     }
 
-    private func enqueueTalkbackUpload(_ id: UUID) {
-        talkbackUploadQueue.append(id)
+    private func enqueueTalkbackUpload(_ id: UUID, pick: Int) {
+        talkbackUploadQueue.append((id, pick))
         guard talkbackUploadTask == nil else { return }
         talkbackUploadTask = Task { [weak self] in
             await self?.drainTalkbackUploads()
@@ -2075,18 +2097,17 @@ final class TerminalSessionController {
 
     private func drainTalkbackUploads() async {
         while !talkbackUploadQueue.isEmpty {
-            let id = talkbackUploadQueue.removeFirst()
-            guard let file = talkbackFiles[id],
-                  talkback.attachments.contains(where: { $0.id == id })
+            let entry = talkbackUploadQueue.removeFirst()
+            guard let file = talkbackFiles[entry.id],
+                  talkback.attachments.contains(where: { $0.id == entry.id })
             else { continue }
-            await uploadTalkbackAttachment(id, file: file)
+            await uploadTalkbackAttachment(entry.id, file: file, pick: entry.pick)
         }
     }
 
     /// The drop path's upload, one file at a time so a failure marks only
-    /// its own chip; the destination is re-resolved per file, like drops
-    /// re-resolve per batch — the pane's cwd may have moved between picks.
-    private func uploadTalkbackAttachment(_ id: UUID, file: DroppedFile) async {
+    /// its own chip, into the destination resolved for this chip's pick.
+    private func uploadTalkbackAttachment(_ id: UUID, file: DroppedFile, pick: Int) async {
         guard canUploadFiles else {
             failTalkbackAttachment(id, Self.uploadUnavailableMessage)
             return
@@ -2096,7 +2117,14 @@ final class TerminalSessionController {
             return
         }
         do {
-            let paths = try await uploadForTypedPaths([file], over: connection) { [weak self] _, fraction in
+            let destination: DropDestination
+            if let memo = talkbackPickDestination, memo.pick == pick {
+                destination = memo.destination
+            } else {
+                destination = try await dropDestination(over: connection)
+                talkbackPickDestination = (pick, destination)
+            }
+            let paths = try await upload([file], to: destination, over: connection) { [weak self] _, fraction in
                 Task { @MainActor [weak self] in
                     self?.talkback.update(id) { attachment in
                         guard attachment.isUploading else { return }

--- a/Multiplex/Services/TerminalSessionController.swift
+++ b/Multiplex/Services/TerminalSessionController.swift
@@ -1757,17 +1757,25 @@ final class TerminalSessionController {
     /// upload each into the active pane's working directory over this tab's
     /// own connection, then type the resulting paths through the input pump
     /// — no Enter, the user finishes the prompt. One batch at a time.
+    /// Whether this tab can take a file: an SSH-backed session tab. Mosh has
+    /// no SFTP channel, and a plain shell has no multiplexer pane whose
+    /// foreground cwd could be resolved. The chrome's FILE rule and the
+    /// Talkback paperclip both read this.
+    var canUploadFiles: Bool {
+        !host.useMosh && route.sessionBackend != nil
+    }
+
+    static let uploadUnavailableMessage = "File upload requires tmux or herdr over SSH"
+
     func deliverDrop(_ files: [DroppedFile]) {
         // The jump search owns the pane's input while it pages; the FINDING
         // veil is visible over the drop target for its few seconds.
         if case .finding = historyJump { return }
-        if host.useMosh || route.sessionBackend == nil,
-           status == .live, dropTask == nil, !files.isEmpty {
-            // Mosh has no SFTP channel, while a plain shell has no
-            // multiplexer pane whose foreground cwd can be resolved. Say so
-            // instead of silently discarding the user's attach/drop intent.
+        if !canUploadFiles, status == .live, dropTask == nil, !files.isEmpty {
+            // Say so instead of silently discarding the user's attach/drop
+            // intent.
             dropClearTask?.cancel()
-            dropState = .failed("File upload requires tmux or herdr over SSH")
+            dropState = .failed(Self.uploadUnavailableMessage)
             dropClearTask = Task { [weak self] in
                 try? await Task.sleep(for: .seconds(5))
                 guard !Task.isCancelled else { return }
@@ -1786,37 +1794,16 @@ final class TerminalSessionController {
 
     private func performDrop(_ files: [DroppedFile], over connection: SSHConnection) async {
         do {
-            let destination = try await dropDestination(over: connection)
-            let uploads = try files.map { file -> SSHUpload in
-                guard file.data.count <= DropText.maxBytes else {
-                    throw DropError(message: "\(file.name) is over 64 MB")
-                }
-                return SSHUpload(
-                    data: file.data,
-                    preferredName: DropText.sanitizedName(file.name)
-                )
-            }
             let displayNames = files.map(\.name)
             dropState = .uploading(name: files[0].name, fraction: 0)
-            let finalNames = try await connection.uploadFiles(
-                uploads,
-                toDirectory: destination.directory,
-                prepareGitIgnoredDirectory: destination.prepareGitIgnoredDirectory,
-                onProgress: { [weak self] index, fraction in
-                    Task { @MainActor [weak self] in
-                        guard case .uploading = self?.dropState else { return }
-                        self?.dropState = .uploading(
-                            name: displayNames[index],
-                            fraction: fraction
-                        )
-                    }
+            let typedPaths = try await uploadForTypedPaths(files, over: connection) { [weak self] index, fraction in
+                Task { @MainActor [weak self] in
+                    guard case .uploading = self?.dropState else { return }
+                    self?.dropState = .uploading(
+                        name: displayNames[index],
+                        fraction: fraction
+                    )
                 }
-            )
-            let typedPaths = finalNames.map { finalName in
-                // Relative names read best in a prompt, but only when the
-                // file verifiably sits under the pane's cwd.
-                destination.typedPrefix.map { $0 + finalName }
-                    ?? destination.directory + "/" + finalName
             }
             dropState = nil
             sendInput(Data(DropText.typedPaths(typedPaths).utf8))
@@ -1832,12 +1819,47 @@ final class TerminalSessionController {
         }
     }
 
+    /// The one upload for both roads — the pane's drop path and the Talkback
+    /// draft: the destination resolved once, names sanitized, the 64 MB cap
+    /// applied, and the paths as they will be typed handed back. Progress
+    /// arrives per file index; failure throws (`DropError` carries the
+    /// user-facing words).
+    private func uploadForTypedPaths(
+        _ files: [DroppedFile],
+        over connection: SSHConnection,
+        onProgress: @escaping @Sendable (_ index: Int, _ fraction: Double) -> Void
+    ) async throws -> [String] {
+        let destination = try await dropDestination(over: connection)
+        let uploads = try files.map { file -> SSHUpload in
+            guard file.data.count <= DropText.maxBytes else {
+                throw DropError(message: "\(file.name) is over 64 MB")
+            }
+            return SSHUpload(
+                data: file.data,
+                preferredName: DropText.sanitizedName(file.name)
+            )
+        }
+        let finalNames = try await connection.uploadFiles(
+            uploads,
+            toDirectory: destination.directory,
+            prepareGitIgnoredDirectory: destination.prepareGitIgnoredDirectory,
+            onProgress: onProgress
+        )
+        return finalNames.map(destination.typedPath(for:))
+    }
+
     private struct DropDestination {
         var directory: String
         /// Prefix for typed relative paths ("" = bare name,
         /// ".multiplex-drops/" inside git worktrees); nil types absolute.
         var typedPrefix: String?
         var prepareGitIgnoredDirectory: Bool
+
+        /// Relative names read best in a prompt, but only when the file
+        /// verifiably sits under the pane's cwd.
+        func typedPath(for finalName: String) -> String {
+            typedPrefix.map { $0 + finalName } ?? directory + "/" + finalName
+        }
     }
 
     /// The pane's cwd when the session backend can tell us (both follow
@@ -1901,6 +1923,198 @@ final class TerminalSessionController {
         case nil:
             return (nil, false)
         }
+    }
+
+    // MARK: Talkback
+
+    /// The chat-style message box under this tab's pane. `talkbackOpen` is
+    /// what the window, the rail and the cluster watch (it flips on the talk
+    /// key); `talkback` is the draft only the composer renders — text and
+    /// attachments — so a keystroke never re-renders a window. Both follow
+    /// the tab across windows and die with it; never persisted. SEND is
+    /// `sendTalkback`. Design record: `local-plan/talkback-bakeoff/`.
+    private(set) var talkbackOpen = false
+    private(set) var talkback = TalkbackDraft()
+    /// The picked bytes behind each attachment, kept until the message is
+    /// sent or the chip removed, so a failed upload retries without another
+    /// trip through the picker.
+    @ObservationIgnored private var talkbackFiles: [UUID: DroppedFile] = [:]
+    @ObservationIgnored private var talkbackUploadQueue: [UUID] = []
+    @ObservationIgnored private var talkbackUploadTask: Task<Void, Never>?
+    /// The last focus request the composer consumed — per tab, so a tab
+    /// switch back to an open box never re-takes the keyboard.
+    @ObservationIgnored private var talkbackFocusHandled = 0
+
+    /// The SEND face with this tab's own input rules folded in: nothing goes
+    /// while the tab isn't live or the history jump owns the pane.
+    var talkbackSendState: TalkbackDraft.SendState {
+        guard status == .live else { return .disabled }
+        if case .finding = historyJump { return .disabled }
+        return talkback.sendState
+    }
+
+    /// The talk key. Opening asks the composer to take the keyboard; a key
+    /// pressed on an already-open box asks again (the box may have lost the
+    /// keyboard to the pane).
+    func setTalkbackOpen(_ open: Bool) {
+        if open { talkback.focusRequest &+= 1 }
+        if talkbackOpen != open { talkbackOpen = open }
+    }
+
+    func toggleTalkback() {
+        setTalkbackOpen(!talkbackOpen)
+    }
+
+    /// True exactly once per open/keypress: the composer focuses its field
+    /// on it and never on a mere re-render.
+    func consumeTalkbackFocusRequest() -> Bool {
+        guard talkback.focusRequest != talkbackFocusHandled else { return false }
+        talkbackFocusHandled = talkback.focusRequest
+        return true
+    }
+
+    /// The field's edits — the composer is the writer, this is the record.
+    func setTalkbackText(_ text: String) {
+        guard talkback.text != text else { return }
+        talkback.text = text
+    }
+
+    /// Files picked through the composer's paperclip: each becomes an
+    /// uploading chip and joins one serial upload queue (the drop path's
+    /// SFTP, into the pane's cwd). Tabs that can't upload fail the chips
+    /// with the drop path's own words instead of dropping the intent
+    /// silently.
+    func attachTalkbackFiles(_ files: [DroppedFile]) {
+        for file in files {
+            let kind = TalkbackAttachment.kind(forName: file.name)
+            let attachment = TalkbackAttachment(
+                name: file.name,
+                byteCount: file.data.count,
+                kind: kind
+            )
+            talkbackFiles[attachment.id] = file
+            talkback.attachments.append(attachment)
+            enqueueTalkbackUpload(attachment.id)
+            guard kind == .image else { continue }
+            // Decoding a camera-sized photo is tens of milliseconds; the chip
+            // shows its ring first and its picture a beat later.
+            let id = attachment.id
+            let data = file.data
+            Task.detached(priority: .userInitiated) { [weak self] in
+                let preview = TalkbackThumbnail.jpeg(from: data)
+                await MainActor.run { [weak self] in
+                    self?.talkback.update(id) { $0.preview = preview }
+                }
+            }
+        }
+    }
+
+    /// The drain loop skips an id no longer attached, so removal needs no
+    /// queue surgery.
+    func removeTalkbackAttachment(_ id: UUID) {
+        talkback.attachments.removeAll { $0.id == id }
+        talkbackFiles[id] = nil
+    }
+
+    /// A failed chip's tap: back to uploading, back in the queue.
+    func retryTalkbackAttachment(_ id: UUID) {
+        guard talkbackFiles[id] != nil,
+              talkback.attachments.first(where: { $0.id == id })?.isFailed == true
+        else { return }
+        talkback.update(id) { $0.state = .uploading(fraction: 0) }
+        enqueueTalkbackUpload(id)
+    }
+
+    /// SEND (`submit`) or a long-press SEND (type only): one paste through
+    /// the ordered pump — the landed paths first, then the body, wrapped in
+    /// the bracketed-paste markers when the pane has mode 2004 on — and, for
+    /// SEND, a CR as its own write ~160 ms later (the slash chips' shape).
+    /// Clears the draft; the box stays open. False when nothing went.
+    @discardableResult
+    func sendTalkback(submit: Bool) -> Bool {
+        guard talkbackSendState == .ready else { return false }
+        let bracketed = terminalView?.getTerminal().bracketedPasteMode == true
+        let payload = TalkbackMessage.payload(
+            body: talkback.text,
+            paths: talkback.readyPaths,
+            bracketed: bracketed
+        )
+        guard !payload.isEmpty else { return false }
+        typeTalkback(payload)
+        if submit {
+            Task { [weak self] in
+                try? await Task.sleep(for: TalkbackMessage.submitDelay)
+                self?.typeTalkback(TalkbackMessage.submit)
+            }
+        }
+        // `.ready` means nothing is uploading or queued, so the kept bytes
+        // are exactly the attachments that just went.
+        talkbackFiles.removeAll()
+        talkback.clearAfterSend()
+        return true
+    }
+
+    /// The view's send path when it exists (it stamps the typing-quiet
+    /// clock and keeps the caret in view), the pump directly otherwise.
+    private func typeTalkback(_ data: Data) {
+        if let terminalView {
+            terminalView.send(data: [UInt8](data)[...])
+        } else {
+            sendInput(data)
+        }
+    }
+
+    private func enqueueTalkbackUpload(_ id: UUID) {
+        talkbackUploadQueue.append(id)
+        guard talkbackUploadTask == nil else { return }
+        talkbackUploadTask = Task { [weak self] in
+            await self?.drainTalkbackUploads()
+            self?.talkbackUploadTask = nil
+        }
+    }
+
+    private func drainTalkbackUploads() async {
+        while !talkbackUploadQueue.isEmpty {
+            let id = talkbackUploadQueue.removeFirst()
+            guard let file = talkbackFiles[id],
+                  talkback.attachments.contains(where: { $0.id == id })
+            else { continue }
+            await uploadTalkbackAttachment(id, file: file)
+        }
+    }
+
+    /// The drop path's upload, one file at a time so a failure marks only
+    /// its own chip; the destination is re-resolved per file, like drops
+    /// re-resolve per batch — the pane's cwd may have moved between picks.
+    private func uploadTalkbackAttachment(_ id: UUID, file: DroppedFile) async {
+        guard canUploadFiles else {
+            failTalkbackAttachment(id, Self.uploadUnavailableMessage)
+            return
+        }
+        guard status == .live, let connection else {
+            failTalkbackAttachment(id, "Not connected")
+            return
+        }
+        do {
+            let paths = try await uploadForTypedPaths([file], over: connection) { [weak self] _, fraction in
+                Task { @MainActor [weak self] in
+                    self?.talkback.update(id) { attachment in
+                        guard attachment.isUploading else { return }
+                        attachment.state = .uploading(fraction: fraction)
+                    }
+                }
+            }
+            guard let path = paths.first else { throw DropError(message: "Upload failed") }
+            talkback.update(id) { $0.state = .ready(path: path) }
+        } catch is CancellationError {
+            failTalkbackAttachment(id, "Cancelled")
+        } catch {
+            failTalkbackAttachment(id, (error as? DropError)?.message ?? "Upload failed")
+        }
+    }
+
+    private func failTalkbackAttachment(_ id: UUID, _ message: String) {
+        talkback.update(id) { $0.state = .failed(message) }
     }
 
     // MARK: Links

--- a/Multiplex/Views/Terminal/AgentHelperStrip.swift
+++ b/Multiplex/Views/Terminal/AgentHelperStrip.swift
@@ -336,7 +336,7 @@ final class AgentHelperStripViewController: UIViewController,
 
         if isCollapsed {
             let dot = AgentHelperStripDotButton(
-                glyph: configuration.agent.dotGlyph,
+                glyph: configuration.agent.glyph,
                 accessibilityLabel: "Show \(configuration.agent.displayName) helpers",
                 action: { [weak self] in self?.perform(.expand) }
             )
@@ -945,20 +945,6 @@ private final class AgentHelperStripDotGlyphView: UIView {
         )
         CTLineDraw(line, context)
         context.restoreGState()
-    }
-}
-
-private extension AgentKind {
-    /// The collapsed dot's face — each agent's own mark where it has one.
-    var dotGlyph: String {
-        switch self {
-        case .claudeCode: "✳"
-        case .codex: "◆"
-        case .pi: "π"
-        // Grok has no single-glyph mark of its own in the TUI; the plain
-        // capital reads as xAI's without leaning on a font-fallback symbol.
-        case .grok: "X"
-        }
     }
 }
 

--- a/Multiplex/Views/Terminal/AgentHelperStrip.swift
+++ b/Multiplex/Views/Terminal/AgentHelperStrip.swift
@@ -948,12 +948,13 @@ private final class AgentHelperStripDotGlyphView: UIView {
     }
 }
 
-/// The command rail's scroller. Same contract as the tab rail's: a scroll
-/// view delays content touches by 150 ms and drops them if the finger drifts
-/// during that window, so an overflowing chip row loses ordinary presses.
-/// Track at once, and keep drag-to-scroll from a chip by answering the cancel
-/// question for controls, whose UIKit default (false) would otherwise pin the
-/// rail once touches are undelayed.
+/// The command rail's scroller — and the Talkback composer's attachment
+/// row's. Same contract as the tab rail's: a scroll view delays content
+/// touches by 150 ms and drops them if the finger drifts during that window,
+/// so an overflowing chip row loses ordinary presses. Track at once, and keep
+/// drag-to-scroll from a chip by answering the cancel question for controls,
+/// whose UIKit default (false) would otherwise pin the rail once touches are
+/// undelayed.
 @MainActor
 final class AgentHelperCommandScrollView: UIScrollView {
     override init(frame: CGRect) {
@@ -965,7 +966,7 @@ final class AgentHelperCommandScrollView: UIScrollView {
     required init?(coder: NSCoder) { fatalError("unused") }
 
     override func touchesShouldCancel(in view: UIView) -> Bool {
-        if view is UIButton { return true }
+        if view is UIControl { return true }
         return super.touchesShouldCancel(in: view)
     }
 }

--- a/Multiplex/Views/Terminal/FileAttachMenu.swift
+++ b/Multiplex/Views/Terminal/FileAttachMenu.swift
@@ -19,9 +19,7 @@ enum FileAttachAvailability {
     /// Mosh has no SFTP channel; a plain shell has no pane to ask.
     @MainActor
     static func canOffer(for controller: TerminalSessionController?) -> Bool {
-        guard let controller else { return false }
-        return !controller.host.useMosh
-            && controller.route.sessionBackend != nil
+        controller?.canUploadFiles == true
     }
 
     #if !os(visionOS)
@@ -66,6 +64,14 @@ class FileAttachPickerPresenterViewController: UIViewController,
 {
     private(set) var queuedPicker: FileAttachPicker?
     private(set) weak var queuedTarget: TerminalSessionController?
+    /// The tab the menu built here aims its pickers at. The FILE chip and
+    /// the Talkback paperclip both point one presenter at the active tab.
+    fileprivate(set) var terminalController: TerminalSessionController?
+    /// Where picked files land. nil = the target's own drop path
+    /// (`deliverDrop`: upload, then type the paths into the pane); the
+    /// Talkback composer routes them into the target's draft instead. The
+    /// target still decides eligibility either way.
+    var deliver: ((TerminalSessionController, [DroppedFile]) -> Void)?
 
     private var activeTarget: TerminalSessionController?
     private var externalRequestIsLatched = false
@@ -81,6 +87,58 @@ class FileAttachPickerPresenterViewController: UIViewController,
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         presentQueuedPickerIfPossible()
+    }
+
+    /// Re-aim at another tab. The FILE chip re-renders its button on top.
+    func update(controller: TerminalSessionController?) {
+        terminalController = controller
+    }
+
+    /// The direct FILE chip, the compact terminal overflow and the Talkback
+    /// paperclip share these exact picker actions. Capturing `target` when
+    /// the menu is built preserves the selected session if a tab switch
+    /// races the system picker.
+    func makeSourceMenu(
+        title: String = "",
+        image: UIImage? = nil,
+        availability: FileAttachMenuAvailability? = nil
+    ) -> UIMenu? {
+        guard let target = terminalController,
+              FileAttachAvailability.canOffer(for: target)
+        else { return nil }
+        let availability = availability
+            ?? FileAttachMenuAvailability(controller: target)
+        guard availability.canOffer else { return nil }
+        let enabled = availability.actionsEnabled
+        var actions: [UIMenuElement] = []
+        #if !os(visionOS)
+        actions.append(UIAction(
+            title: "Camera…",
+            image: UIImage(systemName: "camera"),
+            identifier: UIAction.Identifier("terminal.attach.camera"),
+            attributes: enabled && FileAttachAvailability.cameraAvailable
+                ? [] : .disabled
+        ) { [weak self, weak target] _ in
+            self?.request(.camera, target: target)
+        })
+        #endif
+        actions.append(UIAction(
+            title: "Photo Library…",
+            image: UIImage(systemName: "photo.on.rectangle"),
+            identifier: UIAction.Identifier("terminal.attach.photos"),
+            attributes: enabled ? [] : .disabled
+        ) { [weak self, weak target] _ in
+            self?.request(.photoLibrary, target: target)
+        })
+        actions.append(UIAction(
+            title: "Files…",
+            image: UIImage(systemName: "folder"),
+            identifier: UIAction.Identifier("terminal.attach.files"),
+            attributes: enabled ? [] : .disabled
+        ) { [weak self, weak target] _ in
+            self?.request(.files, target: target)
+        })
+        return UIMenu(title: title, image: image, children: actions)
     }
 
     func request(
@@ -155,8 +213,9 @@ class FileAttachPickerPresenterViewController: UIViewController,
     ) {
         let target = activeTarget
         activeTarget = nil
-        Task { @MainActor in
-            target?.deliverDrop(await FileAttachDataLoader.readSecurityScopedFiles(urls))
+        Task { @MainActor [weak self] in
+            let files = await FileAttachDataLoader.readSecurityScopedFiles(urls)
+            self?.deliverPicked(files, to: target)
         }
         scheduleQueuedPresentation()
     }
@@ -173,8 +232,9 @@ class FileAttachPickerPresenterViewController: UIViewController,
             self?.presentQueuedPickerIfPossible()
         }
         guard !results.isEmpty else { return }
-        Task { @MainActor in
-            target?.deliverDrop(await FileAttachDataLoader.loadPhotos(results))
+        Task { @MainActor [weak self] in
+            let files = await FileAttachDataLoader.loadPhotos(results)
+            self?.deliverPicked(files, to: target)
         }
     }
 
@@ -196,6 +256,17 @@ class FileAttachPickerPresenterViewController: UIViewController,
         guard let picker = makePicker(for: source) else { return }
         activeTarget = target
         present(picker, animated: true)
+    }
+
+    /// One landing for every picker: the composer's draft when it asked, the
+    /// pane's drop path otherwise.
+    func deliverPicked(_ files: [DroppedFile], to target: TerminalSessionController?) {
+        guard let target, !files.isEmpty else { return }
+        if let deliver {
+            deliver(target, files)
+        } else {
+            target.deliverDrop(files)
+        }
     }
 
     private func scheduleQueuedPresentation() {
@@ -239,9 +310,7 @@ extension FileAttachPickerPresenterViewController: UINavigationControllerDelegat
         picker.dismiss(animated: true) { [weak self] in
             self?.presentQueuedPickerIfPossible()
         }
-        target?.deliverDrop([
-            DroppedFile(name: DropText.photoName(), data: data),
-        ])
+        deliverPicked([DroppedFile(name: DropText.photoName(), data: data)], to: target)
     }
 }
 #endif
@@ -297,13 +366,12 @@ enum FileAttachDataLoader {
 final class FileAttachMenuViewController: FileAttachPickerPresenterViewController {
     private(set) var attachButton = FileAttachBadgeButton()
 
-    private var terminalController: TerminalSessionController?
     private var observationGeneration = 0
     private var buttonParkingConstraints: [NSLayoutConstraint] = []
 
     init(controller: TerminalSessionController?) {
-        terminalController = controller
         super.init(nibName: nil, bundle: nil)
+        terminalController = controller
     }
 
     @available(*, unavailable)
@@ -350,8 +418,8 @@ final class FileAttachMenuViewController: FileAttachPickerPresenterViewControlle
         NSLayoutConstraint.activate(buttonParkingConstraints)
     }
 
-    func update(controller: TerminalSessionController?) {
-        terminalController = controller
+    override func update(controller: TerminalSessionController?) {
+        super.update(controller: controller)
         guard isViewLoaded else { return }
         observationGeneration &+= 1
         renderAndObserve(generation: observationGeneration)
@@ -377,53 +445,6 @@ final class FileAttachMenuViewController: FileAttachPickerPresenterViewControlle
             ? makeSourceMenu(availability: availability)
             : nil
     }
-
-    /// The direct FILE chip and compact terminal overflows share these exact
-    /// picker actions. Capturing `target` when the menu is built preserves
-    /// the selected session if a tab switch races the system picker.
-    func makeSourceMenu(
-        title: String = "",
-        image: UIImage? = nil,
-        availability: FileAttachMenuAvailability? = nil
-    ) -> UIMenu? {
-        guard let target = terminalController,
-              FileAttachAvailability.canOffer(for: target)
-        else { return nil }
-        let availability = availability
-            ?? FileAttachMenuAvailability(controller: target)
-        guard availability.canOffer else { return nil }
-        let enabled = availability.actionsEnabled
-        var actions: [UIMenuElement] = []
-        #if !os(visionOS)
-        actions.append(UIAction(
-            title: "Camera…",
-            image: UIImage(systemName: "camera"),
-            identifier: UIAction.Identifier("terminal.attach.camera"),
-            attributes: enabled && FileAttachAvailability.cameraAvailable
-                ? [] : .disabled
-        ) { [weak self, weak target] _ in
-            self?.request(.camera, target: target)
-        })
-        #endif
-        actions.append(UIAction(
-            title: "Photo Library…",
-            image: UIImage(systemName: "photo.on.rectangle"),
-            identifier: UIAction.Identifier("terminal.attach.photos"),
-            attributes: enabled ? [] : .disabled
-        ) { [weak self, weak target] _ in
-            self?.request(.photoLibrary, target: target)
-        })
-        actions.append(UIAction(
-            title: "Files…",
-            image: UIImage(systemName: "folder"),
-            identifier: UIAction.Identifier("terminal.attach.files"),
-            attributes: enabled ? [] : .disabled
-        ) { [weak self, weak target] _ in
-            self?.request(.files, target: target)
-        })
-        return UIMenu(title: title, image: image, children: actions)
-    }
-
 }
 
 @MainActor

--- a/Multiplex/Views/Terminal/TalkbackComposer.swift
+++ b/Multiplex/Views/Terminal/TalkbackComposer.swift
@@ -1,4 +1,5 @@
 import Observation
+import os
 import UIKit
 #if DEBUG
 import notify
@@ -112,8 +113,13 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     /// The paperclip's pickers: FILE's own presenter, with its deliveries
     /// routed into the target's draft instead of the pane.
     private let attachPresenter = FileAttachPickerPresenterViewController()
+    private var keyWindowObserver: NSObjectProtocol?
     #if DEBUG
     private var debugObservers: [NSObjectProtocol] = []
+    private static let keyboardLogger = Logger(
+        subsystem: "app.multiplexterm.multiplex",
+        category: "kbd"
+    )
     #endif
 
     private struct RenderKey: Equatable {
@@ -148,6 +154,9 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     required init?(coder: NSCoder) { fatalError("unused") }
 
     deinit {
+        if let keyWindowObserver {
+            NotificationCenter.default.removeObserver(keyWindowObserver)
+        }
         #if DEBUG
         for observer in debugObservers {
             NotificationCenter.default.removeObserver(observer)
@@ -163,6 +172,7 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         view = root
         buildHierarchy()
         installAttachPresenter()
+        installKeyWindowObserver()
         #if DEBUG
         installDebugObservers()
         #endif
@@ -514,6 +524,30 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         line.addArrangedSubview(sendButton)
     }
 
+    /// The pane taking the keyboard back is a window becoming key on
+    /// visionOS (the card lives in the ornament's own window, the terminal in
+    /// the scene's): the field then steps down so the card dims and a later
+    /// tap on it starts a fresh hand-over. Only ANOTHER window counts — the
+    /// iPad card shares the terminal's window, and Stage Manager flips a
+    /// window's key state transiently while it is moved.
+    private func installKeyWindowObserver() {
+        keyWindowObserver = NotificationCenter.default.addObserver(
+            forName: UIWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            MainActor.assumeIsolated {
+                guard let self,
+                      let window = note.object as? UIWindow,
+                      window !== self.textView.window,
+                      window === self.configuration.controller.terminalView?.window,
+                      self.textView.isFirstResponder
+                else { return }
+                self.textView.resignFirstResponder()
+            }
+        }
+    }
+
     private func installAttachPresenter() {
         addChild(attachPresenter)
         attachPresenter.view.frame = .zero
@@ -738,7 +772,29 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         view.setNeedsLayout()
     }
 
+    /// The field takes the keyboard from the pane. UIKit resigns a previous
+    /// responder only within one window — and on visionOS the card lives in
+    /// the ornament's own window while the pane's terminal stays first
+    /// responder in the scene's window, which is where key events go. So the
+    /// terminal is suspended explicitly (ownership stays with it;
+    /// `resumeAfterPresentation` hands the keyboard back on close) and the
+    /// field's window is made key. Runs for a tap on the field as well as
+    /// for the talk key's programmatic focus.
     func textViewDidBeginEditing(_ textView: UITextView) {
+        if let terminal = configuration.controller.terminalView,
+           terminal.isFirstResponder,
+           !TerminalFocusArbiter.suspendForPresentation(terminal) {
+            terminal.resignFirstResponder()
+        }
+        if let window = textView.window, !window.isKeyWindow {
+            window.makeKey()
+        }
+        #if DEBUG
+        let terminal = configuration.controller.terminalView
+        Self.keyboardLogger.debug(
+            "talkback field focused key=\(textView.window?.isKeyWindow == true, privacy: .public) terminalResponder=\(terminal?.isFirstResponder == true, privacy: .public) terminalWindowKey=\(terminal?.window?.isKeyWindow == true, privacy: .public) sameWindow=\(terminal?.window === textView.window, privacy: .public)"
+        )
+        #endif
         setCardFocused(true)
     }
 

--- a/Multiplex/Views/Terminal/TalkbackComposer.swift
+++ b/Multiplex/Views/Terminal/TalkbackComposer.swift
@@ -74,7 +74,6 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     private var renderedPreviewKey: PreviewKey?
     private var renderedAttachKey: AttachKey?
     private var pendingFocus = false
-    private var lastReportedSize: CGSize = .zero
     /// One TextKit measurement per (text, width) — every sizing question in a
     /// pass reads it instead of re-laying the body out.
     private var measuredField: FieldMeasurement?
@@ -90,7 +89,7 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     private let stateLabel = UIKitChassisMonoLabel()
     private var needsYouLamp: UIKitTallyLamp?
     private let closeButton = TalkbackRoundButton(diameter: 20, symbol: "xmark", pointSize: 9)
-    private let previewScroll = UIScrollView()
+    private let previewScroll = AgentHelperCommandScrollView()
     private let previewRow = UIStackView()
     private var previewHeightConstraint: NSLayoutConstraint?
     private let line = UIStackView()
@@ -113,7 +112,6 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     /// The paperclip's pickers: FILE's own presenter, with its deliveries
     /// routed into the target's draft instead of the pane.
     private let attachPresenter = FileAttachPickerPresenterViewController()
-    private var keyWindowObserver: NSObjectProtocol?
     #if DEBUG
     private var debugObservers: [NSObjectProtocol] = []
     private static let keyboardLogger = Logger(
@@ -153,16 +151,13 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("unused") }
 
+    #if DEBUG
     deinit {
-        if let keyWindowObserver {
-            NotificationCenter.default.removeObserver(keyWindowObserver)
-        }
-        #if DEBUG
         for observer in debugObservers {
             NotificationCenter.default.removeObserver(observer)
         }
-        #endif
     }
+    #endif
 
     // MARK: Lifecycle
 
@@ -172,7 +167,6 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         view = root
         buildHierarchy()
         installAttachPresenter()
-        installKeyWindowObserver()
         #if DEBUG
         installDebugObservers()
         #endif
@@ -316,11 +310,11 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         }
     }
 
+    /// `preferredContentSize` is the memo (the visionOS host reads it too).
     private func reportSizeIfChanged() {
         let size = fittingContentSize()
-        guard size != lastReportedSize else { return }
-        lastReportedSize = size
-        if preferredContentSize != size { preferredContentSize = size }
+        guard size != preferredContentSize else { return }
+        preferredContentSize = size
         onContentSizeChange?()
     }
 
@@ -524,30 +518,6 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         line.addArrangedSubview(sendButton)
     }
 
-    /// The pane taking the keyboard back is a window becoming key on
-    /// visionOS (the card lives in the ornament's own window, the terminal in
-    /// the scene's): the field then steps down so the card dims and a later
-    /// tap on it starts a fresh hand-over. Only ANOTHER window counts — the
-    /// iPad card shares the terminal's window, and Stage Manager flips a
-    /// window's key state transiently while it is moved.
-    private func installKeyWindowObserver() {
-        keyWindowObserver = NotificationCenter.default.addObserver(
-            forName: UIWindow.didBecomeKeyNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
-            MainActor.assumeIsolated {
-                guard let self,
-                      let window = note.object as? UIWindow,
-                      window !== self.textView.window,
-                      window === self.configuration.controller.terminalView?.window,
-                      self.textView.isFirstResponder
-                else { return }
-                self.textView.resignFirstResponder()
-            }
-        }
-    }
-
     private func installAttachPresenter() {
         addChild(attachPresenter)
         attachPresenter.view.frame = .zero
@@ -596,6 +566,7 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         )
         guard key != renderedKey else { return }
         let controllerChanged = key.controllerID != renderedKey?.controllerID
+        let presentationChanged = key.presentation != renderedKey?.presentation
         renderedKey = key
 
         if controllerChanged {
@@ -605,11 +576,15 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
             textView.text = controller.talkback.text
             placeholder.isHidden = !textView.text.isEmpty
         }
-        renderChrome()
-        renderHeader()
-        placeholder.text = TalkbackMessage.placeholder(
-            agentName: configuration.presentation.agent?.displayName
-        )
+        // The chrome and the eyebrow read only the presentation — an
+        // upload's progress ticks leave them alone.
+        if presentationChanged {
+            renderChrome()
+            renderHeader()
+            placeholder.text = TalkbackMessage.placeholder(
+                agentName: configuration.presentation.agent?.displayName
+            )
+        }
         renderPreviews(state.attachments)
         renderButtons(state)
         refreshFieldHeight()
@@ -703,7 +678,9 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
             renderedPreviewKey = key
         } else {
             for (view, attachment) in zip(previewRow.arrangedSubviews, attachments) {
-                (view as? TalkbackAttachmentView)?.update(attachment)
+                guard let chip = view as? TalkbackAttachmentView, chip.attachment != attachment
+                else { continue }
+                chip.update(attachment)
             }
         }
         let hidden = attachments.isEmpty
@@ -772,25 +749,18 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
         view.setNeedsLayout()
     }
 
-    /// The field takes the keyboard from the pane. UIKit resigns a previous
-    /// responder only within one window — and on visionOS the card lives in
-    /// the ornament's own window while the pane's terminal stays first
-    /// responder in the scene's window, which is where key events go. So the
-    /// terminal is suspended explicitly (ownership stays with it;
-    /// `resumeAfterPresentation` hands the keyboard back on close) and the
-    /// field's window is made key. Runs for a tap on the field as well as
-    /// for the talk key's programmatic focus.
+    /// The field takes the keyboard from the pane: the arbiter steps the
+    /// terminal down and keys this window (visionOS mounts the card in the
+    /// ornament's own window, where UIKit would leave the terminal first
+    /// responder in the scene's), and remembers the field as the keyboard's
+    /// borrower — a pane tap, Escape or a scene activation claims a
+    /// terminal, which resigns the field so the card dims. Ownership stays
+    /// with the terminal; `resumeAfterPresentation` hands the keyboard back
+    /// on close.
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if let terminal = configuration.controller.terminalView,
-           terminal.isFirstResponder,
-           !TerminalFocusArbiter.suspendForPresentation(terminal) {
-            terminal.resignFirstResponder()
-        }
-        if let window = textView.window, !window.isKeyWindow {
-            window.makeKey()
-        }
-        #if DEBUG
         let terminal = configuration.controller.terminalView
+        TerminalFocusArbiter.lend(terminal, to: textView)
+        #if DEBUG
         Self.keyboardLogger.debug(
             "talkback field focused key=\(textView.window?.isKeyWindow == true, privacy: .public) terminalResponder=\(terminal?.isFirstResponder == true, privacy: .public) terminalWindowKey=\(terminal?.window?.isKeyWindow == true, privacy: .public) sameWindow=\(terminal?.window === textView.window, privacy: .public)"
         )
@@ -799,6 +769,12 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
+        #if DEBUG
+        let terminal = configuration.controller.terminalView
+        Self.keyboardLogger.debug(
+            "talkback field resigned terminalResponder=\(terminal?.isFirstResponder == true, privacy: .public) terminalWindowKey=\(terminal?.window?.isKeyWindow == true, privacy: .public)"
+        )
+        #endif
         setCardFocused(false)
     }
 
@@ -814,27 +790,25 @@ final class TalkbackComposerViewController: UIViewController, UITextViewDelegate
     private func installDebugObservers() {
         TalkbackDebugHook.install()
         let center = NotificationCenter.default
-        func observe(_ name: Notification.Name, _ action: @escaping @MainActor (Notification) -> Void) {
+        func observe(_ name: Notification.Name, _ action: @escaping @MainActor () -> Void) {
             debugObservers.append(center.addObserver(
                 forName: name,
                 object: nil,
                 queue: .main
-            ) { note in
-                MainActor.assumeIsolated { action(note) }
+            ) { _ in
+                MainActor.assumeIsolated { action() }
             })
         }
-        observe(.multiplexDebugTalkbackType) { [weak self] note in
+        observe(.multiplexDebugTalkbackType) { [weak self] in
             guard let self, self.view.window != nil else { return }
-            let text = (note.userInfo?["text"] as? String)
-                ?? "Talkback headless proof\nsecond line"
-            self.textView.text = text
+            self.textView.text = "Talkback headless proof\nsecond line"
             self.textViewDidChange(self.textView)
         }
-        observe(.multiplexDebugTalkbackSend) { [weak self] _ in
+        observe(.multiplexDebugTalkbackSend) { [weak self] in
             guard let self, self.view.window != nil else { return }
             self.send(submit: true)
         }
-        observe(.multiplexDebugTalkbackAttach) { [weak self] _ in
+        observe(.multiplexDebugTalkbackAttach) { [weak self] in
             guard let self, self.view.window != nil else { return }
             self.configuration.controller.attachTalkbackFiles(Self.debugSampleFiles())
         }
@@ -1262,7 +1236,6 @@ final class TalkbackAttachmentView: UIControl {
             accessibilityLabel = "\(attachment.name), upload failed, \(reason)"
             accessibilityHint = "Retries the upload"
         }
-        setNeedsLayout()
     }
 
     private func refreshColors() {
@@ -1308,29 +1281,19 @@ enum TalkbackDebugHook {
     static func install() {
         guard !installed else { return }
         installed = true
-        var toggleToken: Int32 = 0
-        notify_register_dispatch(
-            "app.multiplexterm.multiplex.debug.talkback", &toggleToken, .main
-        ) { _ in
-            NotificationCenter.default.post(name: .multiplexDebugTalkbackToggle, object: nil)
-        }
-        var typeToken: Int32 = 0
-        notify_register_dispatch(
-            "app.multiplexterm.multiplex.debug.talkbacktype", &typeToken, .main
-        ) { _ in
-            NotificationCenter.default.post(name: .multiplexDebugTalkbackType, object: nil)
-        }
-        var sendToken: Int32 = 0
-        notify_register_dispatch(
-            "app.multiplexterm.multiplex.debug.talkbacksend", &sendToken, .main
-        ) { _ in
-            NotificationCenter.default.post(name: .multiplexDebugTalkbackSend, object: nil)
-        }
-        var attachToken: Int32 = 0
-        notify_register_dispatch(
-            "app.multiplexterm.multiplex.debug.talkbackattach", &attachToken, .main
-        ) { _ in
-            NotificationCenter.default.post(name: .multiplexDebugTalkbackAttach, object: nil)
+        let hooks: [(suffix: String, name: Notification.Name)] = [
+            ("talkback", .multiplexDebugTalkbackToggle),
+            ("talkbacktype", .multiplexDebugTalkbackType),
+            ("talkbacksend", .multiplexDebugTalkbackSend),
+            ("talkbackattach", .multiplexDebugTalkbackAttach),
+        ]
+        for hook in hooks {
+            var token: Int32 = 0
+            notify_register_dispatch(
+                "app.multiplexterm.multiplex.debug.\(hook.suffix)", &token, .main
+            ) { _ in
+                NotificationCenter.default.post(name: hook.name, object: nil)
+            }
         }
     }
 }

--- a/Multiplex/Views/Terminal/TalkbackComposer.swift
+++ b/Multiplex/Views/Terminal/TalkbackComposer.swift
@@ -1,0 +1,1281 @@
+import Observation
+import UIKit
+#if DEBUG
+import notify
+#endif
+
+/// Everything the window hands the composer. The controller is the identity
+/// (whose draft the box renders and edits); `presentation` is the chrome the
+/// eyebrow and geometry follow, comparable so a window render that changed
+/// nothing costs nothing; the closures are the two ways out.
+@MainActor
+struct TalkbackComposerConfiguration {
+    var controller: TerminalSessionController
+    var presentation: TalkbackComposerPresentation
+    /// The header's ✕ and the talk key: close the box (the draft survives).
+    var close: () -> Void
+    /// A hardware Escape in the field: hand the keyboard back to the pane.
+    var focusTerminal: () -> Void
+}
+
+/// The comparable half of the configuration.
+struct TalkbackComposerPresentation: Equatable {
+    /// The UMD's source label — `MAIN · DEVBOX`.
+    var targetLabel: String
+    var agent: AgentKind?
+    /// Fail-soft telemetry for the eyebrow: `.busy` reads RUNNING, `.needsYou`
+    /// lights the amber lamp, anything else says nothing.
+    var agentState: PaneAgentState?
+    /// The phone's previews: 28 pt photo thumbs and compact document chips
+    /// instead of 46 pt squares (Jhen, 2026-08-17).
+    var compactPreviews: Bool
+    /// visionOS: the card rides an ornament slab, so the band around it is
+    /// the slab's own ground rather than the window's bezel strip.
+    var floating: Bool
+    /// The width the box lays out for — the window's, or the ornament's
+    /// console clamp. The field's line count (and so the box's height) is
+    /// derived from it, which keeps `fittingContentSize` arithmetic.
+    var availableWidth: CGFloat
+    var contentSafeArea: UIEdgeInsets
+}
+
+/// Candidate B — MESSAGE CARD. A rounded card on the chassis band above the
+/// key rail (iPad · iPhone) or in its own slab under the visionOS console:
+/// an eyebrow naming the target, previews of the attachments, a round
+/// paperclip, a native text field, and a filled ↑ that sends. The field owns
+/// the keyboard while the rail keeps driving the pane; SEND is one paste plus
+/// a CR through the ordered pump. Design record: `local-plan/talkback-bakeoff/`.
+@MainActor
+final class TalkbackComposerViewController: UIViewController, UITextViewDelegate {
+    static let cardCornerRadius: CGFloat = 14
+    static let roundButtonDiameter: CGFloat = 30
+    static let previewSize: CGFloat = 46
+    static let compactPreviewSize: CGFloat = 28
+    static let bandHorizontalInset: CGFloat = 10
+    static let bandTopInset: CGFloat = 8
+    static let bandBottomInset: CGFloat = 9
+    static let cardPadding = UIEdgeInsets(top: 8, left: 10, bottom: 9, right: 10)
+    static let rowSpacing: CGFloat = 7
+    static let lineSpacing: CGFloat = 8
+    static let headerHeight: CGFloat = 20
+    static let fieldInsets = UIEdgeInsets(top: 6, left: 4, bottom: 6, right: 4)
+    /// The card fades while the pane owns the keyboard — the draft and the
+    /// ↑ stay live, the box just steps back.
+    static let unfocusedAlpha: CGFloat = 0.72
+
+    /// The composer is the only witness to its own height changes (a line
+    /// typed, a chip attached); the window re-insets the pane on this.
+    var onContentSizeChange: (() -> Void)?
+
+    private(set) var configuration: TalkbackComposerConfiguration
+    private var observationGeneration = 0
+    private var renderedKey: RenderKey?
+    private var renderedPreviewKey: PreviewKey?
+    private var renderedAttachKey: AttachKey?
+    private var pendingFocus = false
+    private var lastReportedSize: CGSize = .zero
+    /// One TextKit measurement per (text, width) — every sizing question in a
+    /// pass reads it instead of re-laying the body out.
+    private var measuredField: FieldMeasurement?
+
+    private let band = UIView()
+    private let bandRule = UIView()
+    private let card = UIKitTallyBorderedView()
+    private let content = UIStackView()
+    private let header = UIStackView()
+    private let toLabel = UIKitChassisMonoLabel()
+    private let targetLabel = UILabel()
+    private let agentLabel = UILabel()
+    private let stateLabel = UIKitChassisMonoLabel()
+    private var needsYouLamp: UIKitTallyLamp?
+    private let closeButton = TalkbackRoundButton(diameter: 20, symbol: "xmark", pointSize: 9)
+    private let previewScroll = UIScrollView()
+    private let previewRow = UIStackView()
+    private var previewHeightConstraint: NSLayoutConstraint?
+    private let line = UIStackView()
+    private let attachButton = TalkbackRoundButton(
+        diameter: TalkbackComposerViewController.roundButtonDiameter,
+        symbol: "paperclip",
+        pointSize: 13
+    )
+    private let textView = TalkbackTextView()
+    private let placeholder = UILabel()
+    private let sendButton = TalkbackRoundButton(
+        diameter: TalkbackComposerViewController.roundButtonDiameter,
+        symbol: "arrow.up",
+        pointSize: 13,
+        weight: .bold
+    )
+    private var textHeightConstraint: NSLayoutConstraint?
+    private var cardLeading: NSLayoutConstraint?
+    private var cardTrailing: NSLayoutConstraint?
+    /// The paperclip's pickers: FILE's own presenter, with its deliveries
+    /// routed into the target's draft instead of the pane.
+    private let attachPresenter = FileAttachPickerPresenterViewController()
+    #if DEBUG
+    private var debugObservers: [NSObjectProtocol] = []
+    #endif
+
+    private struct RenderKey: Equatable {
+        var presentation: TalkbackComposerPresentation
+        var controllerID: ObjectIdentifier
+        var state: TalkbackObservedState
+    }
+
+    private struct PreviewKey: Equatable {
+        var ids: [UUID]
+        var compact: Bool
+    }
+
+    private struct AttachKey: Equatable {
+        var controllerID: ObjectIdentifier
+        var enabled: Bool
+    }
+
+    private struct FieldMeasurement {
+        var text: String
+        var width: CGFloat
+        var height: CGFloat
+        var scrolls: Bool
+    }
+
+    init(configuration: TalkbackComposerConfiguration) {
+        self.configuration = configuration
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    deinit {
+        #if DEBUG
+        for observer in debugObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        #endif
+    }
+
+    // MARK: Lifecycle
+
+    override func loadView() {
+        let root = UIView()
+        root.backgroundColor = .clear
+        view = root
+        buildHierarchy()
+        installAttachPresenter()
+        #if DEBUG
+        installDebugObservers()
+        #endif
+        renderAndObserve()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        focusPendingFieldIfNeeded()
+        reportSizeIfChanged()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        focusPendingFieldIfNeeded()
+    }
+
+    /// Store everything (the closures are fresh each render); re-render only
+    /// when the comparable half or the controller changed — `render` gates
+    /// on the same key.
+    func update(configuration: TalkbackComposerConfiguration) {
+        let identityChanged = configuration.controller !== self.configuration.controller
+        let presentationChanged = configuration.presentation != self.configuration.presentation
+        self.configuration = configuration
+        guard isViewLoaded, identityChanged || presentationChanged else { return }
+        renderAndObserve()
+    }
+
+    /// The window is about to drop the composer: stop observing so a late
+    /// render can't touch a controller that moved on. Reports whether the
+    /// field held the keyboard, so the caller can hand it back to the pane.
+    @discardableResult
+    func prepareForRemoval() -> Bool {
+        observationGeneration &+= 1
+        let hadKeyboard = textView.isFirstResponder
+        if hadKeyboard { textView.resignFirstResponder() }
+        return hadKeyboard
+    }
+
+    /// Take the keyboard — now if the view is on screen, else at the first
+    /// layout after it lands (the ornament mounts on SwiftUI's next turn).
+    private func focusField() {
+        guard isViewLoaded, view.window != nil else {
+            pendingFocus = true
+            return
+        }
+        guard !textView.isFirstResponder else { return }
+        textView.becomeFirstResponder()
+    }
+
+    private func focusPendingFieldIfNeeded() {
+        guard pendingFocus, view.window != nil else { return }
+        pendingFocus = false
+        focusField()
+    }
+
+    // MARK: Sizing
+
+    /// The box's height for a width, from the same arithmetic the layout
+    /// uses — the window insets the pane by this before UIKit lays anything
+    /// out, so it can never disagree with what appears. Defaults to the
+    /// width the configuration handed in.
+    func fittingContentSize(for width: CGFloat? = nil) -> CGSize {
+        loadViewIfNeeded()
+        let width = max(1, width ?? configuration.presentation.availableWidth)
+        var height = Self.bandTopInset + Self.bandBottomInset
+            + Self.cardPadding.top + Self.cardPadding.bottom
+            + Self.headerHeight
+        if !configuration.controller.talkback.attachments.isEmpty {
+            height += Self.rowSpacing + previewSize
+        }
+        height += Self.rowSpacing + max(Self.roundButtonDiameter, fieldMetrics(forWidth: width).height)
+        return CGSize(width: width, height: ceil(height))
+    }
+
+    private var previewSize: CGFloat {
+        configuration.presentation.compactPreviews ? Self.compactPreviewSize : Self.previewSize
+    }
+
+    /// FILE's rule: an SSH-backed session tab can upload; mosh and plain
+    /// shells hide the paperclip (text still works there). A per-tab fact.
+    private var showsAttachButton: Bool {
+        FileAttachAvailability.canOffer(for: configuration.controller)
+    }
+
+    private var bandHorizontalInsets: (left: CGFloat, right: CGFloat) {
+        let presentation = configuration.presentation
+        let base = presentation.floating ? 8 : Self.bandHorizontalInset
+        return (
+            base + presentation.contentSafeArea.left,
+            base + presentation.contentSafeArea.right
+        )
+    }
+
+    /// The field's width for a box width: everything else in the line row is
+    /// fixed — two round buttons and their gaps (one button when the tab
+    /// can't attach).
+    private func fieldWidth(forWidth width: CGFloat) -> CGFloat {
+        let insets = bandHorizontalInsets
+        var fixed = insets.left + insets.right
+            + Self.cardPadding.left + Self.cardPadding.right
+            + Self.roundButtonDiameter + Self.lineSpacing
+        if showsAttachButton {
+            fixed += Self.roundButtonDiameter + Self.lineSpacing
+        }
+        return max(40, width - fixed)
+    }
+
+    /// The field's height at a width — one line at least, five at most, and
+    /// whether it scrolls inside itself past that. Measured once per
+    /// (text, width) and reused by every sizing question in the pass.
+    private func fieldMetrics(forWidth width: CGFloat) -> (height: CGFloat, scrolls: Bool) {
+        let fieldWidth = fieldWidth(forWidth: width)
+        let text = textView.text ?? ""
+        if let measured = measuredField, measured.text == text, measured.width == fieldWidth {
+            return (measured.height, measured.scrolls)
+        }
+        let lineHeight = textView.font?.lineHeight ?? 18
+        let insets = Self.fieldInsets.top + Self.fieldInsets.bottom
+        let minimum = ceil(lineHeight + insets)
+        let maximum = ceil(lineHeight * CGFloat(TalkbackMessage.maximumVisibleLines) + insets)
+        let content = ceil(textView.sizeThatFits(
+            CGSize(width: fieldWidth, height: .greatestFiniteMagnitude)
+        ).height)
+        let measurement = FieldMeasurement(
+            text: text,
+            width: fieldWidth,
+            height: min(maximum, max(minimum, content)),
+            scrolls: content > maximum
+        )
+        measuredField = measurement
+        return (measurement.height, measurement.scrolls)
+    }
+
+    private func refreshFieldHeight() {
+        let metrics = fieldMetrics(forWidth: configuration.presentation.availableWidth)
+        if textView.isScrollEnabled != metrics.scrolls { textView.isScrollEnabled = metrics.scrolls }
+        if textHeightConstraint?.constant != metrics.height {
+            textHeightConstraint?.constant = metrics.height
+            view.setNeedsLayout()
+        }
+    }
+
+    private func reportSizeIfChanged() {
+        let size = fittingContentSize()
+        guard size != lastReportedSize else { return }
+        lastReportedSize = size
+        if preferredContentSize != size { preferredContentSize = size }
+        onContentSizeChange?()
+    }
+
+    // MARK: Hierarchy
+
+    private func buildHierarchy() {
+        band.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(band)
+        NSLayoutConstraint.activate([
+            band.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            band.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            band.topAnchor.constraint(equalTo: view.topAnchor),
+            band.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        bandRule.translatesAutoresizingMaskIntoConstraints = false
+        band.addSubview(bandRule)
+        NSLayoutConstraint.activate([
+            bandRule.leadingAnchor.constraint(equalTo: band.leadingAnchor),
+            bandRule.trailingAnchor.constraint(equalTo: band.trailingAnchor),
+            bandRule.topAnchor.constraint(equalTo: band.topAnchor),
+            bandRule.heightAnchor.constraint(equalToConstant: 1),
+        ])
+
+        card.layer.cornerRadius = Self.cardCornerRadius
+        card.layer.cornerCurve = .continuous
+        card.clipsToBounds = true
+        card.accessibilityIdentifier = "terminal.talkback.card"
+        card.translatesAutoresizingMaskIntoConstraints = false
+        band.addSubview(card)
+        let leading = card.leadingAnchor.constraint(equalTo: band.leadingAnchor)
+        let trailing = card.trailingAnchor.constraint(equalTo: band.trailingAnchor)
+        cardLeading = leading
+        cardTrailing = trailing
+        NSLayoutConstraint.activate([
+            leading,
+            trailing,
+            card.topAnchor.constraint(equalTo: band.topAnchor, constant: Self.bandTopInset),
+            card.bottomAnchor.constraint(equalTo: band.bottomAnchor, constant: -Self.bandBottomInset),
+        ])
+
+        content.axis = .vertical
+        content.spacing = Self.rowSpacing
+        content.alignment = .fill
+        content.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.leadingAnchor.constraint(
+                equalTo: card.leadingAnchor,
+                constant: Self.cardPadding.left
+            ),
+            content.trailingAnchor.constraint(
+                equalTo: card.trailingAnchor,
+                constant: -Self.cardPadding.right
+            ),
+            content.topAnchor.constraint(equalTo: card.topAnchor, constant: Self.cardPadding.top),
+            content.bottomAnchor.constraint(
+                equalTo: card.bottomAnchor,
+                constant: -Self.cardPadding.bottom
+            ),
+        ])
+
+        buildHeader()
+        buildPreviewRow()
+        buildLine()
+        content.addArrangedSubview(header)
+        content.addArrangedSubview(previewScroll)
+        content.addArrangedSubview(line)
+    }
+
+    private func buildHeader() {
+        header.axis = .horizontal
+        header.alignment = .center
+        header.spacing = 8
+        header.heightAnchor.constraint(equalToConstant: Self.headerHeight).isActive = true
+
+        toLabel.configure(
+            "TO",
+            font: UIKitChassis.monoFont(9, weight: .semibold),
+            color: UIKitChassis.signal3,
+            kern: 0.9
+        )
+        toLabel.setContentHuggingPriority(.required, for: .horizontal)
+        toLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        // The eyebrow keeps B's sans voice (the bake-off's chat grammar); the
+        // target's words are the UMD's, uppercased to match its case.
+        targetLabel.font = UIKitChassis.uiFont(11)
+        targetLabel.textColor = UIKitChassis.signal2
+        targetLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        targetLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        targetLabel.lineBreakMode = .byTruncatingTail
+
+        agentLabel.font = UIKitChassis.uiFont(11, weight: .semibold)
+        agentLabel.textColor = UIKitChassis.signal
+        agentLabel.setContentHuggingPriority(.required, for: .horizontal)
+        agentLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+        stateLabel.configure(
+            "",
+            font: UIKitChassis.monoFont(9, weight: .semibold),
+            color: UIKitChassis.signal3,
+            kern: 0.9
+        )
+        stateLabel.setContentHuggingPriority(.required, for: .horizontal)
+        stateLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        closeButton.accessibilityLabel = "Close message box"
+        closeButton.accessibilityIdentifier = "terminal.talkback.close"
+        closeButton.addTarget(self, action: #selector(closePressed), for: .touchUpInside)
+
+        for view in [toLabel, targetLabel, agentLabel, stateLabel, spacer, closeButton] {
+            header.addArrangedSubview(view)
+        }
+    }
+
+    private func buildPreviewRow() {
+        previewScroll.showsHorizontalScrollIndicator = false
+        previewScroll.alwaysBounceHorizontal = false
+        previewScroll.clipsToBounds = false
+        previewScroll.accessibilityIdentifier = "terminal.talkback.previews"
+        previewRow.axis = .horizontal
+        previewRow.alignment = .center
+        previewRow.spacing = 8
+        previewRow.translatesAutoresizingMaskIntoConstraints = false
+        previewScroll.addSubview(previewRow)
+        NSLayoutConstraint.activate([
+            previewRow.leadingAnchor.constraint(equalTo: previewScroll.contentLayoutGuide.leadingAnchor),
+            previewRow.trailingAnchor.constraint(equalTo: previewScroll.contentLayoutGuide.trailingAnchor),
+            previewRow.topAnchor.constraint(equalTo: previewScroll.contentLayoutGuide.topAnchor),
+            previewRow.bottomAnchor.constraint(equalTo: previewScroll.contentLayoutGuide.bottomAnchor),
+            previewRow.heightAnchor.constraint(equalTo: previewScroll.frameLayoutGuide.heightAnchor),
+        ])
+        let height = previewScroll.heightAnchor.constraint(equalToConstant: Self.previewSize)
+        height.isActive = true
+        previewHeightConstraint = height
+        previewScroll.isHidden = true
+    }
+
+    private func buildLine() {
+        line.axis = .horizontal
+        line.alignment = .bottom
+        line.spacing = Self.lineSpacing
+
+        attachButton.accessibilityLabel = "Attach a file"
+        attachButton.accessibilityIdentifier = "terminal.talkback.attach"
+        attachButton.showsMenuAsPrimaryAction = true
+
+        textView.delegate = self
+        textView.accessibilityIdentifier = "terminal.talkback.field"
+        textView.accessibilityLabel = "Message"
+        textView.font = UIKitChassis.uiFont(15)
+        textView.textColor = UIKitChassis.signal
+        textView.backgroundColor = .clear
+        textView.textContainerInset = Self.fieldInsets
+        textView.textContainer.lineFragmentPadding = 0
+        textView.isScrollEnabled = false
+        textView.keyboardType = .default
+        textView.returnKeyType = .default
+        textView.autocorrectionType = .default
+        textView.spellCheckingType = .default
+        textView.smartQuotesType = .no
+        textView.smartDashesType = .no
+        textView.smartInsertDeleteType = .no
+        textView.keyboardAppearance = .default
+        textView.onSend = { [weak self] in self?.send(submit: true) }
+        textView.onEscape = { [weak self] in self?.configuration.focusTerminal() }
+        let textHeight = textView.heightAnchor.constraint(equalToConstant: 30)
+        textHeight.priority = .required
+        textHeight.isActive = true
+        textHeightConstraint = textHeight
+
+        placeholder.font = textView.font
+        placeholder.textColor = UIKitChassis.signal3
+        placeholder.isUserInteractionEnabled = false
+        placeholder.translatesAutoresizingMaskIntoConstraints = false
+        textView.addSubview(placeholder)
+        NSLayoutConstraint.activate([
+            placeholder.leadingAnchor.constraint(
+                equalTo: textView.leadingAnchor,
+                constant: Self.fieldInsets.left
+            ),
+            placeholder.topAnchor.constraint(
+                equalTo: textView.topAnchor,
+                constant: Self.fieldInsets.top
+            ),
+        ])
+
+        sendButton.accessibilityLabel = "Send"
+        sendButton.accessibilityIdentifier = "terminal.talkback.send"
+        sendButton.addTarget(self, action: #selector(sendPressed), for: .touchUpInside)
+        let hold = UILongPressGestureRecognizer(target: self, action: #selector(sendHeld(_:)))
+        hold.minimumPressDuration = 0.5
+        sendButton.addGestureRecognizer(hold)
+
+        line.addArrangedSubview(attachButton)
+        line.addArrangedSubview(textView)
+        line.addArrangedSubview(sendButton)
+    }
+
+    private func installAttachPresenter() {
+        addChild(attachPresenter)
+        attachPresenter.view.frame = .zero
+        attachPresenter.view.isHidden = true
+        view.addSubview(attachPresenter.view)
+        attachPresenter.didMove(toParent: self)
+        // The presenter snapshotted its target when the picker opened; the
+        // bytes go to that tab's draft even if this composer moved on.
+        attachPresenter.deliver = { target, files in
+            target.attachTalkbackFiles(files)
+        }
+    }
+
+    // MARK: Render
+
+    private func renderAndObserve(generation: Int? = nil) {
+        let generation = generation ?? {
+            observationGeneration &+= 1
+            return observationGeneration
+        }()
+        guard generation == observationGeneration else { return }
+        let controller = configuration.controller
+        // The draft's text is deliberately not part of this snapshot: the
+        // field is its writer, and a keystroke must not re-render the box.
+        let snapshot = withObservationTracking {
+            TalkbackObservedState(
+                attachments: controller.talkback.attachments,
+                focusRequest: controller.talkback.focusRequest,
+                sendState: controller.talkbackSendState,
+                canAttachNow: FileAttachMenuAvailability(controller: controller).actionsEnabled
+            )
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.renderAndObserve(generation: generation)
+            }
+        }
+        render(snapshot)
+    }
+
+    private func render(_ state: TalkbackObservedState) {
+        let controller = configuration.controller
+        let key = RenderKey(
+            presentation: configuration.presentation,
+            controllerID: ObjectIdentifier(controller),
+            state: state
+        )
+        guard key != renderedKey else { return }
+        let controllerChanged = key.controllerID != renderedKey?.controllerID
+        renderedKey = key
+
+        if controllerChanged {
+            attachPresenter.update(controller: controller)
+            // The draft is the text of record across a tab switch; the field
+            // is its writer otherwise (SEND clears both).
+            textView.text = controller.talkback.text
+            placeholder.isHidden = !textView.text.isEmpty
+        }
+        renderChrome()
+        renderHeader()
+        placeholder.text = TalkbackMessage.placeholder(
+            agentName: configuration.presentation.agent?.displayName
+        )
+        renderPreviews(state.attachments)
+        renderButtons(state)
+        refreshFieldHeight()
+
+        // The talk key asked for the keyboard; a tab switch back to an
+        // open box did not (the request is per tab and consumed once).
+        if controller.consumeTalkbackFocusRequest() {
+            focusField()
+        }
+        view.setNeedsLayout()
+        reportSizeIfChanged()
+    }
+
+    private func renderChrome() {
+        let insets = bandHorizontalInsets
+        cardLeading?.constant = insets.left
+        cardTrailing?.constant = -insets.right
+        // PROTOTYPE(GLASS): the card is a raised strata face over the
+        // ornament slab or the window's bezel band; chassis everywhere else.
+        card.backgroundColor = GlassPrototype.strataChassis
+        card.tallyBorderColor = UIKitChassis.bezelHi
+        if configuration.presentation.floating {
+            band.backgroundColor = .clear
+            bandRule.isHidden = true
+        } else {
+            band.backgroundColor = UIKitChassis.bezel
+            bandRule.isHidden = false
+            bandRule.backgroundColor = UIKitChassis.bezelHi
+        }
+    }
+
+    private func renderHeader() {
+        let presentation = configuration.presentation
+        targetLabel.text = presentation.targetLabel.uppercased()
+        if let agent = presentation.agent {
+            // U+FE0E pins the text presentation: ✳ has an emoji twin the
+            // system font would otherwise pick.
+            agentLabel.text = "\(agent.glyph)\u{FE0E} \(agent.displayName)"
+            agentLabel.isHidden = false
+        } else {
+            agentLabel.text = nil
+            agentLabel.isHidden = true
+        }
+        let running = presentation.agentState == .busy
+        stateLabel.setText(running ? "RUNNING" : "")
+        stateLabel.isHidden = !running
+        var needsYou = false
+        if case .needsYou = presentation.agentState { needsYou = true }
+        if needsYou, needsYouLamp == nil {
+            let lamp = UIKitTallyLamp(caption: "NEEDS YOU", color: TallyPalette.caution)
+            lamp.accessibilityIdentifier = "terminal.talkback.needsYou"
+            header.insertArrangedSubview(lamp, at: header.arrangedSubviews.count - 2)
+            needsYouLamp = lamp
+        } else if !needsYou, let lamp = needsYouLamp {
+            header.removeArrangedSubview(lamp)
+            lamp.removeFromSuperview()
+            needsYouLamp = nil
+        }
+        header.accessibilityLabel = [
+            "To", presentation.targetLabel,
+            presentation.agent?.displayName,
+            running ? "running" : nil,
+            needsYou ? "needs you" : nil,
+        ].compactMap { $0 }.joined(separator: " ")
+    }
+
+    private func renderPreviews(_ attachments: [TalkbackAttachment]) {
+        let compact = configuration.presentation.compactPreviews
+        previewHeightConstraint?.constant = previewSize
+        previewRow.spacing = compact ? 6 : 8
+        let key = PreviewKey(ids: attachments.map(\.id), compact: compact)
+        if key != renderedPreviewKey {
+            for view in previewRow.arrangedSubviews {
+                previewRow.removeArrangedSubview(view)
+                view.removeFromSuperview()
+            }
+            for attachment in attachments {
+                let view = TalkbackAttachmentView(
+                    attachment: attachment,
+                    size: previewSize,
+                    compact: compact,
+                    remove: { [weak self] id in
+                        self?.configuration.controller.removeTalkbackAttachment(id)
+                    },
+                    retry: { [weak self] id in
+                        self?.configuration.controller.retryTalkbackAttachment(id)
+                    }
+                )
+                previewRow.addArrangedSubview(view)
+            }
+            renderedPreviewKey = key
+        } else {
+            for (view, attachment) in zip(previewRow.arrangedSubviews, attachments) {
+                (view as? TalkbackAttachmentView)?.update(attachment)
+            }
+        }
+        let hidden = attachments.isEmpty
+        if previewScroll.isHidden != hidden { previewScroll.isHidden = hidden }
+    }
+
+    private func renderButtons(_ state: TalkbackObservedState) {
+        attachButton.isHidden = !showsAttachButton
+        attachButton.isEnabled = state.canAttachNow
+        // Three actions and three symbol lookups — rebuilt only when what
+        // they render on changes.
+        let attachKey = AttachKey(
+            controllerID: ObjectIdentifier(configuration.controller),
+            enabled: state.canAttachNow
+        )
+        if attachKey != renderedAttachKey {
+            attachButton.menu = state.canAttachNow ? attachPresenter.makeSourceMenu() : nil
+            renderedAttachKey = attachKey
+        }
+        switch state.sendState {
+        case .ready:
+            sendButton.style = .prominent
+            sendButton.isEnabled = true
+            sendButton.accessibilityLabel = "Send"
+        case .waiting:
+            sendButton.style = .waiting
+            sendButton.isEnabled = false
+            sendButton.accessibilityLabel = "Send, waiting for uploads"
+        case .disabled:
+            sendButton.style = .dim
+            sendButton.isEnabled = false
+            sendButton.accessibilityLabel = "Send"
+        }
+    }
+
+    // MARK: Actions
+
+    @objc private func closePressed() {
+        configuration.close()
+    }
+
+    @objc private func sendPressed() {
+        send(submit: true)
+    }
+
+    @objc private func sendHeld(_ recognizer: UILongPressGestureRecognizer) {
+        guard recognizer.state == .began else { return }
+        send(submit: false)
+    }
+
+    /// SEND / a long-press SEND (type only). The controller composes the
+    /// bytes and clears the draft; the field — its writer — clears itself
+    /// (the chips follow through observation).
+    func send(submit: Bool) {
+        guard configuration.controller.sendTalkback(submit: submit) else { return }
+        textView.text = ""
+        textViewDidChange(textView)
+    }
+
+    // MARK: UITextViewDelegate
+
+    func textViewDidChange(_ textView: UITextView) {
+        placeholder.isHidden = !textView.text.isEmpty
+        configuration.controller.setTalkbackText(textView.text)
+        refreshFieldHeight()
+        view.setNeedsLayout()
+    }
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        setCardFocused(true)
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        setCardFocused(false)
+    }
+
+    private func setCardFocused(_ focused: Bool) {
+        let alpha = focused ? 1 : Self.unfocusedAlpha
+        guard card.alpha != alpha else { return }
+        UIView.animate(withDuration: 0.18) { self.card.alpha = alpha }
+    }
+
+    // MARK: DEBUG
+
+    #if DEBUG
+    private func installDebugObservers() {
+        TalkbackDebugHook.install()
+        let center = NotificationCenter.default
+        func observe(_ name: Notification.Name, _ action: @escaping @MainActor (Notification) -> Void) {
+            debugObservers.append(center.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { note in
+                MainActor.assumeIsolated { action(note) }
+            })
+        }
+        observe(.multiplexDebugTalkbackType) { [weak self] note in
+            guard let self, self.view.window != nil else { return }
+            let text = (note.userInfo?["text"] as? String)
+                ?? "Talkback headless proof\nsecond line"
+            self.textView.text = text
+            self.textViewDidChange(self.textView)
+        }
+        observe(.multiplexDebugTalkbackSend) { [weak self] _ in
+            guard let self, self.view.window != nil else { return }
+            self.send(submit: true)
+        }
+        observe(.multiplexDebugTalkbackAttach) { [weak self] _ in
+            guard let self, self.view.window != nil else { return }
+            self.configuration.controller.attachTalkbackFiles(Self.debugSampleFiles())
+        }
+    }
+
+    /// A photo-shaped PNG and a text file, so one hook exercises both preview
+    /// shapes, the upload queue, and the typed-paths half of SEND.
+    private static func debugSampleFiles() -> [DroppedFile] {
+        let size = CGSize(width: 96, height: 72)
+        let image = UIGraphicsImageRenderer(size: size).image { context in
+            UIColor(red: 0.48, green: 0.42, blue: 0.35, alpha: 1).setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+            UIColor(red: 0.24, green: 0.29, blue: 0.35, alpha: 1).setFill()
+            context.fill(CGRect(x: 0, y: 36, width: 96, height: 36))
+            UIColor(red: 0.73, green: 0.67, blue: 0.6, alpha: 1).setFill()
+            context.cgContext.fillEllipse(in: CGRect(x: 60, y: 10, width: 22, height: 22))
+        }
+        return [
+            DroppedFile(name: "talkback-proof.png", data: image.pngData() ?? Data()),
+            DroppedFile(name: "talkback-proof.txt", data: Data("talkback headless attach\n".utf8)),
+        ]
+    }
+    #endif
+}
+
+/// The values the composer re-renders on — its draft's structure (never its
+/// text), the pane's input rules, and whether the paperclip may open now.
+private struct TalkbackObservedState: Equatable {
+    var attachments: [TalkbackAttachment]
+    var focusRequest: Int
+    var sendState: TalkbackDraft.SendState
+    var canAttachNow: Bool
+}
+
+// MARK: - The field
+
+/// A native text view with the hardware-keyboard chat reflexes: Return sends,
+/// Shift+Return breaks a line (UIKit's default, so no command claims it),
+/// ⌘Return sends everywhere, Escape hands the keyboard back to the pane.
+/// The software keyboard's Return is left alone — it inserts a newline; the
+/// ↑ is the only touch submit.
+@MainActor
+final class TalkbackTextView: UITextView {
+    var onSend: (() -> Void)?
+    var onEscape: (() -> Void)?
+
+    /// Built once: UIKit asks for these on every hardware key event.
+    private lazy var chatCommands: [UIKeyCommand] = {
+        let send = UIKeyCommand(
+            input: "\r",
+            modifierFlags: [],
+            action: #selector(sendFromKeyboard)
+        )
+        send.wantsPriorityOverSystemBehavior = true
+        let commandSend = UIKeyCommand(
+            input: "\r",
+            modifierFlags: .command,
+            action: #selector(sendFromKeyboard)
+        )
+        let escape = UIKeyCommand(
+            input: UIKeyCommand.inputEscape,
+            modifierFlags: [],
+            action: #selector(escapeFromKeyboard)
+        )
+        escape.wantsPriorityOverSystemBehavior = true
+        return [send, commandSend, escape]
+    }()
+
+    override var keyCommands: [UIKeyCommand]? {
+        chatCommands + (super.keyCommands ?? [])
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(sendFromKeyboard) || action == #selector(escapeFromKeyboard) {
+            return true
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    @objc private func sendFromKeyboard() { onSend?() }
+    @objc private func escapeFromKeyboard() { onEscape?() }
+}
+
+// MARK: - Round buttons
+
+/// The card's round controls: paperclip and ✕ in the hairline style, the ↑
+/// filled when armed, dashed while SEND waits on an upload, dim otherwise.
+@MainActor
+final class TalkbackRoundButton: UIButton {
+    enum Style: Equatable {
+        case plain
+        case prominent
+        case waiting
+        case dim
+    }
+
+    var style: Style = .plain {
+        didSet {
+            guard style != oldValue else { return }
+            refreshAppearance()
+        }
+    }
+
+    private let diameter: CGFloat
+    private let symbolView = UIImageView()
+    private let ring = CAShapeLayer()
+
+    init(
+        diameter: CGFloat,
+        symbol: String,
+        pointSize: CGFloat,
+        weight: UIImage.SymbolWeight = .semibold
+    ) {
+        self.diameter = diameter
+        super.init(frame: .zero)
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        layer.cornerRadius = diameter / 2
+        layer.borderWidth = 1
+        hoverStyle = UIHoverStyle(effect: .highlight, shape: .circle)
+        symbolView.image = UIImage(
+            systemName: symbol,
+            withConfiguration: UIImage.SymbolConfiguration(
+                pointSize: pointSize * Theme.typeScale,
+                weight: weight
+            )
+        )
+        symbolView.contentMode = .center
+        symbolView.isUserInteractionEnabled = false
+        addSubview(symbolView)
+        ring.fillColor = nil
+        ring.lineWidth = 1
+        ring.lineDashPattern = [3, 3]
+        ring.isHidden = true
+        layer.addSublayer(ring)
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: diameter),
+            heightAnchor.constraint(equalToConstant: diameter),
+        ])
+        refreshAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    override var intrinsicContentSize: CGSize { CGSize(width: diameter, height: diameter) }
+
+    override var isHighlighted: Bool {
+        didSet { refreshAppearance() }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        symbolView.frame = bounds
+        ring.frame = bounds
+        ring.path = UIBezierPath(ovalIn: bounds.insetBy(dx: 0.5, dy: 0.5)).cgPath
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        refreshAppearance()
+    }
+
+    private func refreshAppearance() {
+        let traits = traitCollection
+        switch style {
+        case .plain:
+            // PROTOTYPE(GLASS): strata over the smoke, chassis otherwise —
+            // the chip buttons' ground.
+            backgroundColor = GlassPrototype.strataChassis
+            layer.borderColor = UIKitChassis.bezelHi.resolvedColor(with: traits).cgColor
+            symbolView.tintColor = UIKitChassis.signal2
+            ring.isHidden = true
+        case .prominent:
+            backgroundColor = UIKitChassis.signal
+            layer.borderColor = UIKitChassis.signal.resolvedColor(with: traits).cgColor
+            symbolView.tintColor = UIKitChassis.chassis
+            ring.isHidden = true
+        case .waiting:
+            backgroundColor = GlassPrototype.strataChassis
+            layer.borderColor = UIColor.clear.cgColor
+            symbolView.tintColor = UIKitChassis.signal2
+            ring.strokeColor = UIKitChassis.signal2.resolvedColor(with: traits).cgColor
+            ring.isHidden = false
+        case .dim:
+            backgroundColor = UIKitChassis.bezelHi
+            layer.borderColor = UIKitChassis.bezelHi.resolvedColor(with: traits).cgColor
+            symbolView.tintColor = UIKitChassis.signal3
+            ring.isHidden = true
+        }
+        alpha = isHighlighted ? 0.7 : 1
+    }
+}
+
+// MARK: - Attachment previews
+
+/// One attachment in the card's preview row. Photos show themselves — 46 pt
+/// on iPad and visionOS, 28 pt on the phone — with a progress ring while
+/// they upload; documents show name and size, as a square on the wide
+/// platforms and as a compact chip on the phone. A failed chip wears amber
+/// with its reason and retries on tap; the ✕ badge removes any of them.
+@MainActor
+final class TalkbackAttachmentView: UIControl {
+    private(set) var attachment: TalkbackAttachment
+    let compact: Bool
+    private let size: CGFloat
+    private let remove: (UUID) -> Void
+    private let retry: (UUID) -> Void
+    /// Fixed for the chip's life — measured once.
+    private let byteText: String
+    private var renderedPreview: Data?
+    private let tile = UIKitTallyBorderedView()
+    private let imageView = UIImageView()
+    private let scrim = UIView()
+    private let ringTrack = CAShapeLayer()
+    private let ringFill = CAShapeLayer()
+    private let nameLabel = UIKitChassisMonoLabel()
+    private let detailLabel = UIKitChassisMonoLabel()
+    private let removeBadge = UIButton(type: .custom)
+
+    init(
+        attachment: TalkbackAttachment,
+        size: CGFloat,
+        compact: Bool,
+        remove: @escaping (UUID) -> Void,
+        retry: @escaping (UUID) -> Void
+    ) {
+        self.attachment = attachment
+        self.size = size
+        self.compact = compact
+        self.remove = remove
+        self.retry = retry
+        byteText = ByteCountFormatter.string(
+            fromByteCount: Int64(attachment.byteCount),
+            countStyle: .file
+        )
+        super.init(frame: .zero)
+        isAccessibilityElement = true
+        accessibilityIdentifier = "terminal.talkback.attachment.\(attachment.id.uuidString)"
+        build()
+        update(attachment)
+        addTarget(self, action: #selector(tapped), for: .touchUpInside)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("unused") }
+
+    private var isSquare: Bool { attachment.kind == .image || !compact }
+
+    private func build() {
+        translatesAutoresizingMaskIntoConstraints = false
+        tile.isUserInteractionEnabled = false
+        tile.layer.cornerRadius = compact ? 6 : 8
+        tile.layer.cornerCurve = .continuous
+        tile.clipsToBounds = true
+        tile.backgroundColor = UIKitChassis.bezel
+        addSubview(tile)
+        tile.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tile.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tile.trailingAnchor.constraint(equalTo: trailingAnchor),
+            tile.topAnchor.constraint(equalTo: topAnchor),
+            tile.bottomAnchor.constraint(equalTo: bottomAnchor),
+            heightAnchor.constraint(equalToConstant: size),
+        ])
+        if isSquare {
+            widthAnchor.constraint(equalToConstant: size).isActive = true
+        }
+
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        tile.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: tile.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: tile.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: tile.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: tile.bottomAnchor),
+        ])
+
+        let labels = UIStackView(arrangedSubviews: [nameLabel, detailLabel])
+        labels.axis = isSquare ? .vertical : .horizontal
+        labels.alignment = .center
+        labels.spacing = isSquare ? 1 : 5
+        labels.isUserInteractionEnabled = false
+        labels.translatesAutoresizingMaskIntoConstraints = false
+        tile.addSubview(labels)
+        let fontSize: CGFloat = isSquare ? 7.5 : 9
+        nameLabel.configure("", font: UIKitChassis.monoFont(fontSize), color: TallyPalette.miniText)
+        nameLabel.textAlignment = .center
+        nameLabel.lineBreakMode = .byTruncatingMiddle
+        detailLabel.configure("", font: UIKitChassis.monoFont(fontSize), color: UIKitChassis.signal3)
+        detailLabel.textAlignment = .center
+        let labelInset: CGFloat = isSquare ? 3 : 8
+        NSLayoutConstraint.activate([
+            labels.leadingAnchor.constraint(equalTo: tile.leadingAnchor, constant: labelInset),
+            labels.trailingAnchor.constraint(equalTo: tile.trailingAnchor, constant: -labelInset),
+            labels.centerYAnchor.constraint(equalTo: tile.centerYAnchor),
+        ])
+
+        scrim.backgroundColor = UIColor.black.withAlphaComponent(0.45)
+        scrim.isUserInteractionEnabled = false
+        scrim.translatesAutoresizingMaskIntoConstraints = false
+        tile.addSubview(scrim)
+        NSLayoutConstraint.activate([
+            scrim.leadingAnchor.constraint(equalTo: tile.leadingAnchor),
+            scrim.trailingAnchor.constraint(equalTo: tile.trailingAnchor),
+            scrim.topAnchor.constraint(equalTo: tile.topAnchor),
+            scrim.bottomAnchor.constraint(equalTo: tile.bottomAnchor),
+        ])
+        for ring in [ringTrack, ringFill] {
+            ring.fillColor = nil
+            ring.lineWidth = 2.5
+            ring.lineCap = .round
+            scrim.layer.addSublayer(ring)
+        }
+
+        removeBadge.accessibilityLabel = "Remove attachment"
+        removeBadge.setImage(
+            UIImage(
+                systemName: "xmark",
+                withConfiguration: UIImage.SymbolConfiguration(pointSize: 7, weight: .bold)
+            ),
+            for: .normal
+        )
+        removeBadge.layer.cornerRadius = 7
+        removeBadge.clipsToBounds = true
+        removeBadge.addTarget(self, action: #selector(removePressed), for: .touchUpInside)
+        addSubview(removeBadge)
+        removeBadge.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            removeBadge.widthAnchor.constraint(equalToConstant: 14),
+            removeBadge.heightAnchor.constraint(equalToConstant: 14),
+            removeBadge.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 1),
+            removeBadge.topAnchor.constraint(equalTo: topAnchor, constant: -1),
+        ])
+        refreshColors()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let ringSize = min(bounds.width, bounds.height) * (compact ? 0.62 : 0.5)
+        let rect = CGRect(
+            x: bounds.midX - ringSize / 2,
+            y: bounds.midY - ringSize / 2,
+            width: ringSize,
+            height: ringSize
+        )
+        let path = UIBezierPath(
+            arcCenter: CGPoint(x: rect.midX, y: rect.midY),
+            radius: ringSize / 2,
+            startAngle: -.pi / 2,
+            endAngle: 1.5 * .pi,
+            clockwise: true
+        ).cgPath
+        ringTrack.frame = scrim.bounds
+        ringFill.frame = scrim.bounds
+        ringTrack.path = path
+        ringFill.path = path
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        else { return }
+        refreshColors()
+    }
+
+    /// The badge overhangs the tile's corner; keep it tappable there.
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let badgeHit = removeBadge.frame.insetBy(dx: -6, dy: -6)
+        if badgeHit.contains(point) { return removeBadge }
+        return super.hitTest(point, with: event)
+    }
+
+    func update(_ attachment: TalkbackAttachment) {
+        self.attachment = attachment
+        let showsImage = attachment.kind == .image && attachment.preview != nil
+        if showsImage, attachment.preview != renderedPreview, let preview = attachment.preview {
+            imageView.image = UIImage(data: preview)
+            renderedPreview = preview
+        }
+        imageView.isHidden = !showsImage
+        // The common face; each state below overrides only what differs.
+        nameLabel.isHidden = showsImage
+        detailLabel.isHidden = showsImage
+        nameLabel.setText(attachment.name, ink: TallyPalette.miniText)
+        tile.tallyBorderColor = UIKitChassis.bezelHi
+        ringTrack.isHidden = true
+        ringFill.isHidden = true
+        scrim.isHidden = true
+        accessibilityHint = nil
+        switch attachment.state {
+        case .uploading(let fraction):
+            scrim.isHidden = false
+            ringTrack.isHidden = false
+            ringFill.isHidden = false
+            ringFill.strokeEnd = max(0.02, min(1, fraction))
+            detailLabel.setText(byteText, ink: UIKitChassis.signal3)
+            accessibilityLabel = "\(attachment.name), uploading \(Int(fraction * 100)) percent"
+        case .ready:
+            detailLabel.setText(
+                isSquare ? byteText : "\(byteText) ✓",
+                ink: UIKitChassis.signal3
+            )
+            accessibilityLabel = "\(attachment.name), \(byteText), attached"
+        case .failed(let reason):
+            // The photo stays visible under a scrim so the amber caption
+            // reads; documents keep their name and say why.
+            scrim.isHidden = !showsImage
+            nameLabel.isHidden = false
+            if showsImage {
+                nameLabel.setText("FAILED", ink: TallyPalette.caution)
+            } else {
+                detailLabel.isHidden = false
+                detailLabel.setText(
+                    isSquare ? "FAILED" : "FAILED · \(reason.uppercased())",
+                    ink: TallyPalette.caution
+                )
+            }
+            tile.tallyBorderColor = TallyPalette.caution
+            accessibilityLabel = "\(attachment.name), upload failed, \(reason)"
+            accessibilityHint = "Retries the upload"
+        }
+        setNeedsLayout()
+    }
+
+    private func refreshColors() {
+        let traits = traitCollection
+        ringTrack.strokeColor = UIKitChassis.signal.resolvedColor(with: traits)
+            .withAlphaComponent(0.25).cgColor
+        ringFill.strokeColor = UIKitChassis.signal.resolvedColor(with: traits).cgColor
+        removeBadge.backgroundColor = UIKitChassis.signal
+        removeBadge.tintColor = UIKitChassis.chassis
+    }
+
+    @objc private func removePressed() {
+        remove(attachment.id)
+    }
+
+    @objc private func tapped() {
+        guard attachment.isFailed else { return }
+        retry(attachment.id)
+    }
+}
+
+// MARK: - DEBUG hooks
+
+#if DEBUG
+extension Notification.Name {
+    static let multiplexDebugTalkbackToggle = Notification.Name("MultiplexDebugTalkbackToggle")
+    static let multiplexDebugTalkbackType = Notification.Name("MultiplexDebugTalkbackType")
+    static let multiplexDebugTalkbackSend = Notification.Name("MultiplexDebugTalkbackSend")
+    static let multiplexDebugTalkbackAttach = Notification.Name("MultiplexDebugTalkbackAttach")
+}
+
+/// Headless proof of the composer, no touch required:
+/// `notifyutil -p app.multiplexterm.multiplex.debug.talkback` toggles the box
+/// for the focused terminal (the talk key), `….debug.talkbacktype` puts a
+/// two-line sample into its field, `….debug.talkbackattach` attaches a
+/// sample photo + text file through the real upload queue,
+/// `….debug.talkbacksend` presses ↑ — the harness's `tmux capture-pane` then
+/// shows the message (paths first) landing.
+@MainActor
+enum TalkbackDebugHook {
+    private static var installed = false
+
+    static func install() {
+        guard !installed else { return }
+        installed = true
+        var toggleToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.talkback", &toggleToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugTalkbackToggle, object: nil)
+        }
+        var typeToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.talkbacktype", &typeToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugTalkbackType, object: nil)
+        }
+        var sendToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.talkbacksend", &sendToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugTalkbackSend, object: nil)
+        }
+        var attachToken: Int32 = 0
+        notify_register_dispatch(
+            "app.multiplexterm.multiplex.debug.talkbackattach", &attachToken, .main
+        ) { _ in
+            NotificationCenter.default.post(name: .multiplexDebugTalkbackAttach, object: nil)
+        }
+    }
+}
+#endif

--- a/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
+++ b/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
@@ -32,6 +32,10 @@ private final class LockedKeyboardInputView: UIView {}
 @MainActor
 enum TerminalFocusArbiter {
     private(set) static weak var current: TerminalView?
+    /// An app-owned field that borrowed the keyboard from the current
+    /// terminal (the Talkback composer's). Any claim resigns it first, so
+    /// one input session stays live app-wide even across scenes.
+    private static weak var borrower: UIView?
     private static var keyboardVisible = false
     private static var observersInstalled = false
 
@@ -60,6 +64,12 @@ enum TerminalFocusArbiter {
     static func claim(_ view: TerminalView) {
         guard !inputSuppressed else { return }
         installObserversIfNeeded()
+        // A borrowed keyboard comes back before any terminal takes it —
+        // even one in another window, which UIKit would leave alone.
+        if let borrower, borrower.isFirstResponder {
+            _ = borrower.resignFirstResponder()
+        }
+        borrower = nil
         // Stage Manager can transiently clear `isKeyWindow` while the user
         // moves that very window. The terminal still owns the live input
         // session and remains first responder during that transition. Do not
@@ -159,6 +169,26 @@ enum TerminalFocusArbiter {
         #endif
         _ = view.resignFirstResponder()
         return true
+    }
+
+    /// An app-owned field takes the keyboard while this terminal keeps
+    /// ownership: the terminal steps down and the field's window is made
+    /// key — UIKit resigns responders only within one window, and on
+    /// visionOS the Talkback composer lives in the ornament's window while
+    /// the terminal stays first responder in the scene's, where key events
+    /// go. The next `claim` of ANY terminal resigns the borrower;
+    /// `resumeAfterPresentation` hands the keyboard back on close.
+    static func lend(_ view: TerminalView?, to field: UIView) {
+        borrower = field
+        if let view, view.isFirstResponder {
+            #if DEBUG
+            keyboardLogger.debug("kbd-focus-lend current=\(current === view, privacy: .public)")
+            #endif
+            _ = view.resignFirstResponder()
+        }
+        if let window = field.window, !window.isKeyWindow {
+            window.makeKey()
+        }
     }
 
     /// Resume a presentation-suspended terminal only if it still owns focus.

--- a/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
+++ b/Multiplex/Views/Terminal/TerminalFocusArbiter.swift
@@ -119,17 +119,20 @@ enum TerminalFocusArbiter {
     }
 
     /// Short press on the (locked) keyboard key: release the lock and ask
-    /// for the keyboard — the press means "I want to type again".
-    static func unlock(_ view: TerminalView) {
+    /// for the keyboard — the press means "I want to type again". The
+    /// Talkback key passes `summoning: false`: its own field is about to
+    /// take the keyboard, and a deferred terminal summon would race it.
+    static func unlock(_ view: TerminalView, summoning: Bool = true) {
         guard KeyboardLock.shared.isLocked else { return }
         #if DEBUG
-        keyboardLogger.debug("kbd-lock released")
+        keyboardLogger.debug("kbd-lock released summoning=\(summoning, privacy: .public)")
         #endif
         KeyboardLock.shared.isLocked = false
         applyLockState(to: view)
         if let current, current !== view {
             applyLockState(to: current)
         }
+        guard summoning else { return }
         summon(view, force: true)
     }
 

--- a/Multiplex/Views/Terminal/TerminalGuidePictograms.swift
+++ b/Multiplex/Views/Terminal/TerminalGuidePictograms.swift
@@ -64,6 +64,7 @@ final class TerminalGuidePictogramView: UIView {
         case "shiftreturn": drawShiftReturn()
         case "shortcutkey": drawShortcutKey()
         case "keycommands": drawKeyCommands()
+        case "talkback": drawTalkback()
         case "resize": drawResize()
         case "panemenu": drawPaneMenu()
         case "paste": drawPastePermission()
@@ -349,6 +350,92 @@ final class TerminalGuidePictogramView: UIView {
                 dashed: true
             )
         }
+    }
+
+    /// The message card: eyebrow, paperclip, a line of message, the filled ↑
+    /// — with the talk key that opens it above.
+    private func drawTalkback() {
+        // The talk key: a keycap wearing a small speech bubble.
+        let keycap = CGRect(x: 7, y: 3, width: 16, height: 10)
+        drawKeycap(keycap, label: "", labelSize: 5)
+        let bubble = UIBezierPath(
+            roundedRect: CGRect(x: 11, y: 5, width: 8, height: 5),
+            cornerRadius: 1.2
+        )
+        bubble.move(to: CGPoint(x: 13, y: 10))
+        bubble.addLine(to: CGPoint(x: 12.5, y: 12))
+        bubble.addLine(to: CGPoint(x: 15, y: 10))
+        stroke(bubble, color: UIKitChassis.signal)
+        drawArrow(
+            from: CGPoint(x: 15, y: 14),
+            to: CGPoint(x: 15, y: 20),
+            color: UIKitChassis.signal2,
+            endHead: true
+        )
+
+        // The card.
+        let card = UIBezierPath(
+            roundedRect: CGRect(x: 6, y: 22, width: 84, height: 38),
+            cornerRadius: 5
+        )
+        stroke(card, color: UIKitChassis.signal)
+        drawMonoText(
+            "TO MAIN · DEVBOX",
+            at: CGPoint(x: 11, y: 24.5),
+            size: 4.8,
+            color: UIKitChassis.signal3
+        )
+        // ✕ at the trailing end of the eyebrow.
+        strokeCircle(
+            center: CGPoint(x: 83, y: 28),
+            radius: 3,
+            color: UIKitChassis.signal2
+        )
+        let cross = UIBezierPath()
+        cross.move(to: CGPoint(x: 81.8, y: 26.8))
+        cross.addLine(to: CGPoint(x: 84.2, y: 29.2))
+        cross.move(to: CGPoint(x: 84.2, y: 26.8))
+        cross.addLine(to: CGPoint(x: 81.8, y: 29.2))
+        stroke(cross, color: UIKitChassis.signal2)
+        // Paperclip (a hairline circle stands in for the round button).
+        strokeCircle(
+            center: CGPoint(x: 15, y: 47),
+            radius: 5,
+            color: UIKitChassis.signal2
+        )
+        let clip = UIBezierPath()
+        clip.move(to: CGPoint(x: 13.5, y: 48.5))
+        clip.addLine(to: CGPoint(x: 16.5, y: 45.5))
+        clip.addLine(to: CGPoint(x: 17.5, y: 46.5))
+        clip.addLine(to: CGPoint(x: 14, y: 50))
+        stroke(clip, color: UIKitChassis.signal2)
+        // The message.
+        drawMonoText(
+            "Fix the test",
+            at: CGPoint(x: 24, y: 43.5),
+            size: 5.6,
+            color: UIKitChassis.signal
+        )
+        let caret = UIBezierPath()
+        caret.move(to: CGPoint(x: 65.5, y: 43))
+        caret.addLine(to: CGPoint(x: 65.5, y: 51))
+        stroke(caret, color: UIKitChassis.signal)
+        // The filled ↑.
+        let send = UIBezierPath(
+            arcCenter: CGPoint(x: 80, y: 47),
+            radius: 5.5,
+            startAngle: 0,
+            endAngle: 2 * .pi,
+            clockwise: true
+        )
+        fill(send, color: UIKitChassis.signal)
+        let up = UIBezierPath()
+        up.move(to: CGPoint(x: 80, y: 50))
+        up.addLine(to: CGPoint(x: 80, y: 44))
+        up.move(to: CGPoint(x: 77.5, y: 46.5))
+        up.addLine(to: CGPoint(x: 80, y: 44))
+        up.addLine(to: CGPoint(x: 82.5, y: 46.5))
+        stroke(up, color: UIKitChassis.chassis)
     }
 
     private func drawResize() {

--- a/Multiplex/Views/Terminal/TerminalGuidePictograms.swift
+++ b/Multiplex/Views/Terminal/TerminalGuidePictograms.swift
@@ -421,14 +421,7 @@ final class TerminalGuidePictogramView: UIView {
         caret.addLine(to: CGPoint(x: 65.5, y: 51))
         stroke(caret, color: UIKitChassis.signal)
         // The filled ↑.
-        let send = UIBezierPath(
-            arcCenter: CGPoint(x: 80, y: 47),
-            radius: 5.5,
-            startAngle: 0,
-            endAngle: 2 * .pi,
-            clockwise: true
-        )
-        fill(send, color: UIKitChassis.signal)
+        fillCircle(center: CGPoint(x: 80, y: 47), radius: 5.5, color: UIKitChassis.signal)
         let up = UIBezierPath()
         up.move(to: CGPoint(x: 80, y: 50))
         up.addLine(to: CGPoint(x: 80, y: 44))

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -16,7 +16,10 @@ final class TerminalTallyKeyControl: UIControl {
     }
 
     var isLatched = false {
-        didSet { refreshAppearance() }
+        didSet {
+            guard isLatched != oldValue else { return }
+            refreshAppearance()
+        }
     }
     var faceInset: CGFloat = 0 {
         didSet { setNeedsLayout() }
@@ -407,20 +410,26 @@ enum TerminalKeyBarLayout {
         var faceInset: CGFloat = 0
 
         static let regular = Metric(keyWidth: 46, spacing: 6, groupGap: 12)
-        static let tight = Metric(keyWidth: 40, spacing: 1, groupGap: 1, faceInset: 1)
+        /// The phone tiers run 36 pt faces (the visionOS compact cluster's
+        /// width) since the talk key joined the right group: at 40 pt every
+        /// phone tier overflowed its cutoff (tight 425 > 390, RET floor 400 >
+        /// 375), and the key is essential at every tier — so the faces
+        /// yield, and `SingleWindowShellLayout`'s 390 / 420 cutoffs and the
+        /// 375 locked floor hold unchanged (pinned by the width-ladder test).
+        static let tight = Metric(keyWidth: 36, spacing: 1, groupGap: 1, faceInset: 1)
         static let returnAndTmux = Metric(
-            keyWidth: 40,
+            keyWidth: 36,
             spacing: 0,
             groupGap: 4,
             faceInset: 1
         )
         static let returnFloor = Metric(
-            keyWidth: 40,
+            keyWidth: 36,
             spacing: 0,
             groupGap: 1,
             faceInset: 1
         )
-        static let compact = Metric(keyWidth: 40, spacing: 4, groupGap: 4)
+        static let compact = Metric(keyWidth: 36, spacing: 4, groupGap: 4)
     }
 
     struct Specification: Equatable {
@@ -435,9 +444,11 @@ enum TerminalKeyBarLayout {
             let gap = includesReturn ? min(metric.groupGap, 8) : metric.groupGap
             var groupCounts = [3]
             if !symbols.isEmpty { groupCounts.append(symbols.count) }
+            // arrows · RET · talk · keyboard/mic · TMUX
             let rightCount = (pageKeys ? 2 : 0)
                 + 4
                 + (includesReturn ? 1 : 0)
+                + 1
                 + 1
                 + (tmux ? 1 : 0)
             groupCounts.append(rightCount)
@@ -539,6 +550,8 @@ struct TerminalKeyBarObservedState: Equatable {
     var hardwareKeyboardConnected: Bool
     var keyboardLocked: Bool
     var isDictating: Bool
+    /// The talk key latches while this tab's message box is open.
+    var talkbackOpen: Bool
 }
 
 /// The iPad terminal's app-owned TALLY key rail. It is a normal UIKit sibling
@@ -711,7 +724,8 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         TerminalKeyBarObservedState(
             hardwareKeyboardConnected: HardwareKeyboardMonitor.shared.isConnected,
             keyboardLocked: KeyboardLock.shared.isLocked,
-            isDictating: controller?.isDictating == true
+            isDictating: controller?.isDictating == true,
+            talkbackOpen: controller?.talkbackOpen == true
         )
     }
 
@@ -783,6 +797,17 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
                 identifier: "return"
             ))
         }
+        // Talkback — the message box under the pane; RET · talk · keyboard.
+        // Latched while the box is open, like CTRL and the keyboard lock.
+        right.append(RailKey(
+            key: .talkback,
+            face: .symbol("text.bubble", pointSize: 13, weight: .semibold),
+            accessibility: state.talkbackOpen
+                ? "Close the message box"
+                : "Open the message box",
+            identifier: "talkback",
+            latched: state.talkbackOpen
+        ))
         if state.hardwareKeyboardConnected {
             right.append(RailKey(
                 key: .dictation,
@@ -938,6 +963,9 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
             terminal.send(EscapeSequences.cmdPageDown)
         case .keyboard:
             TerminalFocusArbiter.toggle(terminal)
+        case .talkback:
+            click()
+            controller?.toggleTalkback()
         case .lockKeyboard:
             click()
             TerminalFocusArbiter.lock(terminal)
@@ -1236,6 +1264,7 @@ private enum TerminalKey {
     case keyboard
     case lockKeyboard
     case dictation
+    case talkback
     case showShortcutPanel
     case shortcut(ShortcutPanelItem)
     case keyCommands
@@ -1400,6 +1429,9 @@ final class TerminalKeyClusterContext {
     #endif
 
     private(set) var ctrlLatched = false
+    /// The talk key latches while the active tab's message box is open —
+    /// read from the controller, never mirrored.
+    var talkbackOpen: Bool { controller?.talkbackOpen == true }
 
     init() {
         #if DEBUG
@@ -1454,6 +1486,8 @@ final class TerminalKeyClusterContext {
         let controllerChanged = self.controller !== controller
         self.controller = controller
         let terminal = controller?.terminalView
+        // Every group applies the context's state on its own update; only a
+        // changed terminal re-registers the latch-reset observer.
         guard controllerChanged || observedTerminal !== terminal else { return }
         if let controlResetObserver {
             NotificationCenter.default.removeObserver(controlResetObserver)
@@ -1488,6 +1522,13 @@ final class TerminalKeyClusterContext {
 
     func toggleKeyboard() {
         controller?.toggleKeyboard()
+    }
+
+    func toggleTalkback() {
+        controller?.toggleTalkback()
+        // The window re-renders every group on the open flip; the broadcast
+        // latches the sibling candidates this same turn.
+        broadcast()
     }
 
     func toggleControl(from group: TerminalKeyClusterGroupView) {
@@ -1581,6 +1622,7 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
     private let context: TerminalKeyClusterContext
     private var standaloneVariant: StandaloneVariant?
     private weak var ctrlKey: TerminalTallyKeyControl?
+    private weak var talkKey: TerminalTallyKeyControl?
     private weak var comboPopoverController: UIViewController?
     private let keyCommandsPresenter = KeyCommandPanelPresenter()
     private(set) var keys: [TerminalTallyKeyControl] = []
@@ -1634,6 +1676,9 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
 
     func applyContextState() {
         ctrlKey?.isLatched = context.ctrlLatched
+        talkKey?.isLatched = context.talkbackOpen
+        talkKey?.accessibilityLabel = context.talkbackOpen
+            ? "Close the message box" : "Open the message box"
     }
 
     func fittingSize(maximumWidth: CGFloat?) -> CGSize {
@@ -1734,6 +1779,7 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
         for key in keys { key.removeFromSuperview() }
         keys.removeAll(keepingCapacity: true)
         ctrlKey = nil
+        talkKey = nil
         standaloneVariant = variant
         let activeMetric: TerminalKeyClusterMetric
         let minimal: Bool
@@ -1801,6 +1847,20 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
                 accessibilityIdentifier: "terminal.keyCluster.return",
                 action: { [weak context] in context?.sendReturn() }
             ))
+            // Talkback — RET · talk · keyboard, mirroring the iPad rail;
+            // latched while the message box is open.
+            let talk = TerminalTallyKeyControl(
+                face: .symbol("text.bubble", pointSize: 12, weight: .semibold),
+                width: activeMetric.keyWidth,
+                height: 26,
+                accessibilityLabel: context.talkbackOpen
+                    ? "Close the message box" : "Open the message box",
+                accessibilityIdentifier: "terminal.keyCluster.talkback",
+                latched: context.talkbackOpen,
+                action: { [weak context] in context?.toggleTalkback() }
+            )
+            append(talk)
+            talkKey = talk
             let keyboard = TerminalTallyKeyControl(
                 face: .symbol("keyboard", pointSize: 12, weight: .semibold),
                 width: activeMetric.keyWidth,
@@ -1882,8 +1942,10 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
         24 + metric.keyWidth * 3 + metric.spacing * 2
     }
 
+    /// arrows · RET · talk · keyboard — four arrows in a run, then three
+    /// tail keys each a group gap apart.
     private func trailingWidth(_ metric: TerminalKeyClusterMetric) -> CGFloat {
-        24 + metric.keyWidth * 6 + metric.spacing * 3 + metric.groupGap * 2
+        24 + metric.keyWidth * 7 + metric.spacing * 3 + metric.groupGap * 3
     }
 
     private func standaloneWidth(
@@ -1892,8 +1954,8 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
     ) -> CGFloat {
         let left = metric.keyWidth * 3 + metric.spacing * 2
         let arrows = minimal ? 0 : metric.keyWidth * 4 + metric.spacing * 3
-        let groups = minimal ? 3 : 4
-        return 24 + left + arrows + metric.keyWidth * 2
+        let groups = minimal ? 4 : 5
+        return 24 + left + arrows + metric.keyWidth * 3
             + CGFloat(groups - 1) * metric.groupGap
     }
 

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -371,6 +371,12 @@ final class TerminalCtrlComboViewController: UIViewController {
     }
 }
 
+/// The talk key's VoiceOver name on the rail and in the visionOS cluster —
+/// one wording, flipped in place with the latch.
+private func talkbackKeyLabel(open: Bool) -> String {
+    open ? "Close the message box" : "Open the message box"
+}
+
 #if !os(visionOS)
 
 /// Pure layout ladder for the native rail. Its last two exact floors are
@@ -725,8 +731,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
                 renderedSignature = signature
             }
             talkKeyControl?.isLatched = state.talkbackOpen
-            talkKeyControl?.accessibilityLabel = state.talkbackOpen
-                ? "Close the message box" : "Open the message box"
+            talkKeyControl?.accessibilityLabel = talkbackKeyLabel(open: state.talkbackOpen)
             layoutRow(specification: specification, includesReturn: includesReturn)
             bringSubviewToFront(topBorder)
         }
@@ -828,9 +833,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         right.append(RailKey(
             key: .talkback,
             face: .symbol("text.bubble", pointSize: 13, weight: .semibold),
-            accessibility: state.talkbackOpen
-                ? "Close the message box"
-                : "Open the message box",
+            accessibility: talkbackKeyLabel(open: state.talkbackOpen),
             identifier: "talkback",
             latched: state.talkbackOpen
         ))
@@ -1704,8 +1707,7 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
     func applyContextState() {
         ctrlKey?.isLatched = context.ctrlLatched
         talkKey?.isLatched = context.talkbackOpen
-        talkKey?.accessibilityLabel = context.talkbackOpen
-            ? "Close the message box" : "Open the message box"
+        talkKey?.accessibilityLabel = talkbackKeyLabel(open: context.talkbackOpen)
     }
 
     func fittingSize(maximumWidth: CGFloat?) -> CGSize {
@@ -1880,8 +1882,7 @@ final class TerminalKeyClusterGroupView: UIKitTallyBorderedView {
                 face: .symbol("text.bubble", pointSize: 12, weight: .semibold),
                 width: activeMetric.keyWidth,
                 height: 26,
-                accessibilityLabel: context.talkbackOpen
-                    ? "Close the message box" : "Open the message box",
+                accessibilityLabel: talkbackKeyLabel(open: context.talkbackOpen),
                 accessibilityIdentifier: "terminal.keyCluster.talkback",
                 latched: context.talkbackOpen,
                 action: { [weak context] in context?.toggleTalkback() }

--- a/Multiplex/Views/Terminal/TerminalKeyBar.swift
+++ b/Multiplex/Views/Terminal/TerminalKeyBar.swift
@@ -629,6 +629,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     private var renderedSignature: RenderSignature?
     private(set) var renderedKeys: [TerminalTallyKeyControl] = []
     private weak var ctrlKeyControl: TerminalTallyKeyControl?
+    private weak var talkKeyControl: TerminalTallyKeyControl?
     private weak var shortcutPopoverController: UIViewController?
     private let keyCommandsPresenter = KeyCommandPanelPresenter()
     /// The tier's Key Commands cap and paywall route, handed down with the
@@ -636,9 +637,21 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
     var keyCommandPlan: KeyCommandPlan = .unrestricted
     private var ctrlComboView: TerminalCtrlComboView?
 
+    /// What forces a rebuild of the row. The talk key's latch is deliberately
+    /// not part of it — it flips in place, like CTRL's, so opening the
+    /// message box never re-creates the keys under the finger.
     private struct RenderSignature: Equatable {
         var tier: TerminalKeyBarLayout.Tier
-        var state: TerminalKeyBarObservedState
+        var hardwareKeyboardConnected: Bool
+        var keyboardLocked: Bool
+        var isDictating: Bool
+
+        init(tier: TerminalKeyBarLayout.Tier, state: TerminalKeyBarObservedState) {
+            self.tier = tier
+            hardwareKeyboardConnected = state.hardwareKeyboardConnected
+            keyboardLocked = state.keyboardLocked
+            isDictating = state.isDictating
+        }
     }
 
     init(
@@ -691,22 +704,32 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        topBorder.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 1)
-        let state = observedState ?? currentObservedState
-        let includesReturn = showsReturnKey || state.keyboardLocked
-        let specification = TerminalKeyBarLayout.specification(
-            width: bounds.width,
-            contentSafeArea: contentSafeArea,
-            showsTmux: shortcutBackend != nil,
-            includesReturn: includesReturn
-        )
-        let signature = RenderSignature(tier: specification.tier, state: state)
-        if renderedSignature != signature {
-            rebuildRow(specification: specification, state: state)
-            renderedSignature = signature
+        // The rail's own faces never animate: a row rebuilt or re-tiered
+        // inside someone else's animation block (the Talkback card's spring
+        // runs the window's whole render, and this pass lands in its
+        // `layoutIfNeeded`) would otherwise fly its keys in from zero
+        // frames. The rail as a whole still rides its container's motion.
+        UIView.performWithoutAnimation {
+            topBorder.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 1)
+            let state = observedState ?? currentObservedState
+            let includesReturn = showsReturnKey || state.keyboardLocked
+            let specification = TerminalKeyBarLayout.specification(
+                width: bounds.width,
+                contentSafeArea: contentSafeArea,
+                showsTmux: shortcutBackend != nil,
+                includesReturn: includesReturn
+            )
+            let signature = RenderSignature(tier: specification.tier, state: state)
+            if renderedSignature != signature {
+                rebuildRow(specification: specification, state: state)
+                renderedSignature = signature
+            }
+            talkKeyControl?.isLatched = state.talkbackOpen
+            talkKeyControl?.accessibilityLabel = state.talkbackOpen
+                ? "Close the message box" : "Open the message box"
+            layoutRow(specification: specification, includesReturn: includesReturn)
+            bringSubviewToFront(topBorder)
         }
-        layoutRow(specification: specification, includesReturn: includesReturn)
-        bringSubviewToFront(topBorder)
     }
 
     override func willMove(toWindow newWindow: UIWindow?) {
@@ -740,7 +763,9 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         }
         guard state != observedState else { return }
         observedState = state
-        renderedSignature = nil
+        // The layout pass compares render signatures itself: a state change
+        // that only moves the talk latch re-latches in place; the rest
+        // rebuild the row.
         setNeedsLayout()
     }
 
@@ -751,6 +776,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
         for key in renderedKeys { key.removeFromSuperview() }
         renderedKeys.removeAll(keepingCapacity: true)
         ctrlKeyControl = nil
+        talkKeyControl = nil
         let metric = specification.metric
         let includesReturn = showsReturnKey || state.keyboardLocked
 
@@ -875,6 +901,7 @@ final class TerminalKeyBar: UIView, UIInputViewAudioFeedback {
                 addSubview(control)
                 renderedKeys.append(control)
                 if descriptor.identifier == "control" { ctrlKeyControl = control }
+                if descriptor.identifier == "talkback" { talkKeyControl = control }
             }
         }
     }

--- a/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
+++ b/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
@@ -562,11 +562,11 @@ private struct TerminalVisionConsoleLayout: Layout {
         subviews: Subviews,
         cache: inout ()
     ) -> CGSize {
-        guard let console = console(in: subviews) else { return .zero }
+        guard let console = subview(.console, in: subviews) else { return .zero }
         return TerminalVisionConsoleGeometry.resolve(
-            helperSize: helper(in: subviews)?.sizeThatFits(proposal),
+            helperSize: subview(.helper, in: subviews)?.sizeThatFits(proposal),
             consoleSize: console.sizeThatFits(proposal),
-            talkbackSize: talkback(in: subviews)?.sizeThatFits(proposal),
+            talkbackSize: subview(.talkback, in: subviews)?.sizeThatFits(proposal),
             helperLeading: helperLeading,
             spacing: spacing
         ).size
@@ -578,11 +578,11 @@ private struct TerminalVisionConsoleLayout: Layout {
         subviews: Subviews,
         cache: inout ()
     ) {
-        guard let console = console(in: subviews) else { return }
-        let helper = helper(in: subviews)
+        guard let console = subview(.console, in: subviews) else { return }
+        let helper = subview(.helper, in: subviews)
         let helperSize = helper?.sizeThatFits(proposal)
         let consoleSize = console.sizeThatFits(proposal)
-        let talkback = talkback(in: subviews)
+        let talkback = subview(.talkback, in: subviews)
         let talkbackSize = talkback?.sizeThatFits(proposal)
         let geometry = TerminalVisionConsoleGeometry.resolve(
             helperSize: helperSize,
@@ -638,22 +638,8 @@ private struct TerminalVisionConsoleLayout: Layout {
         }
     }
 
-    private func talkback(in subviews: Subviews) -> LayoutSubview? {
-        subviews.first {
-            $0[TerminalVisionConsoleRoleKey.self] == .talkback
-        }
-    }
-
-    private func helper(in subviews: Subviews) -> LayoutSubview? {
-        subviews.first {
-            $0[TerminalVisionConsoleRoleKey.self] == .helper
-        }
-    }
-
-    private func console(in subviews: Subviews) -> LayoutSubview? {
-        subviews.first {
-            $0[TerminalVisionConsoleRoleKey.self] == .console
-        }
+    private func subview(_ role: TerminalVisionConsoleRole, in subviews: Subviews) -> LayoutSubview? {
+        subviews.first { $0[TerminalVisionConsoleRoleKey.self] == role }
     }
 }
 

--- a/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
+++ b/Multiplex/Views/Terminal/TerminalVisionOrnaments.swift
@@ -35,8 +35,14 @@ struct TerminalVisionOrnamentPresentation: Equatable {
         return Self(
             showsTopSourceLabels: tabCount > 1,
             bottom: bottom,
-            maximumConsoleWidth: max(1, windowWidth - 24)
+            maximumConsoleWidth: consoleClamp(windowWidth: windowWidth)
         )
+    }
+
+    /// The width the console row (and every slab hung from it) is proposed
+    /// at most — the scene less its resize-corner margins.
+    static func consoleClamp(windowWidth: CGFloat) -> CGFloat {
+        max(1, windowWidth - 24)
     }
 }
 
@@ -47,23 +53,40 @@ struct TerminalVisionConsoleGeometry: Equatable {
     var size: CGSize
     var helperOrigin: CGPoint?
     var consoleOrigin: CGPoint
+    /// The Talkback slab hangs below the console row, `spacing` under it.
+    /// It lengthens the lower half — and so, symmetrically, the reported
+    /// bounds — while the console's top stays the exact midpoint.
+    var talkbackOrigin: CGPoint?
 
     static func resolve(
         helperSize: CGSize?,
         consoleSize: CGSize,
+        talkbackSize: CGSize? = nil,
         helperLeading: Bool,
         spacing: CGFloat
     ) -> Self {
         let helperSize = helperSize.map(Self.normalized)
         let consoleSize = Self.normalized(consoleSize)
+        let talkbackSize = talkbackSize.map(Self.normalized)
         let spacing = spacing.isFinite ? max(0, spacing) : 0
         let upperExtent = helperSize.map { $0.height + spacing } ?? 0
-        let halfHeight = max(upperExtent, consoleSize.height)
-        let width = max(helperSize?.width ?? 0, consoleSize.width)
+        let lowerExtent = consoleSize.height + (talkbackSize.map { spacing + $0.height } ?? 0)
+        let halfHeight = max(upperExtent, lowerExtent)
+        let width = max(
+            helperSize?.width ?? 0,
+            consoleSize.width,
+            talkbackSize?.width ?? 0
+        )
         let helperOrigin = helperSize.map { helperSize in
             CGPoint(
                 x: helperLeading ? 0 : (width - helperSize.width) / 2,
                 y: halfHeight - spacing - helperSize.height
+            )
+        }
+        let talkbackOrigin = talkbackSize.map { talkbackSize in
+            CGPoint(
+                x: (width - talkbackSize.width) / 2,
+                y: halfHeight + consoleSize.height + spacing
             )
         }
         return Self(
@@ -72,7 +95,8 @@ struct TerminalVisionConsoleGeometry: Equatable {
             consoleOrigin: CGPoint(
                 x: (width - consoleSize.width) / 2,
                 y: halfHeight
-            )
+            ),
+            talkbackOrigin: talkbackOrigin
         )
     }
 
@@ -99,6 +123,12 @@ final class TerminalVisionOrnamentState {
     private(set) var activeTerminalController: TerminalSessionController?
     private(set) var umdController: UIViewController?
     private(set) var helperController: AgentHelperStripViewController?
+    /// The open Talkback composer for the active tab, mounted as its own
+    /// slab under the console row; nil while the box is closed. Its growth
+    /// (a line typed, a chip attached) reaches the ornament through the
+    /// window: the composer reports, the window re-renders, `revision`
+    /// bumps, and the mount re-asks the composer for its size.
+    private(set) var talkbackController: TalkbackComposerViewController?
     /// The helper controller is native UIKit, so its app-wide collapse choice
     /// is not observable by SwiftUI on its own. Mirror it into ornament state:
     /// this value is the animation trigger for the full rail ↔ corner dot
@@ -131,12 +161,14 @@ final class TerminalVisionOrnamentState {
         activeTerminalController: TerminalSessionController?,
         umdController: UIViewController?,
         helperController: AgentHelperStripViewController?,
+        talkbackController: TalkbackComposerViewController? = nil,
         windowWidth: CGFloat,
         interfaceStyle: UIUserInterfaceStyle,
         forceRevision: Bool
     ) {
         self.interfaceStyle = interfaceStyle
         let nextHelper = isAuxiliary ? nil : helperController
+        let nextTalkback = isAuxiliary ? nil : talkbackController
         let nextPresentation = TerminalVisionOrnamentPresentation.resolve(
             tabCount: tabCount,
             isAuxiliary: isAuxiliary,
@@ -149,10 +181,12 @@ final class TerminalVisionOrnamentState {
             || self.activeTerminalController !== activeTerminalController
             || self.umdController !== umdController
             || self.helperController !== nextHelper
+            || self.talkbackController !== nextTalkback
             || helperCollapsed != nextHelperCollapsed
         self.activeTerminalController = activeTerminalController
         self.umdController = umdController
         self.helperController = nextHelper
+        self.talkbackController = nextTalkback
         helperCollapsed = nextHelperCollapsed
         presentation = nextPresentation
         refreshUMDContentSize()
@@ -175,6 +209,7 @@ final class TerminalVisionOrnamentState {
         activeTerminalController = nil
         umdController = nil
         helperController = nil
+        talkbackController = nil
         helperCollapsed = false
         umdContentSize = .zero
         presentation = TerminalVisionOrnamentPresentation(
@@ -229,6 +264,7 @@ final class TerminalVisionOrnamentCoordinator {
         activeTerminalController: TerminalSessionController?,
         umdController: UIViewController?,
         helperController: AgentHelperStripViewController?,
+        talkbackController: TalkbackComposerViewController? = nil,
         windowWidth: CGFloat,
         interfaceStyle: UIUserInterfaceStyle,
         forceRevision: Bool = false
@@ -239,6 +275,7 @@ final class TerminalVisionOrnamentCoordinator {
             activeTerminalController: activeTerminalController,
             umdController: umdController,
             helperController: helperController,
+            talkbackController: talkbackController,
             windowWidth: windowWidth,
             interfaceStyle: interfaceStyle,
             forceRevision: forceRevision
@@ -400,6 +437,25 @@ private struct TerminalVisionBottomOrnament: View {
                     key: TerminalVisionConsoleRoleKey.self,
                     value: .console
                 )
+
+                if let talkback = state.talkbackController {
+                    // Content-sized like every slab (never window-width),
+                    // hung below the console row: the composer's arithmetic
+                    // decides its height at the console clamp's width, and
+                    // `revision` re-asks it after every window render.
+                    TerminalVisionControllerMount(
+                        controller: talkback,
+                        sizing: .talkback,
+                        revision: state.revision,
+                        interfaceStyle: state.interfaceStyle
+                    )
+                    .fixedSize()
+                    .modifier(GlassPrototypeSlabGround(cornerRadius: 22))
+                    .layoutValue(
+                        key: TerminalVisionConsoleRoleKey.self,
+                        value: .talkback
+                    )
+                }
             }
             // The terminal owner previously wrapped this change in a UIKit
             // animator, but a classic ornament lives in a separate SwiftUI
@@ -487,6 +543,7 @@ private struct TerminalVisionStackedDeckLayout: Layout {
 private enum TerminalVisionConsoleRole: Equatable {
     case helper
     case console
+    case talkback
 }
 
 private struct TerminalVisionConsoleRoleKey: LayoutValueKey {
@@ -509,6 +566,7 @@ private struct TerminalVisionConsoleLayout: Layout {
         return TerminalVisionConsoleGeometry.resolve(
             helperSize: helper(in: subviews)?.sizeThatFits(proposal),
             consoleSize: console.sizeThatFits(proposal),
+            talkbackSize: talkback(in: subviews)?.sizeThatFits(proposal),
             helperLeading: helperLeading,
             spacing: spacing
         ).size
@@ -524,9 +582,12 @@ private struct TerminalVisionConsoleLayout: Layout {
         let helper = helper(in: subviews)
         let helperSize = helper?.sizeThatFits(proposal)
         let consoleSize = console.sizeThatFits(proposal)
+        let talkback = talkback(in: subviews)
+        let talkbackSize = talkback?.sizeThatFits(proposal)
         let geometry = TerminalVisionConsoleGeometry.resolve(
             helperSize: helperSize,
             consoleSize: consoleSize,
+            talkbackSize: talkbackSize,
             helperLeading: helperLeading,
             spacing: spacing
         )
@@ -559,6 +620,27 @@ private struct TerminalVisionConsoleLayout: Layout {
                     height: helperSize.height
                 )
             )
+        }
+        if let talkback,
+           let talkbackSize,
+           let talkbackOrigin = geometry.talkbackOrigin {
+            talkback.place(
+                at: CGPoint(
+                    x: origin.x + talkbackOrigin.x,
+                    y: origin.y + talkbackOrigin.y
+                ),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(
+                    width: talkbackSize.width,
+                    height: talkbackSize.height
+                )
+            )
+        }
+    }
+
+    private func talkback(in subviews: Subviews) -> LayoutSubview? {
+        subviews.first {
+            $0[TerminalVisionConsoleRoleKey.self] == .talkback
         }
     }
 
@@ -917,6 +999,9 @@ private enum TerminalVisionControllerSizing: Equatable {
     case terminalUMD
     case auxiliaryUMD
     case switchboardSlab
+    /// The Talkback slab: the composer's own arithmetic at the width the
+    /// window handed it.
+    case talkback
 }
 
 private struct TerminalVisionControllerMount: UIViewControllerRepresentable {
@@ -1057,6 +1142,10 @@ private final class TerminalVisionControllerHost: UIViewController {
         case .switchboardSlab:
             if let slab = content as? ViewportSwitchboardSlabViewController {
                 return slab.fittingContentSize(for: proposedWidth)
+            }
+        case .talkback:
+            if let composer = content as? TalkbackComposerViewController {
+                return composer.fittingContentSize()
             }
         }
         content.loadViewIfNeeded()

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -770,6 +770,12 @@ final class TerminalWindowViewController: UIViewController,
             }
         }
         updateShownAgent(from: snapshot)
+        #if !os(visionOS)
+        if let transition = pendingTalkbackTransition {
+            animateTalkbackTransition(transition)
+            return
+        }
+        #endif
         renderNow()
     }
 
@@ -1463,6 +1469,127 @@ final class TerminalWindowViewController: UIViewController,
         )
     }
 
+    #if !os(visionOS)
+    /// The card's arrival or departure, when the next render will mount or
+    /// drop it. Same curve as the helper strip's fold — the two share the
+    /// chrome band and should move like one instrument.
+    private enum TalkbackTransition {
+        case opening
+        case closing
+    }
+
+    private var pendingTalkbackTransition: TalkbackTransition? {
+        if talkbackOpen, talkbackController == nil { return .opening }
+        if !talkbackOpen, talkbackController != nil { return .closing }
+        return nil
+    }
+
+    private static let talkbackSpring: (duration: TimeInterval, damping: CGFloat) = (0.35, 0.85)
+
+    /// Opening: the card rises out from behind the rail's edge (its band
+    /// clips it, so it never crosses the keys) while the pane cedes its rows;
+    /// closing: a snapshot of the card sinks back the same way while the pane
+    /// reclaims them. Reduce Motion cuts straight to the result.
+    private func animateTalkbackTransition(_ transition: TalkbackTransition) {
+        guard !UIAccessibility.isReduceMotionEnabled, isViewLoaded, rootView.window != nil else {
+            renderNow()
+            return
+        }
+        switch transition {
+        case .opening:
+            // Mount unanimated and park the band at its final frame with the
+            // card pushed below it (clipped, so it never crosses the keys);
+            // the animated render then insets the pane — the surface lays its
+            // constraint out inside the block, so it animates — while the
+            // card slides up into the band.
+            UIView.performWithoutAnimation {
+                renderTalkback()
+                let container = rootView.talkbackContainer
+                let height = renderedTalkbackHeight
+                container.frame = CGRect(
+                    x: 0,
+                    y: paneChromeBottom - height,
+                    width: rootView.bounds.width,
+                    height: height
+                )
+                container.isHidden = false
+                if let card = talkbackController?.view {
+                    card.frame = container.bounds
+                    card.layoutIfNeeded()
+                    card.transform = CGAffineTransform(translationX: 0, y: height)
+                }
+            }
+            UIView.animate(
+                withDuration: Self.talkbackSpring.duration,
+                delay: 0,
+                usingSpringWithDamping: Self.talkbackSpring.damping,
+                initialSpringVelocity: 0
+            ) { [self] in
+                renderNow()
+                talkbackController?.view.transform = .identity
+                rootView.layoutIfNeeded()
+            }
+        case .closing:
+            // The real card unmounts in the render; a snapshot inside a
+            // clipping stand-in at the same frame sinks out of view while the
+            // pane takes its rows back.
+            let container = rootView.talkbackContainer
+            let clip = UIView(frame: container.frame)
+            clip.clipsToBounds = true
+            clip.isUserInteractionEnabled = false
+            if let ghost = container.snapshotView(afterScreenUpdates: false) {
+                ghost.frame = clip.bounds
+                clip.addSubview(ghost)
+                rootView.insertSubview(clip, aboveSubview: container)
+            }
+            UIView.animate(
+                withDuration: Self.talkbackSpring.duration,
+                delay: 0,
+                usingSpringWithDamping: Self.talkbackSpring.damping,
+                initialSpringVelocity: 0
+            ) { [self] in
+                renderNow()
+                rootView.layoutIfNeeded()
+                clip.subviews.first?.transform = CGAffineTransform(
+                    translationX: 0,
+                    y: clip.bounds.height
+                )
+            } completion: { _ in
+                clip.removeFromSuperview()
+            }
+        }
+    }
+
+    /// A line typed, a chip attached: the card grows upward and the pane
+    /// cedes the row in one motion.
+    private func animateTalkbackGrowth() {
+        guard !UIAccessibility.isReduceMotionEnabled,
+              talkbackController != nil,
+              rootView.window != nil
+        else {
+            renderNow()
+            return
+        }
+        UIView.animate(
+            withDuration: 0.25,
+            delay: 0,
+            usingSpringWithDamping: 0.9,
+            initialSpringVelocity: 0
+        ) { [self] in
+            renderNow()
+            rootView.layoutIfNeeded()
+        }
+    }
+
+    /// Where the pane's bottom chrome starts: the rail's top edge, lifted
+    /// with it over a docked keyboard.
+    private var paneChromeBottom: CGFloat {
+        rootView.paneContainer.frame.maxY
+            - (activeController?.keyboardObstruction ?? 0)
+            - TerminalKeyBar.barHeight(spendsBottomStrip: railOwnsBottomSafeArea)
+    }
+    #endif
+
     private func configurePassphrasePresenter() {
         addChild(passphrasePresenter)
         rootView.addSubview(passphrasePresenter.view)
@@ -2152,8 +2279,9 @@ extension TerminalWindowViewController {
             let composer = TalkbackComposerViewController(configuration: configuration)
             composer.onContentSizeChange = { [weak self] in
                 // Reported from the composer's own layout pass; re-inset the
-                // pane on the next turn rather than inside that pass.
-                Task { @MainActor [weak self] in self?.renderNow() }
+                // pane on the next turn rather than inside that pass — with
+                // the card and the pane moving together.
+                Task { @MainActor [weak self] in self?.animateTalkbackGrowth() }
             }
             talkbackController = composer
             #if !os(visionOS)
@@ -2476,9 +2604,7 @@ extension TerminalWindowViewController {
         // with it over a docked keyboard): the Talkback card first, then the
         // helper strip — docked or its dot. One cursor places both.
         #if !os(visionOS)
-        var chromeBottom = rootView.paneContainer.frame.maxY
-            - (activeController?.keyboardObstruction ?? 0)
-            - TerminalKeyBar.barHeight(spendsBottomStrip: railOwnsBottomSafeArea)
+        var chromeBottom = paneChromeBottom
         let composerHeight = renderedTalkbackHeight
         if let talkbackController, composerHeight > 0 {
             chromeBottom -= composerHeight

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -243,6 +243,18 @@ final class TerminalWindowViewController: UIViewController,
     private var paneControllers: [UUID: UIViewController] = [:]
     private var umdController: UIViewController?
     private var helperController: AgentHelperStripViewController?
+    /// The active tab's open Talkback composer — one per window, re-pointed
+    /// at whichever tab is active; nil while that tab's box is closed.
+    private var talkbackController: TalkbackComposerViewController?
+    /// Whether opening the box folded the helper strip to its dot (so
+    /// closing can unfold it) — the strip stays as the user left it otherwise.
+    private var talkbackFoldedHelper = false
+    /// The open box's height at this render's width, measured once per
+    /// render (before the panes are configured) — never per tab.
+    private var renderedTalkbackHeight: CGFloat = 0
+    #if !os(visionOS)
+    private var lastRenderedKeyboardLocked = false
+    #endif
     /// Mirrors the legacy helper's `.id(activeTab.hostID)`: even when two
     /// hosts expose the same agent kind, their editor drafts and command
     /// configuration must never share controller state.
@@ -600,14 +612,47 @@ final class TerminalWindowViewController: UIViewController,
     private var showsAgentHelper: Bool {
         shownAgent != nil && activeController?.status == .live
     }
+    /// The active tab's Talkback box is open (auxiliary panes have no pane
+    /// to talk to).
+    private var talkbackOpen: Bool {
+        activeTab?.isAuxiliaryPane != true && activeController?.talkbackOpen == true
+    }
+    /// The width the composer lays out for: the window's on iPad / iPhone
+    /// (the shell's available width where the shell insets), the console
+    /// clamp on visionOS — content-sized like every ornament slab, capped so
+    /// a wide window never grows a window-wide card.
+    private var talkbackWidth: CGFloat {
+        #if os(visionOS)
+        if shell == nil {
+            return min(
+                620,
+                TerminalVisionOrnamentPresentation.consoleClamp(windowWidth: rootView.bounds.width)
+            )
+        }
+        #endif
+        return shell?.availableWidth ?? rootView.bounds.width
+    }
+    /// The eyebrow's telemetry: the tmux/herdr session's attention record for
+    /// this tab, or a plain shell's own. Fail-soft — nil says nothing.
+    private var activeTabAgentState: PaneAgentState? {
+        guard let activeTab else { return nil }
+        guard let key = activeTab.sessionKey else {
+            return activeController?.directShellAttention
+        }
+        guard let host = store.host(id: activeTab.hostID) else { return nil }
+        return hub.model(for: host).attention[key]
+    }
     private var terminalBottomChromeHeight: CGFloat {
         #if os(visionOS)
         0
         #else
         // A collapsed strip is a small dot floating over the terminal's
-        // bottom-leading corner; the pane reclaims the docked row.
-        showsAgentHelper && !AgentHelperStripCollapse.shared.isCollapsed
+        // bottom-leading corner; the pane reclaims the docked row. The
+        // Talkback card docks below the strip (or its dot) and above the
+        // rail, and the pane insets by both.
+        let helper = showsAgentHelper && !AgentHelperStripCollapse.shared.isCollapsed
             ? AgentHelperStripViewController.dockedHeight : 0
+        return helper + renderedTalkbackHeight
         #endif
     }
     private var mergeSources: [TerminalWorkspace.WindowEntry] {
@@ -700,6 +745,10 @@ final class TerminalWindowViewController: UIViewController,
             _ = activeController?.directShellAttention
             _ = activeController?.pendingLink
             _ = activeController?.pendingPath
+            _ = activeController?.talkbackOpen
+            // The eyebrow's telemetry matters only while a box is open —
+            // otherwise an attention edge on the host is not this window's.
+            if talkbackOpen { _ = activeTabAgentState }
             _ = keyPassphraseChallenge
             _ = activeTabKeychainNotice
             #if !os(visionOS)
@@ -751,6 +800,8 @@ final class TerminalWindowViewController: UIViewController,
 
     private func renderNow() {
         guard isViewLoaded, !preparedForRemoval else { return }
+        // Before the panes: their bottom inset reads the composer's height.
+        renderTalkback()
         reconcilePaneControllers()
         renderTabStrip()
         renderUMD()
@@ -1337,7 +1388,7 @@ final class TerminalWindowViewController: UIViewController,
         controller.sendInput(command.payload)
         guard command.submitsAfterPause else { return }
         Task {
-            try? await Task.sleep(for: .milliseconds(160))
+            try? await Task.sleep(for: AgentCommand.submitDelay)
             controller.sendInput(Data([0x0D]))
         }
     }
@@ -2020,6 +2071,136 @@ extension TerminalWindowViewController {
         replacement.didMove(toParent: self)
     }
 
+    /// The Talkback composer follows the active tab's draft: mounted while
+    /// that tab's box is open (docked above the rail on iPad / iPhone, its
+    /// own slab under the visionOS console), dropped when it closes or the
+    /// active tab has no box. Opening folds the helper strip to its dot;
+    /// closing unfolds it if this window folded it. Runs first in a render:
+    /// the panes' bottom inset reads the height it measures.
+    private func renderTalkback() {
+        #if !os(visionOS)
+        // Locking the keyboard closes every message box in this window: the
+        // box exists to type, and the lock says "no keyboard". A box opened
+        // while locked is the user's word that they want to type again —
+        // the lock releases (without the terminal summon that would race the
+        // field's own focus) before the box mounts.
+        let locked = KeyboardLock.shared.isLocked
+        if locked, !lastRenderedKeyboardLocked {
+            for tab in route.tabs {
+                workspace.controller(for: tab.id)?.setTalkbackOpen(false)
+            }
+        }
+        lastRenderedKeyboardLocked = locked
+        #endif
+        guard talkbackOpen, let controller = activeController else {
+            if let existing = talkbackController {
+                let hadKeyboard = existing.prepareForRemoval()
+                // visionOS mounts the composer in the bottom ornament, never
+                // in-window (the shell there is a test-only configuration).
+                #if !os(visionOS)
+                unmount(existing)
+                #endif
+                talkbackController = nil
+                // The field held the keyboard: hand it back to the pane it
+                // was talking to, if that pane still owns focus.
+                if hadKeyboard {
+                    let terminal = existing.configuration.controller.terminalView
+                    if let terminal { TerminalFocusArbiter.resumeAfterPresentation(terminal) }
+                }
+                unfoldHelperAfterTalkback()
+            }
+            renderedTalkbackHeight = 0
+            return
+        }
+        let configuration = TalkbackComposerConfiguration(
+            controller: controller,
+            presentation: TalkbackComposerPresentation(
+                targetLabel: umdTitle,
+                agent: shownAgent,
+                agentState: activeTabAgentState,
+                compactPreviews: UIDevice.current.userInterfaceIdiom == .phone,
+                floating: {
+                    #if os(visionOS)
+                    shell == nil
+                    #else
+                    false
+                    #endif
+                }(),
+                availableWidth: talkbackWidth,
+                contentSafeArea: {
+                    #if os(visionOS)
+                    .zero
+                    #else
+                    contentSafeArea
+                    #endif
+                }()
+            ),
+            close: { [weak controller] in controller?.setTalkbackOpen(false) },
+            focusTerminal: { [weak controller] in
+                guard let terminal = controller?.terminalView else { return }
+                TerminalFocusArbiter.claim(terminal)
+            }
+        )
+        if let talkbackController {
+            talkbackController.update(configuration: configuration)
+        } else {
+            #if !os(visionOS)
+            if KeyboardLock.shared.isLocked, let terminal = controller.terminalView {
+                TerminalFocusArbiter.unlock(terminal, summoning: false)
+            }
+            #endif
+            let composer = TalkbackComposerViewController(configuration: configuration)
+            composer.onContentSizeChange = { [weak self] in
+                // Reported from the composer's own layout pass; re-inset the
+                // pane on the next turn rather than inside that pass.
+                Task { @MainActor [weak self] in self?.renderNow() }
+            }
+            talkbackController = composer
+            #if !os(visionOS)
+            mountTalkback(composer)
+            #endif
+            foldHelperForTalkback()
+        }
+        #if os(visionOS)
+        renderedTalkbackHeight = 0
+        #else
+        renderedTalkbackHeight = talkbackController?.fittingContentSize().height ?? 0
+        #endif
+    }
+
+    #if !os(visionOS)
+    private func mountTalkback(_ composer: TalkbackComposerViewController) {
+        addChild(composer)
+        rootView.talkbackContainer.addSubview(composer.view)
+        composer.view.frame = rootView.talkbackContainer.bounds
+        composer.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        composer.didMove(toParent: self)
+    }
+    #endif
+
+    /// The strip's chips are one tap away on the dot; the rows they cost are
+    /// the pane's while a message is being written. Deferred a turn: the
+    /// collapse posts app-wide and every window re-renders on it, and this
+    /// runs inside a render.
+    private func foldHelperForTalkback() {
+        guard !AgentHelperStripCollapse.shared.isCollapsed else { return }
+        talkbackFoldedHelper = true
+        DispatchQueue.main.async {
+            AgentHelperStripCollapse.shared.setCollapsed(true)
+        }
+    }
+
+    private func unfoldHelperAfterTalkback() {
+        guard talkbackFoldedHelper else { return }
+        talkbackFoldedHelper = false
+        // Only if the user left it folded meanwhile — an expanded strip is
+        // their choice, not this window's to undo.
+        guard AgentHelperStripCollapse.shared.isCollapsed else { return }
+        DispatchQueue.main.async {
+            AgentHelperStripCollapse.shared.setCollapsed(false)
+        }
+    }
+
     private func changeFont(by delta: CGFloat) {
         fontSize = min(32, max(9, fontSize + delta))
         renderNow()
@@ -2055,6 +2236,7 @@ extension TerminalWindowViewController {
             activeTerminalController: activeController,
             umdController: umdController,
             helperController: helperController,
+            talkbackController: talkbackController,
             windowWidth: rootView.bounds.width,
             interfaceStyle: themes.appearance.interfaceStyle,
             forceRevision: forceRevision
@@ -2166,6 +2348,8 @@ extension TerminalWindowViewController {
             rootView.umdContainer.frame = .zero
             rootView.helperContainer.frame = .zero
             rootView.helperContainer.isHidden = true
+            rootView.talkbackContainer.frame = .zero
+            rootView.talkbackContainer.isHidden = true
             for pane in paneControllers.values {
                 pane.view.frame = rootView.paneContainer.bounds
             }
@@ -2288,24 +2472,39 @@ extension TerminalWindowViewController {
         )
         umdController?.view.frame = rootView.umdContainer.bounds
 
+        // The pane's bottom chrome stacks upward from the key rail (lifted
+        // with it over a docked keyboard): the Talkback card first, then the
+        // helper strip — docked or its dot. One cursor places both.
+        #if !os(visionOS)
+        var chromeBottom = rootView.paneContainer.frame.maxY
+            - (activeController?.keyboardObstruction ?? 0)
+            - TerminalKeyBar.barHeight(spendsBottomStrip: railOwnsBottomSafeArea)
+        let composerHeight = renderedTalkbackHeight
+        if let talkbackController, composerHeight > 0 {
+            chromeBottom -= composerHeight
+            rootView.talkbackContainer.frame = CGRect(
+                x: 0,
+                y: max(rootView.paneContainer.frame.minY, chromeBottom),
+                width: bounds.width,
+                height: composerHeight
+            )
+            talkbackController.view.frame = rootView.talkbackContainer.bounds
+            rootView.talkbackContainer.isHidden = false
+        } else {
+            rootView.talkbackContainer.frame = .zero
+            rootView.talkbackContainer.isHidden = true
+        }
+        #endif
+
         if let helperController {
             #if !os(visionOS)
-            let obstruction = activeController?.keyboardObstruction ?? 0
-            // The rail grows its chassis where it spends the bottom strip.
-            let railHeight = TerminalKeyBar.barHeight(
-                spendsBottomStrip: railOwnsBottomSafeArea
-            )
             if AgentHelperStripCollapse.shared.isCollapsed {
                 let dotSize = helperController.fittingContentSize()
                 rootView.helperContainer.frame = CGRect(
                     x: rootView.paneContainer.frame.minX + 10 + contentSafeArea.left,
                     y: max(
                         rootView.paneContainer.frame.minY,
-                        rootView.paneContainer.frame.maxY
-                            - obstruction
-                            - railHeight
-                            - dotSize.height
-                            - 8
+                        chromeBottom - dotSize.height - 8
                     ),
                     width: dotSize.width,
                     height: dotSize.height
@@ -2315,10 +2514,7 @@ extension TerminalWindowViewController {
                     x: 0,
                     y: max(
                         rootView.paneContainer.frame.minY,
-                        rootView.paneContainer.frame.maxY
-                            - obstruction
-                            - railHeight
-                            - AgentHelperStripViewController.dockedHeight
+                        chromeBottom - AgentHelperStripViewController.dockedHeight
                     ),
                     width: bounds.width,
                     height: AgentHelperStripViewController.dockedHeight
@@ -2597,6 +2793,13 @@ extension TerminalWindowViewController {
             Task { await fileViewer.showRepoDiff() }
         }
         observe(.multiplexDebugLinkRegions) { [weak self] in self?.debugLogLinkRegions() }
+        // Talkback: the talk key for the focused terminal (the composer's
+        // own type/send hooks install with the composer).
+        TalkbackDebugHook.install()
+        observe(.multiplexDebugTalkbackToggle) { [weak self] in
+            guard let self, ownsFocusedTerminal else { return }
+            activeController?.toggleTalkback()
+        }
     }
 
     private var ownsFocusedTerminal: Bool {
@@ -2756,6 +2959,9 @@ final class TerminalWindowUIKitRootView: UIView {
     let tabScrollView = TerminalTabScrollView()
     let umdContainer = UIView()
     let helperContainer = UIView()
+    /// The Talkback card's band on iPad / iPhone (and the visionOS shell):
+    /// docked between the pane's chrome and its key rail.
+    let talkbackContainer = UIView()
     private let bottomSafeAreaBackfill = UIView()
     private let tabDivider = UIView()
 
@@ -2777,6 +2983,8 @@ final class TerminalWindowUIKitRootView: UIView {
         tabDivider.backgroundColor = UIKitChassis.bezelHi
         umdContainer.backgroundColor = .clear
         helperContainer.backgroundColor = .clear
+        talkbackContainer.backgroundColor = .clear
+        talkbackContainer.clipsToBounds = true
         bottomSafeAreaBackfill.backgroundColor = UIKitChassis.bezel
         bottomSafeAreaBackfill.isUserInteractionEnabled = false
         bottomSafeAreaBackfill.isAccessibilityElement = false
@@ -2787,12 +2995,14 @@ final class TerminalWindowUIKitRootView: UIView {
         addSubview(tabScrollView)
         addSubview(tabDivider)
         addSubview(umdContainer)
+        addSubview(talkbackContainer)
         addSubview(helperContainer)
         addSubview(bottomSafeAreaBackfill)
         paneContainer.accessibilityIdentifier = "terminalWindow.panes"
         tabScrollView.accessibilityIdentifier = "terminalWindow.tabs"
         umdContainer.accessibilityIdentifier = "terminalWindow.umd"
         helperContainer.accessibilityIdentifier = "terminalWindow.helpers"
+        talkbackContainer.accessibilityIdentifier = "terminalWindow.talkback"
     }
 
     @available(*, unavailable)

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -2280,8 +2280,14 @@ extension TerminalWindowViewController {
             composer.onContentSizeChange = { [weak self] in
                 // Reported from the composer's own layout pass; re-inset the
                 // pane on the next turn rather than inside that pass — with
-                // the card and the pane moving together.
-                Task { @MainActor [weak self] in self?.animateTalkbackGrowth() }
+                // the card and the pane moving together where it is docked.
+                Task { @MainActor [weak self] in
+                    #if os(visionOS)
+                    self?.renderNow()
+                    #else
+                    self?.animateTalkbackGrowth()
+                    #endif
+                }
             }
             talkbackController = composer
             #if !os(visionOS)

--- a/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
+++ b/Multiplex/Views/Terminal/TerminalWindowUIKit.swift
@@ -1448,31 +1448,48 @@ final class TerminalWindowViewController: UIViewController,
             return
         }
         #endif
+        animateChromeRender()
+    }
 
+    /// The chrome band's one motion: the helper strip's fold and the
+    /// Talkback card's arrival, departure and growth all run the window's
+    /// render inside this spring, so the pane cedes or reclaims its rows in
+    /// the same curve as the band. `alongside` rides the block; Reduce
+    /// Motion (or a window not yet on screen) cuts straight to the result.
+    private typealias ChromeSpring = (duration: TimeInterval, damping: CGFloat)
+    private nonisolated static let chromeBandSpring: ChromeSpring = (0.35, 0.85)
+
+    private var animatesChrome: Bool {
+        !UIAccessibility.isReduceMotionEnabled && rootView.window != nil
+    }
+
+    private func animateChromeRender(
+        _ spring: ChromeSpring = chromeBandSpring,
+        alongside: @escaping () -> Void = {},
+        completion: (() -> Void)? = nil
+    ) {
         let changes = { [self] in
             renderNow()
+            alongside()
             rootView.layoutIfNeeded()
         }
-        guard !UIAccessibility.isReduceMotionEnabled else {
+        guard animatesChrome else {
             changes()
+            completion?()
             return
         }
-        // The strip cross-dissolves its own content; this spring folds the
-        // slab into (or out of) the corner dot and lets the terminal reclaim
-        // or cede the docked row.
         UIView.animate(
-            withDuration: 0.35,
+            withDuration: spring.duration,
             delay: 0,
-            usingSpringWithDamping: 0.85,
+            usingSpringWithDamping: spring.damping,
             initialSpringVelocity: 0,
             animations: changes
-        )
+        ) { _ in completion?() }
     }
 
     #if !os(visionOS)
     /// The card's arrival or departure, when the next render will mount or
-    /// drop it. Same curve as the helper strip's fold — the two share the
-    /// chrome band and should move like one instrument.
+    /// drop it.
     private enum TalkbackTransition {
         case opening
         case closing
@@ -1484,14 +1501,12 @@ final class TerminalWindowViewController: UIViewController,
         return nil
     }
 
-    private static let talkbackSpring: (duration: TimeInterval, damping: CGFloat) = (0.35, 0.85)
-
     /// Opening: the card rises out from behind the rail's edge (its band
     /// clips it, so it never crosses the keys) while the pane cedes its rows;
     /// closing: a snapshot of the card sinks back the same way while the pane
-    /// reclaims them. Reduce Motion cuts straight to the result.
+    /// reclaims them.
     private func animateTalkbackTransition(_ transition: TalkbackTransition) {
-        guard !UIAccessibility.isReduceMotionEnabled, isViewLoaded, rootView.window != nil else {
+        guard animatesChrome else {
             renderNow()
             return
         }
@@ -1519,16 +1534,9 @@ final class TerminalWindowViewController: UIViewController,
                     card.transform = CGAffineTransform(translationX: 0, y: height)
                 }
             }
-            UIView.animate(
-                withDuration: Self.talkbackSpring.duration,
-                delay: 0,
-                usingSpringWithDamping: Self.talkbackSpring.damping,
-                initialSpringVelocity: 0
-            ) { [self] in
-                renderNow()
+            animateChromeRender(alongside: { [self] in
                 talkbackController?.view.transform = .identity
-                rootView.layoutIfNeeded()
-            }
+            })
         case .closing:
             // The real card unmounts in the render; a snapshot inside a
             // clipping stand-in at the same frame sinks out of view while the
@@ -1542,43 +1550,23 @@ final class TerminalWindowViewController: UIViewController,
                 clip.addSubview(ghost)
                 rootView.insertSubview(clip, aboveSubview: container)
             }
-            UIView.animate(
-                withDuration: Self.talkbackSpring.duration,
-                delay: 0,
-                usingSpringWithDamping: Self.talkbackSpring.damping,
-                initialSpringVelocity: 0
-            ) { [self] in
-                renderNow()
-                rootView.layoutIfNeeded()
+            animateChromeRender(alongside: {
                 clip.subviews.first?.transform = CGAffineTransform(
                     translationX: 0,
                     y: clip.bounds.height
                 )
-            } completion: { _ in
+            }, completion: {
                 clip.removeFromSuperview()
-            }
+            })
         }
     }
+
+    private nonisolated static let chromeGrowthSpring: ChromeSpring = (0.25, 0.9)
 
     /// A line typed, a chip attached: the card grows upward and the pane
     /// cedes the row in one motion.
     private func animateTalkbackGrowth() {
-        guard !UIAccessibility.isReduceMotionEnabled,
-              talkbackController != nil,
-              rootView.window != nil
-        else {
-            renderNow()
-            return
-        }
-        UIView.animate(
-            withDuration: 0.25,
-            delay: 0,
-            usingSpringWithDamping: 0.9,
-            initialSpringVelocity: 0
-        ) { [self] in
-            renderNow()
-            rootView.layoutIfNeeded()
-        }
+        animateChromeRender(Self.chromeGrowthSpring)
     }
 
     /// Where the pane's bottom chrome starts: the rail's top edge, lifted

--- a/MultiplexTests/TalkbackComposerUIKitTests.swift
+++ b/MultiplexTests/TalkbackComposerUIKitTests.swift
@@ -1,0 +1,210 @@
+import UIKit
+import XCTest
+@testable import Multiplex
+
+@MainActor
+final class TalkbackComposerUIKitTests: XCTestCase {
+    func testCardBuildsHeaderControlsAndFieldWithIdentifiers() throws {
+        let controller = makeController()
+        controller.setTalkbackOpen(true)
+        let composer = makeComposer(controller: controller, agent: .claudeCode)
+        composer.loadViewIfNeeded()
+
+        let identifiers = descendants(in: composer.view)
+            .compactMap(\.accessibilityIdentifier)
+        for expected in [
+            "terminal.talkback.card",
+            "terminal.talkback.close",
+            "terminal.talkback.attach",
+            "terminal.talkback.field",
+            "terminal.talkback.send",
+        ] {
+            XCTAssertTrue(identifiers.contains(expected), expected)
+        }
+        let header = try XCTUnwrap(descendants(in: composer.view).first {
+            ($0 as? UIStackView)?.accessibilityLabel?.hasPrefix("To ") == true
+        })
+        XCTAssertEqual(header.accessibilityLabel, "To MAIN · DEVBOX Claude Code")
+        let field = try XCTUnwrap(descendants(in: composer.view).first {
+            $0.accessibilityIdentifier == "terminal.talkback.field"
+        } as? UITextView)
+        XCTAssertEqual(field.returnKeyType, .default, "the software Return breaks a line")
+        XCTAssertFalse(descendants(in: composer.view).contains {
+            String(describing: type(of: $0)).contains("Hosting")
+        })
+    }
+
+    func testSendIsDimUntilThereIsAMessageAndTheTabIsLive() throws {
+        let controller = makeController()
+        controller.setTalkbackOpen(true)
+        let composer = makeComposer(controller: controller, agent: nil)
+        composer.loadViewIfNeeded()
+        let send = try XCTUnwrap(descendants(in: composer.view).first {
+            $0.accessibilityIdentifier == "terminal.talkback.send"
+        } as? TalkbackRoundButton)
+        XCTAssertEqual(send.style, .dim)
+        XCTAssertFalse(send.isEnabled)
+
+        enter("hello", into: composer)
+        // The tab was never connected: the draft is ready but the pane can't
+        // take input, so SEND stays dim and sends nothing.
+        XCTAssertEqual(controller.talkback.text, "hello", "the field is the draft's writer")
+        XCTAssertEqual(controller.talkback.sendState, .ready)
+        XCTAssertEqual(controller.talkbackSendState, .disabled)
+        XCTAssertEqual(send.style, .dim)
+        XCTAssertFalse(controller.sendTalkback(submit: true))
+        XCTAssertEqual(controller.talkback.text, "hello", "an unsent draft is kept")
+    }
+
+    func testFieldHeightGrowsPerLineAndCapsAtFiveLines() {
+        let controller = makeController()
+        controller.setTalkbackOpen(true)
+        let composer = makeComposer(controller: controller, agent: nil)
+        composer.loadViewIfNeeded()
+        let empty = composer.fittingContentSize(for: 720).height
+
+        enter("one\ntwo\nthree", into: composer)
+        let three = composer.fittingContentSize(for: 720).height
+        XCTAssertGreaterThan(three, empty)
+
+        enter((1...12).map(String.init).joined(separator: "\n"), into: composer)
+        let twelve = composer.fittingContentSize(for: 720).height
+        XCTAssertGreaterThan(twelve, three)
+
+        enter((1...30).map(String.init).joined(separator: "\n"), into: composer)
+        XCTAssertEqual(
+            composer.fittingContentSize(for: 720).height,
+            twelve,
+            "past five lines the field scrolls inside itself"
+        )
+    }
+
+    func testCompactPreviewsShrinkTheAttachmentRow() {
+        let controller = makeController()
+        controller.setTalkbackOpen(true)
+        let composer = makeComposer(controller: controller, agent: nil, compact: false)
+        composer.loadViewIfNeeded()
+        let bare = composer.fittingContentSize(for: 720).height
+        controller.attachTalkbackFiles([DroppedFile(name: "trace.log", data: Data("x".utf8))])
+        let regular = composer.fittingContentSize(for: 720).height
+        XCTAssertEqual(
+            regular - bare,
+            TalkbackComposerViewController.previewSize + TalkbackComposerViewController.rowSpacing
+        )
+
+        var compact = composer.configuration
+        compact.presentation.compactPreviews = true
+        composer.update(configuration: compact)
+        XCTAssertEqual(
+            composer.fittingContentSize(for: 720).height - bare,
+            TalkbackComposerViewController.compactPreviewSize
+                + TalkbackComposerViewController.rowSpacing
+        )
+        XCTAssertTrue(descendants(in: composer.view).contains {
+            ($0 as? TalkbackAttachmentView)?.compact == true
+        })
+    }
+
+    func testAttachingOnATabThatCannotUploadFailsTheChipInsteadOfDroppingIt() async {
+        let controller = makeController(mode: .shell)
+        controller.setTalkbackOpen(true)
+        controller.attachTalkbackFiles([DroppedFile(name: "a.txt", data: Data("x".utf8))])
+        XCTAssertEqual(controller.talkback.attachments.count, 1)
+        for _ in 0..<50 {
+            if controller.talkback.attachments.first?.isFailed == true { break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(
+            controller.talkback.attachments.first?.state,
+            .failed("File upload requires tmux or herdr over SSH")
+        )
+        XCTAssertEqual(controller.talkback.sendState, .disabled)
+
+        controller.removeTalkbackAttachment(controller.talkback.attachments[0].id)
+        XCTAssertTrue(controller.talkback.attachments.isEmpty)
+    }
+
+    func testTheTalkKeyRequestsFocusOncePerPress() {
+        let controller = makeController()
+        XCTAssertFalse(controller.consumeTalkbackFocusRequest(), "nothing asked yet")
+        controller.setTalkbackOpen(true)
+        XCTAssertTrue(controller.consumeTalkbackFocusRequest())
+        XCTAssertFalse(controller.consumeTalkbackFocusRequest(), "a re-render never re-focuses")
+        controller.setTalkbackOpen(true)
+        XCTAssertTrue(controller.consumeTalkbackFocusRequest(), "a second press asks again")
+        controller.toggleTalkback()
+        XCTAssertFalse(controller.talkbackOpen)
+        XCTAssertFalse(controller.consumeTalkbackFocusRequest(), "closing asks for nothing")
+    }
+
+    func testHardwareReturnSendsAndEscapeHandsBackTheKeyboard() {
+        let field = TalkbackTextView()
+        var sent = 0
+        var escaped = 0
+        field.onSend = { sent += 1 }
+        field.onEscape = { escaped += 1 }
+        let commands = field.keyCommands ?? []
+        let plainReturn = commands.first { $0.input == "\r" && $0.modifierFlags.isEmpty }
+        let commandReturn = commands.first { $0.input == "\r" && $0.modifierFlags == .command }
+        let escape = commands.first { $0.input == UIKeyCommand.inputEscape }
+        XCTAssertNotNil(plainReturn)
+        XCTAssertNotNil(commandReturn)
+        XCTAssertNotNil(escape)
+        XCTAssertNil(
+            commands.first { $0.input == "\r" && $0.modifierFlags == .shift },
+            "Shift+Return is UIKit's own newline"
+        )
+        for command in [plainReturn, commandReturn, escape].compactMap({ $0 }) {
+            _ = field.perform(command.action)
+        }
+        XCTAssertEqual(sent, 2)
+        XCTAssertEqual(escaped, 1)
+    }
+
+    // MARK: Helpers
+
+    private func makeController(mode: TerminalRoute.Mode = .attach(sessionName: "main")) -> TerminalSessionController {
+        let host = Host(name: "devbox", hostname: "127.0.0.1", username: "dev")
+        return TerminalSessionController(
+            route: TerminalRoute(hostID: host.id, mode: mode),
+            host: host
+        )
+    }
+
+    private func makeComposer(
+        controller: TerminalSessionController,
+        agent: AgentKind?,
+        compact: Bool = false
+    ) -> TalkbackComposerViewController {
+        TalkbackComposerViewController(configuration: TalkbackComposerConfiguration(
+            controller: controller,
+            presentation: TalkbackComposerPresentation(
+                targetLabel: "MAIN · DEVBOX",
+                agent: agent,
+                agentState: nil,
+                compactPreviews: compact,
+                floating: false,
+                availableWidth: 720,
+                contentSafeArea: .zero
+            ),
+            close: {},
+            focusTerminal: {}
+        ))
+    }
+
+    /// The field is the draft's writer: typing goes through the text view
+    /// and its delegate, exactly as the keyboard would.
+    private func enter(_ text: String, into composer: TalkbackComposerViewController) {
+        guard let field = descendants(in: composer.view).first(where: {
+            $0.accessibilityIdentifier == "terminal.talkback.field"
+        }) as? UITextView else {
+            return XCTFail("no field")
+        }
+        field.text = text
+        composer.textViewDidChange(field)
+    }
+
+    private func descendants(in root: UIView) -> [UIView] {
+        root.subviews + root.subviews.flatMap(descendants(in:))
+    }
+}

--- a/MultiplexTests/TalkbackTests.swift
+++ b/MultiplexTests/TalkbackTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import Multiplex
+
+final class TalkbackTests: XCTestCase {
+    // MARK: Body sanitizing
+
+    func testSanitizedBodyKeepsLinesTabsAndUnicode() {
+        XCTAssertEqual(
+            TalkbackMessage.sanitizedBody("fix the flaky test\n\tthen rerun · 測試"),
+            "fix the flaky test\n\tthen rerun · 測試"
+        )
+    }
+
+    func testSanitizedBodyNormalizesCarriageReturns() {
+        XCTAssertEqual(TalkbackMessage.sanitizedBody("a\r\nb\rc"), "a\nb\nc")
+        XCTAssertEqual(TalkbackMessage.sanitizedBody("a\r\r\nb"), "a\n\nb")
+    }
+
+    func testSanitizedBodyDropsEveryControlIncludingEscapeAndCtrlB() {
+        // ESC (a CSI could ride it), Ctrl-B (the remote tmux prefix), DEL, and
+        // a C1 CSI introducer are all gone. Only the control bytes go — the
+        // printable tail of a would-be sequence is harmless text.
+        XCTAssertEqual(
+            TalkbackMessage.sanitizedBody("run\u{1B}[2J it \u{02}now\u{7F}\u{9B}!"),
+            "run[2J it now!"
+        )
+    }
+
+    func testSanitizedBodyTrimsTrailingBlankSpaceOnly() {
+        XCTAssertEqual(TalkbackMessage.sanitizedBody("  keep leading\n\n  \t"), "  keep leading")
+        XCTAssertEqual(TalkbackMessage.sanitizedBody("\n\n"), "")
+    }
+
+    // MARK: Payload
+
+    func testPayloadWrapsInBracketedPasteMarkersWhenThePaneHasThemOn() {
+        let payload = TalkbackMessage.payload(body: "hello\nworld", paths: [], bracketed: true)
+        var expected = Data([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E])
+        expected.append(Data("hello\nworld".utf8))
+        expected.append(Data([0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E]))
+        XCTAssertEqual(payload, expected)
+    }
+
+    func testPayloadIsRawTextWithoutBracketedPaste() {
+        XCTAssertEqual(
+            TalkbackMessage.payload(body: "ls -la\n", paths: [], bracketed: false),
+            Data("ls -la".utf8)
+        )
+    }
+
+    func testPayloadTypesLandedPathsFirstQuotedOnlyWhereNeeded() {
+        let payload = TalkbackMessage.payload(
+            body: "look at these",
+            paths: [".multiplex-drops/IMG_4021.jpg", "/home/dev/my report.pdf"],
+            bracketed: false
+        )
+        XCTAssertEqual(
+            String(decoding: payload, as: UTF8.self),
+            ".multiplex-drops/IMG_4021.jpg '/home/dev/my report.pdf' look at these"
+        )
+    }
+
+    func testPayloadWithOnlyPathsKeepsTheTrailingSpaceAndEmptyMessageIsEmpty() {
+        XCTAssertEqual(
+            String(decoding: TalkbackMessage.payload(body: "  ", paths: ["a.txt"], bracketed: false), as: UTF8.self),
+            "a.txt "
+        )
+        XCTAssertTrue(TalkbackMessage.payload(body: " \n", paths: [], bracketed: true).isEmpty)
+    }
+
+    func testSubmitIsASeparateCarriageReturnAfterTheChipsPause() {
+        XCTAssertEqual(TalkbackMessage.submit, Data([0x0D]))
+        XCTAssertEqual(TalkbackMessage.submitDelay, .milliseconds(160))
+    }
+
+    // MARK: Draft
+
+    func testSendStateFollowsEmptinessUploadsAndFailures() {
+        var draft = TalkbackDraft()
+        XCTAssertEqual(draft.sendState, .disabled, "nothing to send")
+        draft.text = "   \n"
+        XCTAssertEqual(draft.sendState, .disabled, "blank text is nothing")
+        draft.text = "hi"
+        XCTAssertEqual(draft.sendState, .ready)
+
+        let photo = TalkbackAttachment(name: "IMG_1.jpg", byteCount: 10, kind: .image)
+        draft.attachments = [photo]
+        XCTAssertEqual(draft.sendState, .waiting, "an upload in flight holds the message")
+
+        draft.update(photo.id) { $0.state = .ready(path: ".multiplex-drops/IMG_1.jpg") }
+        XCTAssertEqual(draft.sendState, .ready)
+        XCTAssertEqual(draft.readyPaths, [".multiplex-drops/IMG_1.jpg"])
+
+        draft.text = ""
+        XCTAssertEqual(draft.sendState, .ready, "a landed attachment alone is a message")
+
+        draft.update(photo.id) { $0.state = .failed("Over 64 MB") }
+        XCTAssertEqual(draft.sendState, .disabled, "a failed chip is never sent half")
+    }
+
+    func testClearAfterSendLeavesAnEmptyBox() {
+        var draft = TalkbackDraft(text: "done", attachments: [
+            TalkbackAttachment(name: "a.txt", byteCount: 1, kind: .file, state: .ready(path: "a.txt")),
+        ], focusRequest: 3)
+        draft.clearAfterSend()
+        XCTAssertTrue(draft.isEmpty)
+        XCTAssertEqual(draft.sendState, .disabled)
+        XCTAssertEqual(draft.focusRequest, 3, "the keyboard request is not part of the message")
+    }
+
+    func testAttachmentKindReadsTheExtension() {
+        XCTAssertEqual(TalkbackAttachment.kind(forName: "photo-20260817.HEIC"), .image)
+        XCTAssertEqual(TalkbackAttachment.kind(forName: "trace.log"), .file)
+        XCTAssertEqual(TalkbackAttachment.kind(forName: "noext"), .file)
+    }
+
+    func testPlaceholderNamesTheAgentWhenThereIsOne() {
+        XCTAssertEqual(TalkbackMessage.placeholder(agentName: "Claude Code"), "Message Claude Code…")
+        XCTAssertEqual(TalkbackMessage.placeholder(agentName: nil), "Message this pane…")
+    }
+}

--- a/MultiplexTests/TerminalGuideTests.swift
+++ b/MultiplexTests/TerminalGuideTests.swift
@@ -4,11 +4,11 @@ import XCTest
 final class TerminalGuideTests: XCTestCase {
     func testDeckIntegrityAndCanonicalFigures() {
         let entries = TerminalGuide.allEntries
-        XCTAssertEqual(entries.count, 15)
+        XCTAssertEqual(entries.count, 16)
 
         let figures = entries.compactMap(\.figure)
-        XCTAssertEqual(figures, Array(1...14))
-        XCTAssertEqual(Set(figures).count, 14)
+        XCTAssertEqual(figures, Array(1...15))
+        XCTAssertEqual(Set(figures).count, 15)
         for entry in entries {
             XCTAssertFalse(entry.title.isEmpty, entry.id)
             XCTAssertFalse(entry.body.isEmpty, entry.id)
@@ -23,7 +23,7 @@ final class TerminalGuideTests: XCTestCase {
         ))
         XCTAssertEqual(entries.map(\.id), [
             "doubletap", "longpress", "rightclick", "pan",
-            "link", "path", "shiftreturn", "shortcutkey", "keycommands",
+            "link", "path", "shiftreturn", "shortcutkey", "keycommands", "talkback",
         ])
     }
 
@@ -55,7 +55,7 @@ final class TerminalGuideTests: XCTestCase {
         ))
         let link = try XCTUnwrap(entries.first { $0.id == "link" })
         XCTAssertEqual(link.figure, 6)
-        XCTAssertEqual(entries.compactMap(\.figure), [1, 2, 3, 4, 6, 7, 10, 11, 12])
+        XCTAssertEqual(entries.compactMap(\.figure), [1, 2, 3, 4, 6, 7, 10, 11, 12, 13])
     }
 
     func testBankOrder() {

--- a/MultiplexTests/TerminalKeyBarUIKitTests.swift
+++ b/MultiplexTests/TerminalKeyBarUIKitTests.swift
@@ -63,8 +63,14 @@ final class TerminalTallyKeyControlTests: XCTestCase {
 final class TerminalKeyBarUIKitTests: XCTestCase {
     func testWidthLadderPreservesEveryDocumentedFloor() {
         XCTAssertEqual(specification(width: 1024, returns: true).tier, .full)
+        // The talk key (RET · talk · keyboard) costs a 768 pt window its page
+        // keys — the ladder's first sacrifice — and nothing below.
         XCTAssertEqual(
             specification(width: 768, returns: true).tier,
+            .twoSymbols
+        )
+        XCTAssertEqual(
+            specification(width: 820, returns: true).tier,
             .twoSymbolsAndPages
         )
         XCTAssertEqual(
@@ -164,6 +170,18 @@ final class TerminalKeyBarUIKitTests: XCTestCase {
                 "terminal.keybar.tab",
             ]
         )
+        // Talkback sits between RET and the keyboard / mic slot on every tier.
+        let identifiers = bar.renderedKeys.compactMap(\.accessibilityIdentifier)
+        let talk = try XCTUnwrap(identifiers.firstIndex(of: "terminal.keybar.talkback"))
+        XCTAssertEqual(identifiers[talk - 1], "terminal.keybar.return")
+        XCTAssertTrue(
+            ["terminal.keybar.keyboard", "terminal.keybar.dictation"]
+                .contains(identifiers[talk + 1])
+        )
+        XCTAssertEqual(
+            bar.renderedKeys[talk].accessibilityLabel,
+            "Open the message box"
+        )
         XCTAssertEqual(
             bar.renderedKeys.first {
                 $0.accessibilityIdentifier == "terminal.keybar.control"
@@ -215,18 +233,21 @@ final class TerminalKeyClusterUIKitTests: XCTestCase {
         )
 
         XCTAssertEqual(leading.intrinsicContentSize, CGSize(width: 174, height: 44))
-        XCTAssertEqual(trailing.intrinsicContentSize, CGSize(width: 342, height: 44))
+        // arrows · RET · talk · keyboard: seven faces, three tail gaps.
+        XCTAssertEqual(trailing.intrinsicContentSize, CGSize(width: 400, height: 44))
         XCTAssertEqual(
             standalone.fittingSize(maximumWidth: 600),
-            CGSize(width: 504, height: 44)
+            CGSize(width: 562, height: 44)
         )
+        // 420 no longer holds the compact run with its arrows (436): the
+        // standalone slab drops to its minimal tier there.
         XCTAssertEqual(
             standalone.fittingSize(maximumWidth: 420),
-            CGSize(width: 392, height: 44)
+            CGSize(width: 272, height: 44)
         )
         XCTAssertEqual(
             standalone.fittingSize(maximumWidth: 375),
-            CGSize(width: 228, height: 44)
+            CGSize(width: 272, height: 44)
         )
     }
 
@@ -259,11 +280,12 @@ final class TerminalKeyClusterUIKitTests: XCTestCase {
                 "terminal.keyCluster.down",
                 "terminal.keyCluster.right",
                 "terminal.keyCluster.return",
+                "terminal.keyCluster.talkback",
                 "terminal.keyCluster.keyboard",
             ]
         )
         XCTAssertTrue(trailing.keys.prefix(4).allSatisfy(\.repeats))
-        XCTAssertFalse(trailing.keys.suffix(2).contains(where: \.repeats))
+        XCTAssertFalse(trailing.keys.suffix(3).contains(where: \.repeats))
         XCTAssertEqual(leading.layer.cornerRadius, 12)
         XCTAssertEqual(leading.layer.borderWidth, 1)
         XCTAssertFalse((leading.subviews + trailing.subviews).contains {

--- a/MultiplexTests/TerminalWindowUIKitTests.swift
+++ b/MultiplexTests/TerminalWindowUIKitTests.swift
@@ -888,6 +888,47 @@ final class TerminalWindowUIKitTests: XCTestCase {
     }
     #endif
 
+    #if !os(visionOS)
+    func testLockingTheKeyboardClosesEveryTalkbackBoxInTheWindow() async throws {
+        let host = Host(name: "devbox", hostname: "127.0.0.1", username: "dev")
+        let first = TerminalRoute(hostID: host.id, mode: .attach(sessionName: "main"))
+        let second = TerminalRoute(hostID: host.id, mode: .attach(sessionName: "agent"))
+        let fixture = makeFixture(
+            route: TerminalWindowRoute(tabs: [first, second], activeTabID: first.id),
+            hosts: [host]
+        )
+        fixture.controller.loadViewIfNeeded()
+        let active = try XCTUnwrap(fixture.workspace.controller(for: first.id))
+        let other = try XCTUnwrap(fixture.workspace.controller(for: second.id))
+        active.setTalkbackOpen(true)
+        other.setTalkbackOpen(true)
+        for _ in 0..<8 { await Task.yield() }
+        XCTAssertNotNil(
+            view("terminal.talkback.card", in: fixture.controller.view),
+            "the active tab's open box mounts its card"
+        )
+
+        // The lock is app-wide state only the arbiter writes; a scratch
+        // terminal engages it and the defer releases it for the next test.
+        let terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 300, height: 200))
+        TerminalFocusArbiter.lock(terminal)
+        defer { TerminalFocusArbiter.unlock(terminal, summoning: false) }
+        for _ in 0..<8 { await Task.yield() }
+
+        XCTAssertFalse(active.talkbackOpen, "locking closes the active tab's box")
+        XCTAssertFalse(other.talkbackOpen, "and every other tab's in this window")
+        XCTAssertNil(view("terminal.talkback.card", in: fixture.controller.view))
+
+        // Opening again while still locked is allowed — the talk key
+        // releases the lock first — and the box mounts once more.
+        TerminalFocusArbiter.unlock(terminal, summoning: false)
+        active.setTalkbackOpen(true)
+        for _ in 0..<8 { await Task.yield() }
+        XCTAssertTrue(active.talkbackOpen)
+        XCTAssertNotNil(view("terminal.talkback.card", in: fixture.controller.view))
+    }
+    #endif
+
     private struct Fixture {
         let controller: TerminalWindowViewController
         let workspace: TerminalWorkspace

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -80,6 +80,13 @@ UIKit scene runtime (MultiplexSceneDelegate + UIKitSceneRootViewController;
                      Document owns the PDF / audio clip, so a moved tab
                      keeps page and position
   TerminalSessionController  one per tab; input pump + TerminalView
+    TalkbackDraft        the tab's chat-style message box (text +
+                         attachments; pure) beside its observed talkbackOpen
+                         — sendTalkback = one paste + CR through the pump,
+                         attachTalkbackFiles = the drop path's one upload
+                         primitive, held until SEND; rendered by
+                         TalkbackComposerViewController (window-docked on
+                         iPad/iPhone, an ornament slab on visionOS)
     TerminalTransport    the tab's byte pipe; picked by host.useMosh
                          (exec + SFTP stay SSH-only capabilities)
     SessionResumePolicy  pure: suspension damage vs user-ended session

--- a/docs/agents/e2e-headless.md
+++ b/docs/agents/e2e-headless.md
@@ -191,6 +191,12 @@ app.multiplexterm.multiplex.<name>`:
 - `debug.tmuxshortcuts` / `debug.customcommands` / `debug.msghistory` — open
   the focused tab's shortcut popover (TMUX content, or HRDR on a herdr
   tab) / Command Setup editor / agent HISTORY panel for layout capture.
+- `debug.talkback` / `debug.talkbacktype` / `debug.talkbackattach` /
+  `debug.talkbacksend` — toggle the focused terminal's Talkback message box
+  (the talk key), put a two-line sample in its field, attach a sample photo +
+  text file through the real upload queue, press ↑. Proof: `tmux
+  capture-pane -t agent:0 -p` shows the paths and both lines land as one
+  paste + CR; the uploads sit in the pane cwd's `.multiplex-drops/`.
 - `debug.keycommands` / `debug.keycommandsetup` / `debug.keycommandcompose` —
   the hold-CTRL KEY COMMANDS popover (iPad rail or visionOS cluster) on its
   COMMANDS grid / CUSTOM SETUP list / with a fresh row's composer expanded.

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -469,6 +469,76 @@ routing, tab moves, keyboard avoidance, or secret fields.
   only host a system `SecureField`) empties its field in every button
   action. Don't regress any of these.
 
+- **Talkback — the chat-style message box under a pane — is per-tab state
+  rendered by one composer per window** (`TalkbackDraft` /
+  `TalkbackMessage` pure + tested in `Models/Talkback.swift`;
+  `TerminalSessionController.talkbackOpen` (what the window / rail / cluster
+  observe — it flips on the talk key) beside `.talkback` (the draft only the
+  composer observes, WITHOUT its text: the field is the text's writer, so a
+  keystroke re-renders nothing), `attachTalkbackFiles` / `sendTalkback`;
+  `TalkbackComposerViewController` in `Views/Terminal/TalkbackComposer.swift`
+  gates its render on an Equatable key — presentation + controller identity +
+  observed state — and measures the field once per (text, width); decided B
+  "MESSAGE CARD" in `local-plan/talkback-bakeoff/`, 2026-08-17). The talk key is `RET · talk ·
+  keyboard` on the iPad/iPhone rail and the same slot in the visionOS
+  cluster, latched while the box is open; **the phone rail tiers run 36 pt
+  faces** since it joined (40 pt overflowed every phone cutoff), which is
+  what keeps `SingleWindowShellLayout`'s 390 / 420 cutoffs and the 375
+  locked floor unchanged — and costs a 768 pt iPad its page keys (the ladder
+  drops them first). Docking: iPad/iPhone mount it in the window's
+  `talkbackContainer` above the rail (lifted with the rail over a docked
+  keyboard) and the pane insets by its measured height
+  (`terminalBottomChromeHeight`, arithmetic in
+  `fittingContentSize(for:)` — read BEFORE the panes are configured, so
+  `renderTalkback()` runs first in `renderNow()`); visionOS mounts it as its
+  own content-sized slab BELOW the console row (`TerminalVisionConsoleGeometry
+  .talkbackSize`, width `min(620, TerminalVisionOrnamentPresentation
+  .consoleClamp)`, never in-window; growth reaches the ornament through the
+  window's render → `revision`, no mirrored size — proven rendering below the
+  anchor at one, two and three-row heights, sim 2026-08-17). Opening
+  folds the helper strip to its dot (deferred a turn — the collapse posts
+  app-wide and runs inside a render); closing unfolds only what this window
+  folded. **Focus split**: the field is a native `UITextView` (system
+  autocorrect / IME / the keyboard's own mic; hardware ↩ = SEND, ⇧↩ newline,
+  ⌘↩ SEND, Escape hands the keyboard back — `UIKeyCommand`s on the field);
+  the arbiter still counts the TERMINAL as owner (the composer never claims),
+  so a pane tap `claim`s it back and the card dims to 0.72; a keypress-scoped
+  `focusRequest` counter (consumed once per press) is what focuses the field
+  — a tab switch back to an open box never steals the keyboard; on close a
+  field that held the keyboard `resumeAfterPresentation`s the terminal.
+  **Bytes**: SEND = ONE paste — landed attachment paths first (the FILE drop
+  path's `DropText.typedPaths`, quoted only where needed) then the sanitized
+  body (CR/CRLF → LF, every other C0/C1/DEL dropped, trailing blank trimmed),
+  bracketed with `ESC[200~ … ESC[201~` only when the pane has mode 2004 on,
+  through `TerminalView.send` (the typing-quiet stamp) — then a CR as its own
+  write ~160 ms later (the slash chips' Codex-safe shape); long-press SEND
+  omits the CR. Attachments upload ON PICK through the ONE upload primitive
+  the pane's drop path also uses (`uploadForTypedPaths` — destination,
+  sanitized names, the 64 MB cap, typed paths back; `canUploadFiles` +
+  `uploadUnavailableMessage` are the shared eligibility rule) on a serial
+  per-tab queue; the composer owns FILE's base picker presenter
+  (`FileAttachPickerPresenterViewController.makeSourceMenu` + `.deliver`
+  reroutes the pickers into the SNAPSHOTTED target's draft; mosh / `.shell`
+  tabs fail the chip with the drop path's message); SEND waits on uploads
+  (dashed ↑) and refuses a failed chip (tap retries, ✕ removes). Phone
+  previews are 28 pt thumbs + compact document chips (Jhen), 46 pt squares
+  elsewhere; photo thumbnails are ImageIO thumbnails made off-main
+  (`Services/TalkbackThumbnail.swift` — never the full bitmap). ⚠ Not verified headlessly: the docked
+  software keyboard under the card (the sim reports a hardware keyboard) —
+  it rides the same `keyboardObstruction` the helper strip does; and
+  `restoreActiveTerminalFocusIfOwner` on scene activation re-claims the
+  terminal, so a foregrounded app hands the keyboard back to the pane.
+  **Locking the keyboard closes every box in the window, and a box opened
+  while locked releases the lock first** — both halves live in
+  `renderTalkback` (the lock's false→true transition closes; the composer's
+  creation under a lock calls `TerminalFocusArbiter.unlock(_, summoning:
+  false)`, the deferred terminal claim would race the field's focus), so
+  every opener — key, cluster, hook, whatever comes next — inherits the rule;
+  the rail key is a plain `toggleTalkback()`. Pinned by
+  `testLockingTheKeyboardClosesEveryTalkbackBoxInTheWindow`.
+  Hooks: `debug.talkback` (toggle) / `talkbacktype` / `talkbackattach` /
+  `talkbacksend` — proof is `tmux capture-pane` on the harness `agent:0`.
+
 ## Known limit: held-backspace input filler
 
 - **Held-backspace auto-repeat rides an input filler and is NOT verified**

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -508,6 +508,12 @@ routing, tab moves, keyboard avoidance, or secret fields.
   stand-in while `renderNow` unmounts and the pane reclaims; growth (a line,
   a chip) is a 0.25 s spring around `renderNow`. The transition is decided in
   `observeAndRender` from `talkbackOpen` vs `talkbackController != nil`.
+  ⚠ Because that render runs inside an animation block, `TerminalKeyBar
+  .layoutSubviews` wraps its own key layout in `performWithoutAnimation`
+  (a row rebuilt in that pass flew every key in from a zero frame —
+  shipped-and-caught 2026-08-17), and the talk latch is NOT part of the
+  rail's rebuild signature — it flips in place like CTRL's, so opening the
+  box never re-creates the keys under the finger.
   **Focus split**: the field is a native `UITextView` (system
   autocorrect / IME / the keyboard's own mic; hardware ↩ = SEND, ⇧↩ newline,
   ⌘↩ SEND, Escape hands the keyboard back — `UIKeyCommand`s on the field);

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -498,7 +498,17 @@ routing, tab moves, keyboard avoidance, or secret fields.
   anchor at one, two and three-row heights, sim 2026-08-17). Opening
   folds the helper strip to its dot (deferred a turn — the collapse posts
   app-wide and runs inside a render); closing unfolds only what this window
-  folded. **Focus split**: the field is a native `UITextView` (system
+  folded. **iPad/iPhone motion** (`animateTalkbackTransition`, the helper
+  strip's 0.35 s / 0.85 spring; Reduce Motion cuts to the result): opening
+  mounts unanimated, parks the band at its final frame with the card pushed
+  BELOW it (the band clips, so the card rises out from behind the rail's edge
+  and never crosses the keys) and runs `renderNow` inside the spring — the
+  surface lays its inset constraint out inside the block, so the pane cedes
+  its rows in the same motion; closing sinks a snapshot inside a clipping
+  stand-in while `renderNow` unmounts and the pane reclaims; growth (a line,
+  a chip) is a 0.25 s spring around `renderNow`. The transition is decided in
+  `observeAndRender` from `talkbackOpen` vs `talkbackController != nil`.
+  **Focus split**: the field is a native `UITextView` (system
   autocorrect / IME / the keyboard's own mic; hardware ↩ = SEND, ⇧↩ newline,
   ⌘↩ SEND, Escape hands the keyboard back — `UIKeyCommand`s on the field);
   the arbiter still counts the TERMINAL as owner (the composer never claims):

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -501,8 +501,16 @@ routing, tab moves, keyboard avoidance, or secret fields.
   folded. **Focus split**: the field is a native `UITextView` (system
   autocorrect / IME / the keyboard's own mic; hardware ↩ = SEND, ⇧↩ newline,
   ⌘↩ SEND, Escape hands the keyboard back — `UIKeyCommand`s on the field);
-  the arbiter still counts the TERMINAL as owner (the composer never claims),
-  so a pane tap `claim`s it back and the card dims to 0.72; a keypress-scoped
+  the arbiter still counts the TERMINAL as owner (the composer never claims):
+  on begin-editing the field `suspendForPresentation`s the terminal and
+  makes its OWN window key — ⚠ on visionOS the card lives in the ornament's
+  window and UIKit resigns responders only within one window, so without
+  this the terminal stayed first responder in the scene's key window and
+  every keystroke went to the pane (shipped-and-caught 2026-08-17; proof is
+  the `kbd` log line `talkback field focused key=true terminalResponder=
+  false`); the terminal's window becoming key again (a pane tap, Escape, a
+  scene activation) resigns the field through a `didBecomeKeyNotification`
+  observer scoped to ANOTHER window, so the card dims to 0.72; a keypress-scoped
   `focusRequest` counter (consumed once per press) is what focuses the field
   — a tab switch back to an open box never steals the keyboard; on close a
   field that held the keyboard `resumeAfterPresentation`s the terminal.

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -134,7 +134,7 @@ routing, tab moves, keyboard avoidance, or secret fields.
   sheet presents (`presentPaywall` refuses while anything is presented).
   `entitlements.isPro` is in the window's observation set, so a purchase
   re-renders with the lifted plan. The terminal
-  GUIDE carries a HOLD CTRL card (figure 12). Focus: the
+  GUIDE carries a HOLD CTRL card (figure 12) and a MESSAGE BOX card (figure 13). Focus: the
   panel never suspends the terminal; only if one of its own fields took the
   keyboard does dismissal `resumeAfterPresentation`. Design record + grill:
   `local-plan/key-commands-bakeoff/`. visionOS: `TerminalKeyCluster`

--- a/docs/agents/input-and-windows.md
+++ b/docs/agents/input-and-windows.md
@@ -470,98 +470,57 @@ routing, tab moves, keyboard avoidance, or secret fields.
   action. Don't regress any of these.
 
 - **Talkback — the chat-style message box under a pane — is per-tab state
-  rendered by one composer per window** (`TalkbackDraft` /
-  `TalkbackMessage` pure + tested in `Models/Talkback.swift`;
-  `TerminalSessionController.talkbackOpen` (what the window / rail / cluster
-  observe — it flips on the talk key) beside `.talkback` (the draft only the
-  composer observes, WITHOUT its text: the field is the text's writer, so a
-  keystroke re-renders nothing), `attachTalkbackFiles` / `sendTalkback`;
-  `TalkbackComposerViewController` in `Views/Terminal/TalkbackComposer.swift`
-  gates its render on an Equatable key — presentation + controller identity +
-  observed state — and measures the field once per (text, width); decided B
-  "MESSAGE CARD" in `local-plan/talkback-bakeoff/`, 2026-08-17). The talk key is `RET · talk ·
-  keyboard` on the iPad/iPhone rail and the same slot in the visionOS
-  cluster, latched while the box is open; **the phone rail tiers run 36 pt
-  faces** since it joined (40 pt overflowed every phone cutoff), which is
-  what keeps `SingleWindowShellLayout`'s 390 / 420 cutoffs and the 375
-  locked floor unchanged — and costs a 768 pt iPad its page keys (the ladder
-  drops them first). Docking: iPad/iPhone mount it in the window's
-  `talkbackContainer` above the rail (lifted with the rail over a docked
-  keyboard) and the pane insets by its measured height
-  (`terminalBottomChromeHeight`, arithmetic in
-  `fittingContentSize(for:)` — read BEFORE the panes are configured, so
-  `renderTalkback()` runs first in `renderNow()`); visionOS mounts it as its
-  own content-sized slab BELOW the console row (`TerminalVisionConsoleGeometry
-  .talkbackSize`, width `min(620, TerminalVisionOrnamentPresentation
-  .consoleClamp)`, never in-window; growth reaches the ornament through the
-  window's render → `revision`, no mirrored size — proven rendering below the
-  anchor at one, two and three-row heights, sim 2026-08-17). Opening
-  folds the helper strip to its dot (deferred a turn — the collapse posts
-  app-wide and runs inside a render); closing unfolds only what this window
-  folded. **iPad/iPhone motion** (`animateTalkbackTransition`, the helper
-  strip's 0.35 s / 0.85 spring; Reduce Motion cuts to the result): opening
-  mounts unanimated, parks the band at its final frame with the card pushed
-  BELOW it (the band clips, so the card rises out from behind the rail's edge
-  and never crosses the keys) and runs `renderNow` inside the spring — the
-  surface lays its inset constraint out inside the block, so the pane cedes
-  its rows in the same motion; closing sinks a snapshot inside a clipping
-  stand-in while `renderNow` unmounts and the pane reclaims; growth (a line,
-  a chip) is a 0.25 s spring around `renderNow`. The transition is decided in
-  `observeAndRender` from `talkbackOpen` vs `talkbackController != nil`.
-  ⚠ Because that render runs inside an animation block, `TerminalKeyBar
-  .layoutSubviews` wraps its own key layout in `performWithoutAnimation`
-  (a row rebuilt in that pass flew every key in from a zero frame —
-  shipped-and-caught 2026-08-17), and the talk latch is NOT part of the
-  rail's rebuild signature — it flips in place like CTRL's, so opening the
-  box never re-creates the keys under the finger.
-  **Focus split**: the field is a native `UITextView` (system
-  autocorrect / IME / the keyboard's own mic; hardware ↩ = SEND, ⇧↩ newline,
-  ⌘↩ SEND, Escape hands the keyboard back — `UIKeyCommand`s on the field);
-  the arbiter still counts the TERMINAL as owner (the composer never claims):
-  on begin-editing the field `suspendForPresentation`s the terminal and
-  makes its OWN window key — ⚠ on visionOS the card lives in the ornament's
-  window and UIKit resigns responders only within one window, so without
-  this the terminal stayed first responder in the scene's key window and
-  every keystroke went to the pane (shipped-and-caught 2026-08-17; proof is
-  the `kbd` log line `talkback field focused key=true terminalResponder=
-  false`); the terminal's window becoming key again (a pane tap, Escape, a
-  scene activation) resigns the field through a `didBecomeKeyNotification`
-  observer scoped to ANOTHER window, so the card dims to 0.72; a keypress-scoped
-  `focusRequest` counter (consumed once per press) is what focuses the field
-  — a tab switch back to an open box never steals the keyboard; on close a
-  field that held the keyboard `resumeAfterPresentation`s the terminal.
-  **Bytes**: SEND = ONE paste — landed attachment paths first (the FILE drop
-  path's `DropText.typedPaths`, quoted only where needed) then the sanitized
-  body (CR/CRLF → LF, every other C0/C1/DEL dropped, trailing blank trimmed),
-  bracketed with `ESC[200~ … ESC[201~` only when the pane has mode 2004 on,
-  through `TerminalView.send` (the typing-quiet stamp) — then a CR as its own
-  write ~160 ms later (the slash chips' Codex-safe shape); long-press SEND
-  omits the CR. Attachments upload ON PICK through the ONE upload primitive
-  the pane's drop path also uses (`uploadForTypedPaths` — destination,
-  sanitized names, the 64 MB cap, typed paths back; `canUploadFiles` +
-  `uploadUnavailableMessage` are the shared eligibility rule) on a serial
-  per-tab queue; the composer owns FILE's base picker presenter
-  (`FileAttachPickerPresenterViewController.makeSourceMenu` + `.deliver`
-  reroutes the pickers into the SNAPSHOTTED target's draft; mosh / `.shell`
-  tabs fail the chip with the drop path's message); SEND waits on uploads
-  (dashed ↑) and refuses a failed chip (tap retries, ✕ removes). Phone
-  previews are 28 pt thumbs + compact document chips (Jhen), 46 pt squares
-  elsewhere; photo thumbnails are ImageIO thumbnails made off-main
-  (`Services/TalkbackThumbnail.swift` — never the full bitmap). ⚠ Not verified headlessly: the docked
-  software keyboard under the card (the sim reports a hardware keyboard) —
-  it rides the same `keyboardObstruction` the helper strip does; and
-  `restoreActiveTerminalFocusIfOwner` on scene activation re-claims the
-  terminal, so a foregrounded app hands the keyboard back to the pane.
-  **Locking the keyboard closes every box in the window, and a box opened
-  while locked releases the lock first** — both halves live in
-  `renderTalkback` (the lock's false→true transition closes; the composer's
-  creation under a lock calls `TerminalFocusArbiter.unlock(_, summoning:
-  false)`, the deferred terminal claim would race the field's focus), so
-  every opener — key, cluster, hook, whatever comes next — inherits the rule;
-  the rail key is a plain `toggleTalkback()`. Pinned by
-  `testLockingTheKeyboardClosesEveryTalkbackBoxInTheWindow`.
-  Hooks: `debug.talkback` (toggle) / `talkbacktype` / `talkbackattach` /
-  `talkbacksend` — proof is `tmux capture-pane` on the harness `agent:0`.
+  rendered by one composer per window** (`Models/Talkback.swift` pure +
+  tested; `TerminalSessionController.talkbackOpen` is what the window / rail
+  / cluster observe, the draft is observed by the composer alone and WITHOUT
+  its text — the field is the text's writer, so a keystroke re-renders
+  nothing; `Views/Terminal/TalkbackComposer.swift`; decided B "MESSAGE CARD",
+  `local-plan/talkback-bakeoff/`, 2026-08-17). The talk key sits at
+  `RET · talk · keyboard` on the rail and in the visionOS cluster, latched
+  while open; **the phone rail runs 36 pt faces** since it joined (40 pt
+  overflowed every phone cutoff — the 390 / 420 / 375 rules are unchanged;
+  a 768 pt iPad pays with its page keys). Docking: iPad/iPhone mount it in
+  the window's `talkbackContainer` above the rail and the pane insets by
+  its measured height — `renderTalkback()` runs FIRST in `renderNow()`
+  because `terminalBottomChromeHeight` is read before the panes are
+  configured; visionOS mounts it as its own slab BELOW the console row
+  (`TerminalVisionConsoleGeometry.talkbackSize`, never in-window; growth
+  reaches the ornament through the window's render → `revision`). Opening
+  folds the helper strip (deferred a turn — the collapse posts app-wide and
+  runs inside a render); closing unfolds only what this window folded.
+  iPad/iPhone motion (`animateTalkbackTransition`, the strip's spring):
+  opening mounts unanimated and runs `renderNow` inside the spring — the
+  card rises from behind the rail band and the pane cedes its rows in the
+  same motion. ⚠ That render lands inside an animation block, so
+  `TerminalKeyBar.layoutSubviews` wraps its key layout in
+  `performWithoutAnimation` and the talk latch is NOT part of the rail's
+  rebuild signature (a rebuilt row flew every key in from a zero frame —
+  shipped-and-caught 2026-08-17). **Focus**: the field is a native
+  `UITextView` (hardware ↩ = SEND, ⇧↩ newline, ⌘↩ SEND, Escape hands the
+  keyboard back); the arbiter still counts the TERMINAL as owner — on
+  begin-editing `TerminalFocusArbiter.lend` steps the terminal down, keys
+  the field's window and remembers the field as the keyboard's BORROWER,
+  which the next `claim` of any terminal (a pane tap, Escape, a scene
+  activation) resigns. ⚠ visionOS: the card lives in the ornament's window
+  and UIKit resigns responders only within one window — without the lend
+  the terminal stayed first responder and every keystroke went to the pane
+  (shipped-and-caught 2026-08-17; proof is the `kbd` log line `talkback
+  field focused key=true terminalResponder=false`). A per-press
+  `focusRequest` counter is what focuses the field, so a tab switch back to
+  an open box never steals the keyboard.
+  **Bytes**: SEND = ONE paste (landed attachment paths via
+  `DropText.typedPaths`, then the sanitized body — `ComposedText`, bracketed
+  only when the pane has mode 2004 on) through `TerminalView.send`, then a
+  CR as its own write ~160 ms later (the slash chips' Codex-safe shape;
+  long-press SEND omits it). Attachments upload ON PICK through the drop
+  path's one primitive (`uploadForTypedPaths`; `canUploadFiles` is the shared
+  eligibility rule — mosh / `.shell` tabs fail the chip); SEND waits on
+  uploads and refuses a failed chip. **Locking the keyboard closes every box
+  in the window, and a box opened while locked releases the lock first** —
+  both halves live in `renderTalkback`, so every opener inherits the rule
+  (`testLockingTheKeyboardClosesEveryTalkbackBoxInTheWindow`). ⚠ Not
+  verified headlessly: the docked software keyboard under the card (the sim
+  reports a hardware keyboard). Hooks: `docs/agents/e2e-headless.md`.
 
 ## Known limit: held-backspace input filler
 

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -12,7 +12,7 @@ NEW SINCE 1.3.1
 • CONNECTION STATS — a live latency chip on every host rail (free), and a Pro board with per-host drill-in: round-trips, typing echo, mosh loss and roams, reconnects, and data volume. Off switch in Settings.
 • GROK BUILD JOINS the agent roster — detected in panes, its own chip strip, NEW SESSION launch with model and first prompt, and Pro alerts when it needs permission or an answer.
 • WIDGETS SHOW THE SESSION YOU LAST OPENED on each host (herdr included) — or the one you pick in the widget's Session setting.
-• MESSAGE BOX — a chat-style field under the terminal (the speech-bubble key on the key rail / visionOS key cluster). Write with autocorrect and your keyboard's dictation, attach photos or files (uploaded to the pane's folder, paths typed first), then send: the whole message pastes in and submits. The rail keeps driving the pane while you write; hardware Return sends, Shift+Return breaks a line.
+• MESSAGE BOX — a chat-style field under the terminal (the speech-bubble key on the key rail / visionOS key cluster). Write with autocorrect and your keyboard's dictation, attach photos or files (uploaded to the pane's folder, paths typed first), then send: the whole message pastes in and submits. The rail keeps driving the pane while you write; hardware Return sends, Shift+Return breaks a line. The terminal GUIDE gains a MESSAGE BOX card.
 
 PLEASE TRY
 1. Hop through windows from the TMUX panel — it should stay up, with ACTIVE following.

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -12,6 +12,7 @@ NEW SINCE 1.3.1
 • CONNECTION STATS — a live latency chip on every host rail (free), and a Pro board with per-host drill-in: round-trips, typing echo, mosh loss and roams, reconnects, and data volume. Off switch in Settings.
 • GROK BUILD JOINS the agent roster — detected in panes, its own chip strip, NEW SESSION launch with model and first prompt, and Pro alerts when it needs permission or an answer.
 • WIDGETS SHOW THE SESSION YOU LAST OPENED on each host (herdr included) — or the one you pick in the widget's Session setting.
+• MESSAGE BOX — a chat-style field under the terminal (the speech-bubble key on the key rail / visionOS key cluster). Write with autocorrect and your keyboard's dictation, attach photos or files (uploaded to the pane's folder, paths typed first), then send: the whole message pastes in and submits. The rail keeps driving the pane while you write; hardware Return sends, Shift+Return breaks a line.
 
 PLEASE TRY
 1. Hop through windows from the TMUX panel — it should stay up, with ACTIVE following.
@@ -22,5 +23,6 @@ PLEASE TRY
 6. Open STATS on the deck, expand a host, and type in a session — the ECHO number should follow your keystrokes.
 7. Run `grok` in a pane: the tile should read GROK and the strip should show Grok's chips (MODE cycles Normal → Plan → Always-approve). Let it ask for permission while you look elsewhere — a banner should arrive.
 8. Open a herdr session from the deck, then check the Host widget — its tile should switch to that session. Pick another in the widget's Session setting and confirm the tile and shell tap follow.
+9. In a Claude Code session tap the speech-bubble key, attach a photo, write two lines and send — the paths and both lines should land as one prompt; the box should stay open and empty. Tap the pane and the arrows should still move the agent's picker.
 
 Feedback: screenshot in TestFlight

--- a/fastlane/testflight-whats-new.txt
+++ b/fastlane/testflight-whats-new.txt
@@ -12,7 +12,7 @@ NEW SINCE 1.3.1
 • CONNECTION STATS — a live latency chip on every host rail (free), and a Pro board with per-host drill-in: round-trips, typing echo, mosh loss and roams, reconnects, and data volume. Off switch in Settings.
 • GROK BUILD JOINS the agent roster — detected in panes, its own chip strip, NEW SESSION launch with model and first prompt, and Pro alerts when it needs permission or an answer.
 • WIDGETS SHOW THE SESSION YOU LAST OPENED on each host (herdr included) — or the one you pick in the widget's Session setting.
-• MESSAGE BOX — a chat-style field under the terminal (the speech-bubble key on the key rail / visionOS key cluster). Write with autocorrect and your keyboard's dictation, attach photos or files (uploaded to the pane's folder, paths typed first), then send: the whole message pastes in and submits. The rail keeps driving the pane while you write; hardware Return sends, Shift+Return breaks a line. The terminal GUIDE gains a MESSAGE BOX card.
+• MESSAGE BOX — the speech-bubble key on the key rail opens a chat-style field under the terminal: write with autocorrect and your keyboard's dictation, attach photos or files (uploaded to the pane's folder), then send it all as one message. The rail keeps driving the pane while you write; the GUIDE gains a MESSAGE BOX card.
 
 PLEASE TRY
 1. Hop through windows from the TMUX panel — it should stay up, with ACTIVE following.


### PR DESCRIPTION
## What

**Talkback** — a chat-style message box under the terminal pane. A speech-bubble key on the key rail (`RET · talk · keyboard`; the same slot in the visionOS key cluster) opens a rounded card:

- an eyebrow naming the target (`TO MAIN · DEVBOX · ✳ Claude Code`, RUNNING as grey telemetry, NEEDS YOU as the amber lamp) with an ✕;
- a round paperclip → FILE's own Camera / Photos / Files pickers, **uploaded on pick** over the tab's SFTP into the pane's cwd (the drop path — git worktrees corral into `.multiplex-drops/`), shown as 46 pt previews (28 pt thumbs + compact document chips on iPhone) with a progress ring, ✓, or an amber FAILED (tap retries, ✕ removes);
- a native `UITextView` — system autocorrect, IME, the keyboard's own dictation — growing to five lines;
- a filled **↑** that sends the whole message as **one paste** (landed paths first, quoted only where a shell would need it, then the body; wrapped in `ESC[200~ … ESC[201~` when the pane has bracketed paste on) and a CR as its own write ~160 ms later — the slash chips' Codex-safe shape. Long-press ↑ types without submitting. Dashed while an upload is in flight; a failed chip is never sent half.

The box **stays open and clears** after SEND; open state and draft follow the tab across window/tab switches and die with it. The rail / cluster keys keep driving the **pane** while you write (arrows walk an agent's picker, ESC still interrupts); software Return breaks a line, hardware Return sends, ⇧Return breaks a line, ⌘Return sends, Escape hands the keyboard back. Tapping the pane moves keyboard focus back without closing (the card dims); the talk key or ✕ closes; **locking the keyboard closes every box in the window**, and a box opened while locked releases the lock first.

Geometry: docked between the pane and the key rail on iPad/iPhone (the pane insets by the card's height; the helper strip folds to its dot while composing and unfolds on close), its **own content-sized slab below the console row** on visionOS. The phone rail tiers drop faces 40 → 36 pt so the talk key fits every tier with the 390 / 420 / 375 cutoffs unchanged (a 768 pt iPad loses its page keys — the ladder's first sacrifice). Free.

Bake-off (three candidates, twelve-question grill, decision: B "MESSAGE CARD" with compact phone previews) is recorded in `local-plan/talkback-bakeoff/`.

## How

- **Model** — `Models/Talkback.swift`: `TalkbackDraft` (text · attachments · per-press focus request), `TalkbackAttachment` (uploading / ready / failed, image vs file, thumbnail bytes), `TalkbackMessage` (payload builder; sanitizer via the new `ComposedText.lineNormalized`, which `CustomAgentCommand` now shares; `AgentCommand.submitDelay` is the one 160 ms for slash chips, Key Commands and SEND).
- **Service** — `TerminalSessionController`: `talkbackOpen` (what the window / rail / cluster observe) beside `talkback` (the draft only the composer observes — and never its text, so a keystroke re-renders nothing); `attachTalkbackFiles` on a serial per-tab queue through the drop path's new single upload primitive (`uploadForTypedPaths`, `canUploadFiles`, one eligibility message), `sendTalkback` through `TerminalView.send`; `Services/TalkbackThumbnail` makes ImageIO thumbnails off-main. `FileAttachPickerPresenterViewController` gains `makeSourceMenu` / `update(controller:)` (hoisted from the FILE chip) and a `deliver` override that lands picked files in the snapshotted target's draft.
- **Views** — `TalkbackComposerViewController` (card, previews, round buttons, the field's hardware-key reflexes) with an Equatable render key and one field measurement per (text, width); the talk key on `TerminalKeyBar` and in `TerminalKeyClusterGroupView` (latched while open); the window docks the card above the rail with a bottom-up chrome cursor and owns the lock rule in `renderTalkback`; the visionOS ornament hangs it as a slab through `TerminalVisionConsoleGeometry.talkbackSize` (console top stays the root's midpoint). `TerminalFocusArbiter.unlock(_, summoning:)` lets the talk key release the lock without the terminal summon that would race the field's focus.

Load-bearing decisions and traps are in `docs/agents/input-and-windows.md`; the component map and `DESIGN.md` describe the surface.

## Verification

- 1,307 unit tests green on visionOS and iPad (new: `TalkbackTests`, `TalkbackComposerUIKitTests`, the window's lock test; the rail width ladder and cluster geometry re-pinned). Both platforms build; SwiftLint `--strict` at zero.
- Headless E2E on the visionOS, iPad and iPhone 17 Pro simulators against the dev-sshd harness (`agent:0` = `cat` under a `✳ Claude Code` title): open → type two lines → attach a photo + text file (SFTP into `.multiplex-drops/`) → SEND lands `<paths> Talkback headless proof⏎second line` + CR in the pane; the card clears and stays open; close unlatches the key and unfolds the strip; the visionOS slab renders below the anchor at one/two/three-row heights. New hooks `debug.talkback` / `talkbacktype` / `talkbackattach` / `talkbacksend` in `docs/agents/e2e-headless.md`.
- `fastlane/testflight-whats-new.txt` updated; `Tools/check-metadata.rb` passes.

Not verified headlessly (the sim always reports a hardware keyboard): the docked software keyboard under the card — it rides the same `keyboardObstruction` as the helper strip. Left for later: a Guide card, tap-to-preview on thumbnails.

## Checklist

- [x] `./Tools/build.sh lint` passes
- [x] Unit tests pass (`MultiplexTests`)
- [x] User-visible change noted in `fastlane/testflight-whats-new.txt`
