### PR TITLE
docs and networking: improve viewport reach detection

### DIFF
--- a/Multiplex/Models/ViewportReach.swift
+++ b/Multiplex/Models/ViewportReach.swift
@@ -56,11 +56,19 @@ enum ViewportReach: Equatable {
         if host == "localhost" || host.hasSuffix(".localhost") { return true }
         if host == "0.0.0.0" || host == "::" || host == "::1" { return true }
         if let octets = ipv4Octets(host) { return octets[0] == 127 }
+        if let octets = ipv4MappedOctets(host) { return octets[0] == 127 }
         return false
     }
 
     private static func isLAN(_ host: String) -> Bool {
         if let octets = ipv4Octets(host) {
+            if octets[0] == 10 { return true }
+            if octets[0] == 192, octets[1] == 168 { return true }
+            if octets[0] == 172, (16...31).contains(octets[1]) { return true }
+            if octets[0] == 169, octets[1] == 254 { return true }
+            return false
+        }
+        if let octets = ipv4MappedOctets(host) {
             if octets[0] == 10 { return true }
             if octets[0] == 192, octets[1] == 168 { return true }
             if octets[0] == 172, (16...31).contains(octets[1]) { return true }
@@ -76,6 +84,14 @@ enum ViewportReach: Equatable {
         // network's search domains — LAN by construction.
         if !host.contains(".") && !host.contains(":") { return true }
         return false
+    }
+
+    /// The IPv4 payload of the common `::ffff:w.x.y.z` mapped form, or nil.
+    private static func ipv4MappedOctets(_ host: String) -> [Int]? {
+        guard let separator = host.lastIndex(of: ":"),
+              host[..<separator] == "::ffff"
+        else { return nil }
+        return ipv4Octets(String(host[host.index(after: separator)...]))
     }
 
     /// The four octets of a dotted-quad IPv4 literal, or nil for anything

--- a/MultiplexTests/ViewportReachTests.swift
+++ b/MultiplexTests/ViewportReachTests.swift
@@ -38,6 +38,13 @@ final class ViewportReachTests: XCTestCase {
         }
     }
 
+    func testIPv4MappedPrivateAddressesKeepTheirIPv4Reach() {
+        XCTAssertEqual(classify("http://[::ffff:192.168.1.68]:5173/"), .lan)
+        XCTAssertEqual(classify("http://[::ffff:10.0.0.5]/"), .lan)
+        XCTAssertEqual(classify("http://[::ffff:127.0.0.1]:8080/"), .remoteLoopback)
+        XCTAssertEqual(classify("http://[::ffff:8.8.8.8]/"), .internet)
+    }
+
     func testUnqualifiedSingleLabelIsLAN() {
         // A bare machine name resolves through the local network's search
         // domains — LAN by construction.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Point `MULTIPLEX_SEED_HOST` at `Tools/dev-sshd/state/seed.json` to seed a DEBUG 
 
 ## mpx CLI
 
-[`mpx`](https://multiplexterm.dev/mpx/) is the companion CLI for binding a machine. Run `mpx bind` on the remote host and it appears on the deck with the app's SSH key enrolled and the host key fingerprints pinned from the first connection — nothing typed. The offer reaches the app by QR, local-network announcement with a PIN, or `--copy` to the clipboard; the default handshake never moves a private key.
+[`mpx`](https://github.com/multiplex-term/mpx-cli) is the companion CLI for binding a machine. Run `mpx bind` on the remote host and it appears on the deck with the app's SSH key enrolled and the host key fingerprints pinned from the first connection — nothing typed. The offer reaches the app by QR, local-network announcement with a PIN, or `--copy` to the clipboard; the default handshake never moves a private key.
 
 Install and usage: [multiplex-term/mpx-cli](https://github.com/multiplex-term/mpx-cli).
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Some features require Multiplex Pro; see [`docs/store-metadata.md`](docs/store-m
 
 ## Building
 
-Requires Xcode with the visionOS SDK and [XcodeGen](https://github.com/yonaskolb/XcodeGen). The project is generated, so edit `project.yml`, not the `.xcodeproj`.
+Requires Xcode with the visionOS SDK and [XcodeGen](https://github.com/yonaskolb/XcodeGen). Install the command-line prerequisites with [Homebrew](https://brew.sh/):
+
+```sh
+brew install xcodegen swiftlint
+```
+
+The Xcode project is generated, so edit `project.yml`, not the `.xcodeproj`. Regenerate it after project configuration changes:
 
 ```sh
 xcodegen generate
@@ -81,7 +87,7 @@ Point `MULTIPLEX_SEED_HOST` at `Tools/dev-sshd/state/seed.json` to seed a DEBUG 
 
 ## mpx CLI
 
-[`mpx`](https://github.com/multiplex-term/mpx-cli) is the companion CLI for binding a machine. Run `mpx bind` on the remote host and it appears on the deck with the app's SSH key enrolled and the host key fingerprints pinned from the first connection — nothing typed. The offer reaches the app by QR, local-network announcement with a PIN, or `--copy` to the clipboard; the default handshake never moves a private key.
+[`mpx`](https://multiplexterm.dev/mpx/) is the companion CLI for binding a machine. Run `mpx bind` on the remote host and it appears on the deck with the app's SSH key enrolled and the host key fingerprints pinned from the first connection — nothing typed. The offer reaches the app by QR, local-network announcement with a PIN, or `--copy` to the clipboard; the default handshake never moves a private key.
 
 Install and usage: [multiplex-term/mpx-cli](https://github.com/multiplex-term/mpx-cli).
 


### PR DESCRIPTION
## Summary

This PR improves both contributor setup and viewport address classification.

## Changes

- Document Homebrew installation for XcodeGen and SwiftLint.
- Clarify that `project.yml` is the source of truth and show when to run `xcodegen generate`.
- Correctly classify IPv4-mapped IPv6 hosts (`::ffff:w.x.y.z`) using the existing IPv4 private-range and loopback rules.
- Add regression coverage for mapped LAN, loopback, and public addresses.

## Verification

- Added focused XCTest coverage in `ViewportReachTests`.
- The full Xcode test suite could not be run here because this session has no local workspace or macOS/Xcode environment.
- Existing `mpx` CLI repository link preserved.